### PR TITLE
Add GitHub Actions CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,129 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  engine:
+    name: Engine (test + clippy + wasm)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: engine
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+          components: clippy
+
+      - name: Cache cargo registry and build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            engine/target
+          key: engine-${{ runner.os }}-cargo-${{ hashFiles('engine/Cargo.lock') }}
+          restore-keys: engine-${{ runner.os }}-cargo-
+
+      - name: Run tests
+        run: cargo test --verbose
+
+      - name: Run clippy
+        run: cargo clippy --all-targets -- -D warnings
+
+      - name: Check formatting
+        run: cargo fmt -- --check
+
+      - name: Install wasm-pack
+        uses: jetli/wasm-pack-action@v0.4.0
+
+      - name: Build Wasm
+        run: wasm-pack build --target web
+
+  backend:
+    name: Backend (test + clippy)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Cache cargo registry and build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            backend/target
+          key: backend-${{ runner.os }}-cargo-${{ hashFiles('backend/Cargo.lock') }}
+          restore-keys: backend-${{ runner.os }}-cargo-
+
+      - name: Run tests
+        run: cargo test --verbose
+
+      - name: Run clippy
+        run: cargo clippy --all-targets -- -D warnings
+
+      - name: Check formatting
+        run: cargo fmt -- --check
+
+  frontend:
+    name: Frontend (build)
+    runs-on: ubuntu-latest
+    needs: engine
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache cargo registry and build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            engine/target
+          key: engine-${{ runner.os }}-cargo-${{ hashFiles('engine/Cargo.lock') }}
+          restore-keys: engine-${{ runner.os }}-cargo-
+
+      - name: Install wasm-pack
+        uses: jetli/wasm-pack-action@v0.4.0
+
+      - name: Build Wasm engine
+        run: wasm-pack build --target web
+        working-directory: engine
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -19,12 +19,9 @@ impl Config {
     {
         let database_url = get("DATABASE_URL").ok_or(ConfigError::Missing("DATABASE_URL"))?;
 
-        let frontend_url = get("FRONTEND_URL")
-            .unwrap_or_else(|| "http://localhost:5173".into());
+        let frontend_url = get("FRONTEND_URL").unwrap_or_else(|| "http://localhost:5173".into());
 
-        let port: u16 = get("PORT")
-            .and_then(|p| p.parse().ok())
-            .unwrap_or(3001);
+        let port: u16 = get("PORT").and_then(|p| p.parse().ok()).unwrap_or(3001);
 
         let jwt_secret_str = get("JWT_SECRET").ok_or(ConfigError::Missing("JWT_SECRET"))?;
         let jwt_secret = jwt_secret_str.into_bytes();
@@ -121,18 +118,14 @@ mod tests {
 
     #[test]
     fn missing_database_url() {
-        let lookup = make_lookup(&[
-            ("JWT_SECRET", "this-is-a-secret-that-is-at-least-32-bytes!"),
-        ]);
+        let lookup = make_lookup(&[("JWT_SECRET", "this-is-a-secret-that-is-at-least-32-bytes!")]);
         let err = Config::from_lookup(lookup).unwrap_err();
         assert!(matches!(err, ConfigError::Missing("DATABASE_URL")));
     }
 
     #[test]
     fn missing_jwt_secret() {
-        let lookup = make_lookup(&[
-            ("DATABASE_URL", "postgresql://localhost/test"),
-        ]);
+        let lookup = make_lookup(&[("DATABASE_URL", "postgresql://localhost/test")]);
         let err = Config::from_lookup(lookup).unwrap_err();
         assert!(matches!(err, ConfigError::Missing("JWT_SECRET")));
     }

--- a/backend/src/errors.rs
+++ b/backend/src/errors.rs
@@ -4,6 +4,7 @@ use axum::Json;
 use serde_json::json;
 
 #[derive(Debug)]
+#[allow(dead_code)]
 pub enum AppError {
     BadRequest(String),
     Unauthorized(String),
@@ -61,16 +62,14 @@ mod tests {
 
     #[tokio::test]
     async fn unauthorized_returns_401() {
-        let (status, json) =
-            response_parts(AppError::Unauthorized("bad credentials".into())).await;
+        let (status, json) = response_parts(AppError::Unauthorized("bad credentials".into())).await;
         assert_eq!(status, StatusCode::UNAUTHORIZED);
         assert_eq!(json["error"], "bad credentials");
     }
 
     #[tokio::test]
     async fn conflict_returns_409() {
-        let (status, json) =
-            response_parts(AppError::Conflict("username taken".into())).await;
+        let (status, json) = response_parts(AppError::Conflict("username taken".into())).await;
         assert_eq!(status, StatusCode::CONFLICT);
         assert_eq!(json["error"], "username taken");
     }

--- a/backend/src/models/user.rs
+++ b/backend/src/models/user.rs
@@ -2,6 +2,7 @@ use chrono::{DateTime, Utc};
 use uuid::Uuid;
 
 #[derive(Debug, sqlx::FromRow)]
+#[allow(dead_code)]
 pub struct User {
     pub id: Uuid,
     pub username: String,
@@ -12,6 +13,7 @@ pub struct User {
 }
 
 #[derive(Debug, sqlx::FromRow)]
+#[allow(dead_code)]
 pub struct RefreshToken {
     pub id: Uuid,
     pub user_id: Uuid,

--- a/engine/src/parser.rs
+++ b/engine/src/parser.rs
@@ -220,7 +220,10 @@ pub fn parse_warrior(source: &str) -> Result<ParsedWarrior, ParseError> {
             } else if let Ok(n) = target.parse::<usize>() {
                 n
             } else {
-                return Err(ParseError::UnknownLabel { line: 0, label: target });
+                return Err(ParseError::UnknownLabel {
+                    line: 0,
+                    label: target,
+                });
             }
         }
         None => 0,
@@ -438,7 +441,10 @@ fn parse_instruction_body(
     })
 }
 
-fn parse_opcode_token(token: &str, line_no: usize) -> Result<(Opcode, Option<Modifier>), ParseError> {
+fn parse_opcode_token(
+    token: &str,
+    line_no: usize,
+) -> Result<(Opcode, Option<Modifier>), ParseError> {
     let mut parts = token.splitn(2, '.');
     let opcode_str = parts.next().unwrap_or("");
     let modifier_str = parts.next();
@@ -508,7 +514,10 @@ fn parse_value(
     }
 
     let tokens = tokenize_expr(trimmed, line_no)?;
-    let mut cursor = ExprCursor { tokens: &tokens, pos: 0 };
+    let mut cursor = ExprCursor {
+        tokens: &tokens,
+        pos: 0,
+    };
     let mut visiting = HashSet::new();
     let value = cursor.parse_expr(offset, line_no, labels, equ_table, &mut visiting)?;
     if cursor.pos < tokens.len() {
@@ -549,10 +558,12 @@ fn tokenize_expr(text: &str, line_no: usize) -> Result<Vec<Tok>, ParseError> {
                 i += 1;
             }
             let slice = &text[start..i];
-            let n = slice.parse::<i32>().map_err(|_| ParseError::InvalidNumber {
-                line: line_no,
-                text: slice.to_string(),
-            })?;
+            let n = slice
+                .parse::<i32>()
+                .map_err(|_| ParseError::InvalidNumber {
+                    line: line_no,
+                    text: slice.to_string(),
+                })?;
             tokens.push(Tok::Num(n));
             continue;
         }
@@ -1175,11 +1186,7 @@ bomb    DAT.F  #0, #0
         ];
 
         for (i, exp) in expected.iter().enumerate() {
-            assert_eq!(
-                &parsed.instructions()[i],
-                exp,
-                "instruction {i} mismatch",
-            );
+            assert_eq!(&parsed.instructions()[i], exp, "instruction {i} mismatch",);
         }
     }
 

--- a/engine/src/vm.rs
+++ b/engine/src/vm.rs
@@ -564,11 +564,7 @@ impl MatchState {
                     }
                     Modifier::I => src == dest,
                 };
-                let resume_pc = if equal {
-                    (pc + 2) % core_size
-                } else {
-                    next_pc
-                };
+                let resume_pc = if equal { (pc + 2) % core_size } else { next_pc };
                 self.warriors[warrior_idx].processes.push_back(resume_pc);
             }
 
@@ -626,11 +622,7 @@ impl MatchState {
                             && src.field(Field::B) < dest.field(Field::A)
                     }
                 };
-                let resume_pc = if less {
-                    (pc + 2) % core_size
-                } else {
-                    next_pc
-                };
+                let resume_pc = if less { (pc + 2) % core_size } else { next_pc };
                 self.warriors[warrior_idx].processes.push_back(resume_pc);
             }
 
@@ -869,14 +861,17 @@ mod tests {
             state.step();
             for cell in 0..=n {
                 assert_eq!(
-                    state.core().get(cell as i32),
+                    state.core().get(cell),
                     imp(),
                     "after {n} steps, cell {cell} should be the imp",
                 );
             }
         }
 
-        assert!(state.warriors()[0].is_alive(), "imp should still be running");
+        assert!(
+            state.warriors()[0].is_alive(),
+            "imp should still be running"
+        );
         assert_eq!(state.steps(), 5);
     }
 
@@ -894,7 +889,11 @@ mod tests {
         }
 
         for cell in 0..4 {
-            assert_eq!(state.core().get(cell), imp(), "cell {cell} should be the imp");
+            assert_eq!(
+                state.core().get(cell),
+                imp(),
+                "cell {cell} should be the imp"
+            );
         }
         assert!(state.warriors()[0].is_alive());
     }
@@ -935,7 +934,9 @@ mod tests {
         let mut state = MatchState::new(16, 10);
         state.add_warrior(Warrior::new(0, 0));
 
-        state.core_mut().set(0, instr(Opcode::Add, Modifier::AB, imm(7), dir(1)));
+        state
+            .core_mut()
+            .set(0, instr(Opcode::Add, Modifier::AB, imm(7), dir(1)));
         // Cell 1 starts as DAT.F #0, #5 — we'll watch its B-field grow to 12.
         state
             .core_mut()
@@ -945,7 +946,10 @@ mod tests {
 
         let cell1 = state.core().get(1);
         assert_eq!(cell1.b.value, 12, "5 + 7 should be 12");
-        assert_eq!(cell1.a.value, 0, ".AB must not touch the destination's A field");
+        assert_eq!(
+            cell1.a.value, 0,
+            ".AB must not touch the destination's A field"
+        );
     }
 
     #[test]
@@ -1007,7 +1011,10 @@ mod tests {
 
         // 5 iterations × 3 instructions per iteration = 15 steps.
         for _ in 0..15 {
-            assert!(state.step(), "dwarf should never die — it has no DAT in its loop");
+            assert!(
+                state.step(),
+                "dwarf should never die — it has no DAT in its loop"
+            );
         }
 
         // Bomb pointer (cell 3's B-field) advanced 5 times by 4.
@@ -1307,7 +1314,11 @@ mod tests {
         }
 
         // The counter and dest pointer ended in their expected exhausted state.
-        assert_eq!(state.core().get(0).b.value, 0, "counter should be exhausted");
+        assert_eq!(
+            state.core().get(0).b.value,
+            0,
+            "counter should be exhausted"
+        );
         assert_eq!(
             state.core().get(1).b.value,
             5,
@@ -1813,7 +1824,11 @@ mod tests {
 
         // The destination cell must NOT have been modified (the operation
         // aborted before any write).
-        assert_eq!(state.core().get(2).b.value, 20, "DIV-by-zero must not write");
+        assert_eq!(
+            state.core().get(2).b.value,
+            20,
+            "DIV-by-zero must not write"
+        );
         // And the process is dead.
         assert_eq!(state.result(), MatchResult::AllDead);
     }
@@ -1998,7 +2013,10 @@ mod tests {
         );
         assert_eq!(state.steps(), 4);
         assert_eq!(state.max_steps(), 4);
-        assert!(!state.step(), "step() should refuse to advance past max_steps");
+        assert!(
+            !state.step(),
+            "step() should refuse to advance past max_steps"
+        );
     }
 
     // ==================================================================
@@ -2438,8 +2456,16 @@ mod tests {
             "load_warrior should attribute cell 10 to warrior 0 (owner = id + 1 = 1)",
         );
         // Cells outside the loaded range remain unowned.
-        assert_eq!(state2.core().owner(9), 0, "cell before load range should be unowned");
-        assert_eq!(state2.core().owner(11), 0, "cell after load range should be unowned");
+        assert_eq!(
+            state2.core().owner(9),
+            0,
+            "cell before load range should be unowned"
+        );
+        assert_eq!(
+            state2.core().owner(11),
+            0,
+            "cell after load range should be unowned"
+        );
     }
 
     #[test]
@@ -2456,14 +2482,26 @@ mod tests {
 
         // Step 1: warrior 0 (imp at 0) writes cell 1. Cell 1 should be owned by warrior 0.
         state.step();
-        assert_eq!(state.core().owner(1), 1, "imp 0 should own cell 1 after writing");
+        assert_eq!(
+            state.core().owner(1),
+            1,
+            "imp 0 should own cell 1 after writing"
+        );
 
         // Step 2: warrior 1 (imp at 50) writes cell 51. Cell 51 should be owned by warrior 1.
         state.step();
-        assert_eq!(state.core().owner(51), 2, "imp 1 should own cell 51 after writing");
+        assert_eq!(
+            state.core().owner(51),
+            2,
+            "imp 1 should own cell 51 after writing"
+        );
 
         // Unwritten cells remain unowned.
-        assert_eq!(state.core().owner(25), 0, "unwritten cell should be unowned");
+        assert_eq!(
+            state.core().owner(25),
+            0,
+            "unwritten cell should be unowned"
+        );
     }
 
     #[test]

--- a/engine/src/wasm.rs
+++ b/engine/src/wasm.rs
@@ -139,12 +139,7 @@ impl WasmMatchState {
     /// written sequentially starting at `baseAddress`, and its first
     /// process starts at `baseAddress + warrior.startOffset()`.
     #[wasm_bindgen(js_name = "loadWarrior")]
-    pub fn load_warrior(
-        &mut self,
-        id: usize,
-        warrior: &WasmParsedWarrior,
-        base_address: usize,
-    ) {
+    pub fn load_warrior(&mut self, id: usize, warrior: &WasmParsedWarrior, base_address: usize) {
         self.inner.load_warrior(id, &warrior.inner, base_address);
     }
 
@@ -366,8 +361,8 @@ impl WasmMatchState {
                 | (instr.a.mode as u32) << 3
                 | instr.b.mode as u32;
             // Word 1: a_value(i16) in upper half, b_value(i16) in lower half
-            let w1 = ((instr.a.value as i16 as u16) as u32) << 16
-                | (instr.b.value as i16 as u16) as u32;
+            let w1 =
+                ((instr.a.value as i16 as u16) as u32) << 16 | (instr.b.value as i16 as u16) as u32;
             buf.push(w0);
             buf.push(w1);
         }

--- a/engine/tests/canonical_warriors.rs
+++ b/engine/tests/canonical_warriors.rs
@@ -112,8 +112,16 @@ fn parsed_mice_lite_replicates_imp_three_times() {
 
     // The counter (cell 0) and dest pointer (cell 1) ended in their
     // expected exhausted states.
-    assert_eq!(state.core().get(0).b.value, 0, "counter should be exhausted");
-    assert_eq!(state.core().get(1).b.value, 5, "dest should have decremented 8 → 5");
+    assert_eq!(
+        state.core().get(0).b.value,
+        0,
+        "counter should be exhausted"
+    );
+    assert_eq!(
+        state.core().get(1).b.value,
+        5,
+        "dest should have decremented 8 → 5"
+    );
 
     // Process died on the DAT landing pad.
     assert_eq!(state.result(), MatchResult::AllDead);
@@ -131,8 +139,7 @@ fn parsed_scanner_finds_and_bombs_planted_marker() {
     //
     // We construct the marker by parsing a tiny one-line "warrior", which
     // keeps the test 100% on the public API — no Instruction literals.
-    let marker_warrior =
-        parse_warrior("JMP.B $123, $456").expect("marker source should parse");
+    let marker_warrior = parse_warrior("JMP.B $123, $456").expect("marker source should parse");
     let marker = marker_warrior.instructions()[0];
     state.core_mut().set(12, marker);
 
@@ -165,8 +172,7 @@ fn parsed_dwarf_outlasts_passive_dat_warrior_in_two_warrior_match() {
     // A deliberately suicidal warrior: a single DAT cell. The first time
     // its process executes, it dies. (Parsed via the same public API, just
     // from an inline source string instead of an .red file.)
-    let suicide =
-        parse_warrior("DAT.F #0, #0").expect("suicide warrior should parse");
+    let suicide = parse_warrior("DAT.F #0, #0").expect("suicide warrior should parse");
 
     let mut state = MatchState::new(64, 50);
     state.load_warrior(0, &dwarf, 0);
@@ -220,7 +226,11 @@ bomb    DAT.F  #0, #0
 
     // The standard Dwarf bomb positions (7, 15) should still be empty.
     assert_eq!(state.core().get(7).opcode, Opcode::Dat);
-    assert_eq!(state.core().get(7).b.value, 0, "cell 7 should NOT have a bomb (step is 8, not 4)");
+    assert_eq!(
+        state.core().get(7).b.value,
+        0,
+        "cell 7 should NOT have a bomb (step is 8, not 4)"
+    );
 }
 
 /// The real Mice replicator. After one copy cycle (8 MOV iterations via


### PR DESCRIPTION
## Summary
- Add `.github/workflows/ci.yml` with three jobs running on every push/PR to `master`:
  - **Engine**: `cargo test` (104 unit + 8 integration), `cargo clippy -- -D warnings`, `cargo fmt -- --check`, `wasm-pack build`
  - **Backend**: `cargo test` (13 unit), `cargo clippy -- -D warnings`, `cargo fmt -- --check`
  - **Frontend**: `npm ci` + `npm run build` (depends on engine job for Wasm output)
- Cargo caching for faster CI runs
- Fix pre-existing `cargo fmt` violations in engine (parser, vm, wasm) and backend (config, errors)
- Fix `cargo clippy` unnecessary cast in engine `vm.rs`
- Add `#[allow(dead_code)]` on scaffolding structs that clippy flags before auth handlers exist

Closes #11

## Test plan
- [x] `cargo fmt -- --check` passes in both engine and backend
- [x] `cargo clippy --all-targets -- -D warnings` passes in both engine and backend
- [x] `cargo test` passes: 104 engine unit + 8 integration + 13 backend = 125 total
- [x] CI pipeline runs successfully on this PR

🤖 Generated with [Claude Code](https://claude.ai/claude-code)