### PR TITLE
Set up ESLint and Prettier for the frontend

### DIFF
--- a/frontend/.prettierrc
+++ b/frontend/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "singleQuote": true,
+  "semi": true,
+  "trailingComma": "all",
+  "tabWidth": 2,
+  "printWidth": 100
+}

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -1,0 +1,27 @@
+import eslint from '@eslint/js';
+import tseslint from 'typescript-eslint';
+import reactHooks from 'eslint-plugin-react-hooks';
+import reactRefresh from 'eslint-plugin-react-refresh';
+import prettier from 'eslint-config-prettier';
+
+export default tseslint.config(
+  eslint.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    plugins: {
+      'react-hooks': reactHooks,
+      'react-refresh': reactRefresh,
+    },
+    rules: {
+      ...reactHooks.configs.recommended.rules,
+      'react-refresh/only-export-components': [
+        'warn',
+        { allowConstantExport: true },
+      ],
+    },
+  },
+  prettier,
+  {
+    ignores: ['dist/'],
+  },
+);

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,10 +17,19 @@
         "socket.io-client": "^4.8.3"
       },
       "devDependencies": {
+        "@eslint/js": "^10.0.1",
         "@types/react": "^18.0.0",
         "@types/react-dom": "^18.0.0",
+        "@typescript-eslint/eslint-plugin": "^8.58.2",
+        "@typescript-eslint/parser": "^8.58.2",
         "@vitejs/plugin-react": "^4.0.0",
+        "eslint": "^10.2.1",
+        "eslint-config-prettier": "^10.1.8",
+        "eslint-plugin-react-hooks": "^7.1.1",
+        "eslint-plugin-react-refresh": "^0.5.2",
+        "prettier": "^3.8.3",
         "typescript": "^5.0.0",
+        "typescript-eslint": "^8.58.2",
         "vite": "^5.0.0"
       }
     },
@@ -699,6 +708,187 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^3.0.5",
+        "debug": "^4.3.1",
+        "minimatch": "^10.2.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.5.tgz",
+      "integrity": "sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.1.tgz",
+      "integrity": "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -1614,10 +1804,24 @@
       "integrity": "sha512-qp3m9PPz4gULB9MhjGID7wpo3gJ4bTGXm7ltNDsmOvsPduTeHp8wSW9YckBj3mljeOh4F0m2z/0JKAALRKbmLQ==",
       "license": "MIT"
     },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
     },
@@ -1657,6 +1861,252 @@
       "optional": true,
       "peer": true
     },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.2.tgz",
+      "integrity": "sha512-aC2qc5thQahutKjP+cl8cgN9DWe3ZUqVko30CMSZHnFEHyhOYoZSzkGtAI2mcwZ38xeImDucI4dnqsHiOYuuCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.58.2",
+        "@typescript-eslint/type-utils": "8.58.2",
+        "@typescript-eslint/utils": "8.58.2",
+        "@typescript-eslint/visitor-keys": "8.58.2",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.58.2",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.2.tgz",
+      "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.58.2",
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/typescript-estree": "8.58.2",
+        "@typescript-eslint/visitor-keys": "8.58.2",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.2.tgz",
+      "integrity": "sha512-Cq6UfpZZk15+r87BkIh5rDpi38W4b+Sjnb8wQCPPDDweS/LRCFjCyViEbzHk5Ck3f2QDfgmlxqSa7S7clDtlfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.58.2",
+        "@typescript-eslint/types": "^8.58.2",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.2.tgz",
+      "integrity": "sha512-SgmyvDPexWETQek+qzZnrG6844IaO02UVyOLhI4wpo82dpZJY9+6YZCKAMFzXb7qhx37mFK1QcPQ18tud+vo6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/visitor-keys": "8.58.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.2.tgz",
+      "integrity": "sha512-3SR+RukipDvkkKp/d0jP0dyzuls3DbGmwDpVEc5wqk5f38KFThakqAAO0XMirWAE+kT00oTauTbzMFGPoAzB0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.2.tgz",
+      "integrity": "sha512-Z7EloNR/B389FvabdGeTo2XMs4W9TjtPiO9DAsmT0yom0bwlPyRjkJ1uCdW1DvrrrYP50AJZ9Xc3sByZA9+dcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/typescript-estree": "8.58.2",
+        "@typescript-eslint/utils": "8.58.2",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.2.tgz",
+      "integrity": "sha512-9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.2.tgz",
+      "integrity": "sha512-ELGuoofuhhoCvNbQjFFiobFcGgcDCEm0ThWdmO4Z0UzLqPXS3KFvnEZ+SHewwOYHjM09tkzOWXNTv9u6Gqtyuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.58.2",
+        "@typescript-eslint/tsconfig-utils": "8.58.2",
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/visitor-keys": "8.58.2",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.2.tgz",
+      "integrity": "sha512-QZfjHNEzPY8+l0+fIXMvuQ2sJlplB4zgDZvA+NmvZsZv3EQwOcc1DuIU1VJUTWZ/RKouBMhDyNaBMx4sWvrzRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.58.2",
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/typescript-estree": "8.58.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.2.tgz",
+      "integrity": "sha512-f1WO2Lx8a9t8DARmcWAUPJbu0G20bJlj8L4z72K00TMeJAoyLr/tHhI/pzYBLrR4dXWkcxO1cWYZEOX8DKHTqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.58.2",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
@@ -1678,6 +2128,56 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.16",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.16.tgz",
@@ -1689,6 +2189,19 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/browserslist": {
@@ -1799,6 +2312,21 @@
       "resolved": "../engine/pkg",
       "link": true
     },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -1822,6 +2350,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dompurify": {
       "version": "3.2.7",
@@ -1961,11 +2496,348 @@
         "node": ">=6"
       }
     },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.2.1.tgz",
+      "integrity": "sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.5.5",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "minimatch": "^10.2.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
+      "integrity": "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "hermes-parser": "^0.25.1",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-validation-error": "^3.5.0 || ^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-react-refresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.5.2.tgz",
+      "integrity": "sha512-hmgTH57GfzoTFjVN0yBwTggnsVUF2tcqi7RJZHqi9lIezSs4eFyAMktA68YD4r5kNw1mxyY4dmkyoFDb3FIqrA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "eslint": "^9 || ^10"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "license": "MIT"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -2038,6 +2910,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -2074,6 +2959,73 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hermes-estree": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
+      "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/hermes-parser": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
+      "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.25.1"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/ismobilejs": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ismobilejs/-/ismobilejs-1.1.1.tgz",
@@ -2099,6 +3051,27 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -2110,6 +3083,46 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/loose-envify": {
@@ -2156,6 +3169,22 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/monaco-editor": {
       "version": "0.55.1",
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
@@ -2192,6 +3221,13 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/node-releases": {
       "version": "2.0.37",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
@@ -2211,12 +3247,95 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/pixi.js": {
       "version": "7.4.3",
@@ -2287,6 +3406,32 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/punycode": {
@@ -2453,6 +3598,29 @@
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "license": "MIT"
     },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/side-channel": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
@@ -2569,6 +3737,49 @@
       "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==",
       "license": "MIT"
     },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -2581,6 +3792,30 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.58.2.tgz",
+      "integrity": "sha512-V8iSng9mRbdZjl54VJ9NKr6ZB+dW0J3TzRXRGcSbLIej9jV86ZRtlYeTKDR/QLxXykocJ5icNzbsl2+5TzIvcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.58.2",
+        "@typescript-eslint/parser": "8.58.2",
+        "@typescript-eslint/typescript-estree": "8.58.2",
+        "@typescript-eslint/utils": "8.58.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -2612,6 +3847,26 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/uri-js/node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/url": {
@@ -2687,6 +3942,32 @@
         }
       }
     },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/ws": {
       "version": "8.18.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
@@ -2722,6 +4003,42 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-validation-error": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
+      "integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      }
     }
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,10 +2,14 @@
   "name": "core-war-frontend",
   "version": "0.1.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "lint": "eslint src/",
+    "format": "prettier --write src/",
+    "format:check": "prettier --check src/"
   },
   "dependencies": {
     "@monaco-editor/react": "^4.0.0",
@@ -17,10 +21,19 @@
     "socket.io-client": "^4.8.3"
   },
   "devDependencies": {
+    "@eslint/js": "^10.0.1",
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
+    "@typescript-eslint/eslint-plugin": "^8.58.2",
+    "@typescript-eslint/parser": "^8.58.2",
     "@vitejs/plugin-react": "^4.0.0",
+    "eslint": "^10.2.1",
+    "eslint-config-prettier": "^10.1.8",
+    "eslint-plugin-react-hooks": "^7.1.1",
+    "eslint-plugin-react-refresh": "^0.5.2",
+    "prettier": "^3.8.3",
     "typescript": "^5.0.0",
+    "typescript-eslint": "^8.58.2",
     "vite": "^5.0.0"
   }
 }

--- a/frontend/src/core/coreRenderer.ts
+++ b/frontend/src/core/coreRenderer.ts
@@ -11,24 +11,18 @@
 // lookup table, written into the canvas's ImageData, then uploaded to a
 // PixiJS texture on a single Sprite scaled up with NEAREST filtering.
 
-import {
-  Application,
-  BaseTexture,
-  Sprite,
-  Texture,
-  SCALE_MODES,
-} from 'pixi.js';
+import { Application, BaseTexture, Sprite, Texture, SCALE_MODES } from 'pixi.js';
 import { CORE_SIZE, GRID_COLS, GRID_ROWS, CELL_SCALE } from './constants';
 
 // Warrior color palette: index = ownership value from the engine.
 // 0 = unowned (dark), 1 = warrior 0, 2 = warrior 1, ...
 // Pre-computed as flat RGBA for zero-allocation hot-path access.
 const WARRIOR_COLORS: [number, number, number][] = [
-  [17, 17, 23],      // 0: unowned — near-black
-  [233, 69, 96],     // 1: warrior 0 — red/warm
-  [79, 195, 247],    // 2: warrior 1 — blue/cool
-  [76, 175, 80],     // 3: warrior 2 — green (future)
-  [255, 171, 0],     // 4: warrior 3 — amber (future)
+  [17, 17, 23], // 0: unowned — near-black
+  [233, 69, 96], // 1: warrior 0 — red/warm
+  [79, 195, 247], // 2: warrior 1 — blue/cool
+  [76, 175, 80], // 3: warrior 2 — green (future)
+  [255, 171, 0], // 4: warrior 3 — amber (future)
 ];
 
 const WARRIOR_RGBA = new Uint8Array(WARRIOR_COLORS.length * 4);

--- a/frontend/src/core/opcodeColors.ts
+++ b/frontend/src/core/opcodeColors.ts
@@ -10,22 +10,22 @@
 //   JMP=7  JMZ=8  JMN=9  DJN=10 SPL=11 SLT=12 SEQ=13 SNE=14 NOP=15
 
 const OPCODE_RGB: [number, number, number][] = [
-  [26, 26, 46],     // 0  DAT — near-black (dead/empty cells dominate, should recede)
-  [233, 69, 96],    // 1  MOV — red (aggressive, the most common warrior action)
-  [15, 155, 88],    // 2  ADD — green (arithmetic)
-  [13, 122, 70],    // 3  SUB — darker green
-  [52, 168, 83],    // 4  MUL — brighter green
-  [27, 107, 58],    // 5  DIV — deep green
-  [45, 138, 86],    // 6  MOD — mid green
-  [79, 195, 247],   // 7  JMP — light blue (unconditional jump)
-  [41, 182, 246],   // 8  JMZ — blue (conditional jump)
-  [2, 136, 209],    // 9  JMN — darker blue
-  [2, 119, 189],    // 10 DJN — deep blue (loop/decrement jump)
-  [255, 171, 0],    // 11 SPL — amber/gold (split is special, stands out)
-  [206, 147, 216],  // 12 SLT — light purple (comparison)
-  [171, 71, 188],   // 13 SEQ — purple
-  [123, 31, 162],   // 14 SNE — dark purple
-  [51, 51, 51],     // 15 NOP — dark gray (no-op, subtle)
+  [26, 26, 46], // 0  DAT — near-black (dead/empty cells dominate, should recede)
+  [233, 69, 96], // 1  MOV — red (aggressive, the most common warrior action)
+  [15, 155, 88], // 2  ADD — green (arithmetic)
+  [13, 122, 70], // 3  SUB — darker green
+  [52, 168, 83], // 4  MUL — brighter green
+  [27, 107, 58], // 5  DIV — deep green
+  [45, 138, 86], // 6  MOD — mid green
+  [79, 195, 247], // 7  JMP — light blue (unconditional jump)
+  [41, 182, 246], // 8  JMZ — blue (conditional jump)
+  [2, 136, 209], // 9  JMN — darker blue
+  [2, 119, 189], // 10 DJN — deep blue (loop/decrement jump)
+  [255, 171, 0], // 11 SPL — amber/gold (split is special, stands out)
+  [206, 147, 216], // 12 SLT — light purple (comparison)
+  [171, 71, 188], // 13 SEQ — purple
+  [123, 31, 162], // 14 SNE — dark purple
+  [51, 51, 51], // 15 NOP — dark gray (no-op, subtle)
 ];
 
 export const OPCODE_RGBA = new Uint8Array(16 * 4);
@@ -38,6 +38,4 @@ for (let i = 0; i < 16; i++) {
 }
 
 // Hex colors for non-hot-path uses (legends, UI elements).
-export const OPCODE_HEX: number[] = OPCODE_RGB.map(
-  ([r, g, b]) => (r << 16) | (g << 8) | b,
-);
+export const OPCODE_HEX: number[] = OPCODE_RGB.map(([r, g, b]) => (r << 16) | (g << 8) | b);

--- a/frontend/src/core/redcodeFormat.ts
+++ b/frontend/src/core/redcodeFormat.ts
@@ -5,8 +5,22 @@ import type { MatchState } from 'core-war-engine';
 import { GRID_COLS, CELL_SCALE } from './constants';
 
 const OPCODE_NAMES = [
-  'DAT', 'MOV', 'ADD', 'SUB', 'MUL', 'DIV', 'MOD',
-  'JMP', 'JMZ', 'JMN', 'DJN', 'SPL', 'SLT', 'SEQ', 'SNE', 'NOP',
+  'DAT',
+  'MOV',
+  'ADD',
+  'SUB',
+  'MUL',
+  'DIV',
+  'MOD',
+  'JMP',
+  'JMZ',
+  'JMN',
+  'DJN',
+  'SPL',
+  'SLT',
+  'SEQ',
+  'SNE',
+  'NOP',
 ];
 
 const MODIFIER_NAMES = ['A', 'B', 'AB', 'BA', 'F', 'X', 'I'];

--- a/frontend/src/pages/BattlefieldPage.tsx
+++ b/frontend/src/pages/BattlefieldPage.tsx
@@ -1,11 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import init, {
-  parseWarrior,
-  MatchState,
-  engineVersion,
-  type ParsedWarrior,
-} from 'core-war-engine';
+import init, { parseWarrior, MatchState, engineVersion, type ParsedWarrior } from 'core-war-engine';
 import { createCoreRenderer, type CoreRenderer } from '../core/coreRenderer';
 import { cellAddressAtPixel, formatCellTooltip } from '../core/redcodeFormat';
 import { CORE_SIZE } from '../core/constants';
@@ -94,15 +89,9 @@ export default function BattlefieldPage() {
   const [resultCode, setResultCode] = useState(ONGOING);
   const [resultWinner, setResultWinner] = useState(-1);
   const [stepsPerFrame, setStepsPerFrame] = useState(50);
-  const [redId, setRedId] = useState(() =>
-    pickInitial(library, searchParams.get('red'), 0),
-  );
-  const [blueId, setBlueId] = useState(() =>
-    pickInitial(library, searchParams.get('blue'), 1),
-  );
-  const [warriors, setWarriors] = useState<
-    { name: string; alive: boolean; procs: number }[]
-  >([]);
+  const [redId, setRedId] = useState(() => pickInitial(library, searchParams.get('red'), 0));
+  const [blueId, setBlueId] = useState(() => pickInitial(library, searchParams.get('blue'), 1));
+  const [warriors, setWarriors] = useState<{ name: string; alive: boolean; procs: number }[]>([]);
   const [parseError, setParseError] = useState<string | null>(null);
 
   const gridRef = useRef<HTMLDivElement>(null);
@@ -111,15 +100,9 @@ export default function BattlefieldPage() {
   const rendererRef = useRef<CoreRenderer | null>(null);
   const matchRef = useRef<MatchState | null>(null);
   const warriorNamesRef = useRef<string[]>([]);
-  const redIdRef = useRef(redId);
-  const blueIdRef = useRef(blueId);
   const rafRef = useRef(0);
   const frameCountRef = useRef(0);
   const spfRef = useRef(stepsPerFrame);
-
-  spfRef.current = stepsPerFrame;
-  redIdRef.current = redId;
-  blueIdRef.current = blueId;
 
   // Keep the URL in sync with current selection so handoff from the builder is linkable.
   useEffect(() => {
@@ -137,34 +120,31 @@ export default function BattlefieldPage() {
     return map;
   }, [library]);
 
-  const handleGridMouseMove = useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => {
-      const m = matchRef.current;
-      const tip = tooltipRef.current;
-      if (!m || !tip) return;
+  const handleGridMouseMove = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+    const m = matchRef.current;
+    const tip = tooltipRef.current;
+    if (!m || !tip) return;
 
-      const rect = e.currentTarget.getBoundingClientRect();
-      const x = e.clientX - rect.left;
-      const y = e.clientY - rect.top;
-      const addr = cellAddressAtPixel(x, y);
+    const rect = e.currentTarget.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
+    const addr = cellAddressAtPixel(x, y);
 
-      if (addr < 0) {
-        tip.style.display = 'none';
-        hoveredAddrRef.current = -1;
-        return;
-      }
+    if (addr < 0) {
+      tip.style.display = 'none';
+      hoveredAddrRef.current = -1;
+      return;
+    }
 
-      hoveredAddrRef.current = addr;
-      tip.textContent = formatCellTooltip(m, addr);
-      tip.style.display = 'block';
+    hoveredAddrRef.current = addr;
+    tip.textContent = formatCellTooltip(m, addr);
+    tip.style.display = 'block';
 
-      const tipX = Math.min(x + 12, rect.width - tip.offsetWidth - 4);
-      const tipY = y > 40 ? y - 32 : y + 20;
-      tip.style.left = `${tipX}px`;
-      tip.style.top = `${tipY}px`;
-    },
-    [],
-  );
+    const tipX = Math.min(x + 12, rect.width - tip.offsetWidth - 4);
+    const tipY = y > 40 ? y - 32 : y + 20;
+    tip.style.left = `${tipX}px`;
+    tip.style.top = `${tipY}px`;
+  }, []);
 
   const handleGridMouseLeave = useCallback(() => {
     hoveredAddrRef.current = -1;
@@ -172,15 +152,7 @@ export default function BattlefieldPage() {
     if (tip) tip.style.display = 'none';
   }, []);
 
-  useEffect(() => {
-    let cancelled = false;
-    init().then(() => {
-      if (!cancelled) setReady(true);
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
+  const readyRef = useRef(false);
 
   useEffect(() => {
     if (!gridRef.current) return;
@@ -192,55 +164,66 @@ export default function BattlefieldPage() {
     };
   }, []);
 
-  const loadBattle = useCallback(() => {
-    if (!ready) return;
+  const loadBattle = useCallback(
+    (currentRedId: string, currentBlueId: string) => {
+      if (!readyRef.current) return;
 
-    cancelAnimationFrame(rafRef.current);
-    setRunning(false);
+      cancelAnimationFrame(rafRef.current);
+      setRunning(false);
 
-    const red = libraryById.get(redIdRef.current);
-    const blue = libraryById.get(blueIdRef.current);
-    if (!red || !blue) {
-      setParseError('Selected warrior not found in library.');
-      return;
-    }
+      const red = libraryById.get(currentRedId);
+      const blue = libraryById.get(currentBlueId);
+      if (!red || !blue) {
+        setParseError('Selected warrior not found in library.');
+        return;
+      }
 
-    let w1: ParsedWarrior, w2: ParsedWarrior;
-    try {
-      w1 = parseWarrior(red.source);
-      w2 = parseWarrior(blue.source);
-    } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e);
-      setParseError(`Parse error: ${msg}`);
-      return;
-    }
-    setParseError(null);
+      let w1: ParsedWarrior, w2: ParsedWarrior;
+      try {
+        w1 = parseWarrior(red.source);
+        w2 = parseWarrior(blue.source);
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        setParseError(`Parse error: ${msg}`);
+        return;
+      }
+      setParseError(null);
 
-    const match = new MatchState(CORE_SIZE, 80_000);
-    match.loadWarrior(0, w1, 0);
-    match.loadWarrior(1, w2, Math.floor(CORE_SIZE / 2));
-    matchRef.current = match;
-    warriorNamesRef.current = [
-      w1.name() ?? red.label,
-      w2.name() ?? blue.label,
-    ];
+      const match = new MatchState(CORE_SIZE, 80_000);
+      match.loadWarrior(0, w1, 0);
+      match.loadWarrior(1, w2, Math.floor(CORE_SIZE / 2));
+      matchRef.current = match;
+      warriorNamesRef.current = [w1.name() ?? red.label, w2.name() ?? blue.label];
 
-    if (rendererRef.current) {
-      rendererRef.current.update(match.coreOwnership());
-    }
+      if (rendererRef.current) {
+        rendererRef.current.update(match.coreOwnership());
+      }
 
-    setStepCount(0);
-    setResultCode(ONGOING);
-    setResultWinner(-1);
-    setWarriors([
-      { name: warriorNamesRef.current[0], alive: true, procs: 1 },
-      { name: warriorNamesRef.current[1], alive: true, procs: 1 },
-    ]);
-  }, [ready, libraryById]);
+      setStepCount(0);
+      setResultCode(ONGOING);
+      setResultWinner(-1);
+      setWarriors([
+        { name: warriorNamesRef.current[0], alive: true, procs: 1 },
+        { name: warriorNamesRef.current[1], alive: true, procs: 1 },
+      ]);
+    },
+    [libraryById],
+  );
 
   useEffect(() => {
-    if (ready) loadBattle();
-  }, [ready, loadBattle]);
+    let cancelled = false;
+    init().then(() => {
+      if (cancelled) return;
+      readyRef.current = true;
+      setReady(true);
+      loadBattle(redId, blueId);
+    });
+    return () => {
+      cancelled = true;
+    };
+    // Only run once on mount — warrior changes are handled by event handlers
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const syncUiState = useCallback(() => {
     const m = matchRef.current;
@@ -261,29 +244,32 @@ export default function BattlefieldPage() {
     setWarriors(ws);
   }, []);
 
-  const tick = useCallback(() => {
-    const m = matchRef.current;
-    const r = rendererRef.current;
-    if (!m || !r) return;
+  const tickRef = useRef<() => void>(() => {});
+  useEffect(() => {
+    tickRef.current = () => {
+      const m = matchRef.current;
+      const r = rendererRef.current;
+      if (!m || !r) return;
 
-    m.stepN(spfRef.current);
-    r.update(m.coreOwnership());
+      m.stepN(spfRef.current);
+      r.update(m.coreOwnership());
 
-    if (hoveredAddrRef.current >= 0 && tooltipRef.current) {
-      tooltipRef.current.textContent = formatCellTooltip(m, hoveredAddrRef.current);
-    }
+      if (hoveredAddrRef.current >= 0 && tooltipRef.current) {
+        tooltipRef.current.textContent = formatCellTooltip(m, hoveredAddrRef.current);
+      }
 
-    frameCountRef.current++;
-    if (frameCountRef.current % 6 === 0) {
-      syncUiState();
-    }
+      frameCountRef.current++;
+      if (frameCountRef.current % 6 === 0) {
+        syncUiState();
+      }
 
-    if (m.resultCode() === ONGOING) {
-      rafRef.current = requestAnimationFrame(tick);
-    } else {
-      syncUiState();
-      setRunning(false);
-    }
+      if (m.resultCode() === ONGOING) {
+        rafRef.current = requestAnimationFrame(() => tickRef.current());
+      } else {
+        syncUiState();
+        setRunning(false);
+      }
+    };
   }, [syncUiState]);
 
   const play = useCallback(() => {
@@ -291,8 +277,8 @@ export default function BattlefieldPage() {
     if (matchRef.current.resultCode() !== ONGOING) return;
     setRunning(true);
     frameCountRef.current = 0;
-    rafRef.current = requestAnimationFrame(tick);
-  }, [tick]);
+    rafRef.current = requestAnimationFrame(() => tickRef.current());
+  }, []);
 
   const pause = useCallback(() => {
     cancelAnimationFrame(rafRef.current);
@@ -321,18 +307,20 @@ export default function BattlefieldPage() {
   const reset = useCallback(() => {
     cancelAnimationFrame(rafRef.current);
     setRunning(false);
-    loadBattle();
-  }, [loadBattle]);
+    loadBattle(redId, blueId);
+  }, [loadBattle, redId, blueId]);
 
   const handlePickChange = useCallback(
     (side: 0 | 1, id: string) => {
+      const newRed = side === 0 ? id : redId;
+      const newBlue = side === 1 ? id : blueId;
       if (side === 0) setRedId(id);
       else setBlueId(id);
       cancelAnimationFrame(rafRef.current);
       setRunning(false);
-      setTimeout(() => loadBattle(), 0);
+      loadBattle(newRed, newBlue);
     },
-    [loadBattle],
+    [loadBattle, redId, blueId],
   );
 
   const selectStyle: React.CSSProperties = {
@@ -350,9 +338,7 @@ export default function BattlefieldPage() {
 
   return (
     <div style={ROOT_STYLE}>
-      <h1 style={{ margin: 0, fontSize: '1.5rem', letterSpacing: '0.1em' }}>
-        CORE WAR
-      </h1>
+      <h1 style={{ margin: 0, fontSize: '1.5rem', letterSpacing: '0.1em' }}>CORE WAR</h1>
 
       <div style={{ ...CONTROLS_STYLE, gap: '0.75rem' }}>
         <label style={{ color: WARRIOR_HEX[1], fontSize: '0.85rem' }}>
@@ -475,14 +461,26 @@ export default function BattlefieldPage() {
         <button style={BUTTON_STYLE} onClick={reset}>
           Reset
         </button>
-        <label style={{ fontSize: '0.8rem', color: '#888', display: 'flex', alignItems: 'center', gap: '0.4rem' }}>
+        <label
+          style={{
+            fontSize: '0.8rem',
+            color: '#888',
+            display: 'flex',
+            alignItems: 'center',
+            gap: '0.4rem',
+          }}
+        >
           Speed:
           <input
             type="range"
             min={1}
             max={500}
             value={stepsPerFrame}
-            onChange={(e) => setStepsPerFrame(Number(e.target.value))}
+            onChange={(e) => {
+              const v = Number(e.target.value);
+              setStepsPerFrame(v);
+              spfRef.current = v;
+            }}
             style={{ verticalAlign: 'middle', width: '100px' }}
           />
           <input
@@ -493,6 +491,7 @@ export default function BattlefieldPage() {
             onChange={(e) => {
               const v = Math.max(1, Math.min(500, Number(e.target.value) || 1));
               setStepsPerFrame(v);
+              spfRef.current = v;
             }}
             style={{
               width: '3.5rem',
@@ -513,9 +512,7 @@ export default function BattlefieldPage() {
       <div style={STATUS_STYLE}>
         {ready ? (
           <>
-            <div>
-              Steps: {stepCount.toLocaleString()} / 80,000
-            </div>
+            <div>Steps: {stepCount.toLocaleString()} / 80,000</div>
             <div style={{ marginTop: '0.3rem' }}>
               {warriors.map((w, i) => (
                 <span
@@ -526,9 +523,7 @@ export default function BattlefieldPage() {
                   }}
                 >
                   {w.name}:{' '}
-                  {w.alive
-                    ? `alive (${w.procs} proc${w.procs !== 1 ? 's' : ''})`
-                    : 'dead'}
+                  {w.alive ? `alive (${w.procs} proc${w.procs !== 1 ? 's' : ''})` : 'dead'}
                 </span>
               ))}
             </div>
@@ -536,7 +531,7 @@ export default function BattlefieldPage() {
               const banner = resultBanner(
                 resultCode,
                 resultWinner,
-                warriorNamesRef.current,
+                warriors.map((w) => w.name),
               );
               if (!banner) return null;
               return (

--- a/frontend/src/pages/BuilderPage.tsx
+++ b/frontend/src/pages/BuilderPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import Editor, { type Monaco, type OnMount } from '@monaco-editor/react';
 import init, { parseWarrior } from 'core-war-engine';
@@ -10,11 +10,7 @@ import {
   duplicateWarrior,
   type Warrior,
 } from '../warriors/library';
-import {
-  REDCODE_LANGUAGE_ID,
-  registerRedcode,
-  parseErrorToMarker,
-} from '../redcode/monaco';
+import { REDCODE_LANGUAGE_ID, registerRedcode, parseErrorToMarker } from '../redcode/monaco';
 import CheatSheetPanel from '../redcode/CheatSheetPanel';
 
 const PAGE_STYLE: React.CSSProperties = {
@@ -141,16 +137,13 @@ export default function BuilderPage() {
     };
   }, []);
 
-  // The Editor below uses `key={selectedId}` so it remounts cleanly per
-  // warrior. Pair that with `defaultValue` (uncontrolled) and `onChange`
-  // only fires on real keystrokes — never spuriously on warrior switch.
   const selected = library.find((w) => w.id === selectedId);
-  useEffect(() => {
-    if (!selected) return;
-    setSource(selected.source);
-    setLabel(selected.label);
+
+  const syncFromWarrior = useCallback((warrior: Warrior) => {
+    setSource(warrior.source);
+    setLabel(warrior.label);
     setDirty(false);
-  }, [selectedId, selected?.source, selected?.label]);
+  }, []);
 
   // Re-run parser whenever source or wasm readiness changes.
   useEffect(() => {
@@ -192,6 +185,8 @@ export default function BuilderPage() {
   const handleSelect = (id: string) => {
     if (dirty && !confirm('Discard unsaved changes?')) return;
     setSelectedId(id);
+    const warrior = library.find((w) => w.id === id);
+    if (warrior) syncFromWarrior(warrior);
   };
 
   const handleSave = () => {
@@ -199,7 +194,7 @@ export default function BuilderPage() {
     if (selected.isPreset) {
       const created = createUserWarrior(label || 'Untitled', source);
       setSelectedId(created.id);
-      setDirty(false);
+      syncFromWarrior(created);
       return;
     }
     updateUserWarrior(selected.id, { label: label || 'Untitled', source });
@@ -209,7 +204,10 @@ export default function BuilderPage() {
   const handleDuplicate = () => {
     if (!selected) return;
     const created = duplicateWarrior(selected.id);
-    if (created) setSelectedId(created.id);
+    if (created) {
+      setSelectedId(created.id);
+      syncFromWarrior(created);
+    }
   };
 
   const handleDelete = () => {
@@ -217,7 +215,10 @@ export default function BuilderPage() {
     if (!confirm(`Delete "${selected.label}"? This cannot be undone.`)) return;
     deleteUserWarrior(selected.id);
     const remaining = library.filter((w) => w.id !== selected.id);
-    setSelectedId(remaining[0]?.id ?? '');
+    const nextId = remaining[0]?.id ?? '';
+    setSelectedId(nextId);
+    const next = remaining[0];
+    if (next) syncFromWarrior(next);
   };
 
   const handleNew = () => {
@@ -228,6 +229,7 @@ start   MOV.I  $0, $1
 `;
     const created = createUserWarrior('New Warrior', template);
     setSelectedId(created.id);
+    syncFromWarrior(created);
   };
 
   const handleTestInBattle = () => {
@@ -246,8 +248,7 @@ start   MOV.I  $0, $1
     // Pick an opponent: first preset that isn't us, else first warrior that isn't us.
     const presets = library.filter((w) => w.isPreset);
     const opponent =
-      presets.find((w) => w.id !== targetId) ??
-      library.find((w) => w.id !== targetId);
+      presets.find((w) => w.id !== targetId) ?? library.find((w) => w.id !== targetId);
     const opponentId = opponent?.id ?? targetId;
     navigate(`/battle?red=${encodeURIComponent(targetId)}&blue=${encodeURIComponent(opponentId)}`);
   };
@@ -256,7 +257,6 @@ start   MOV.I  $0, $1
   const userWarriors = library.filter((w) => !w.isPreset);
 
   const canSave = !!selected && dirty;
-  const canDelete = !!selected && !selected.isPreset;
 
   return (
     <div style={PAGE_STYLE}>
@@ -272,7 +272,14 @@ start   MOV.I  $0, $1
         ))}
         <div style={LIST_HEADER_STYLE}>My Warriors</div>
         {userWarriors.length === 0 && (
-          <div style={{ padding: '0.5rem 1rem', fontSize: '0.8rem', color: '#555', fontStyle: 'italic' }}>
+          <div
+            style={{
+              padding: '0.5rem 1rem',
+              fontSize: '0.8rem',
+              color: '#555',
+              fontStyle: 'italic',
+            }}
+          >
             None yet. Duplicate a classic or create a new one.
           </div>
         )}
@@ -390,16 +397,11 @@ function WarriorListItem({
   onSelect: (id: string) => void;
 }) {
   return (
-    <div
-      style={listItemStyle(active, warrior.isPreset)}
-      onClick={() => onSelect(warrior.id)}
-    >
+    <div style={listItemStyle(active, warrior.isPreset)} onClick={() => onSelect(warrior.id)}>
       <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
         {warrior.label}
       </span>
-      {warrior.isPreset && (
-        <span style={{ fontSize: '0.65rem', color: '#666' }}>CLASSIC</span>
-      )}
+      {warrior.isPreset && <span style={{ fontSize: '0.65rem', color: '#666' }}>CLASSIC</span>}
     </div>
   );
 }

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -51,9 +51,8 @@ export default function HomePage() {
       <h1 style={TITLE_STYLE}>CORE WAR</h1>
       <p style={LEDE_STYLE}>
         A modernized rebuild of the 1984 programming game. Write programs in{' '}
-        <strong>Redcode</strong> assembly, load them into <strong>MARS</strong>{' '}
-        &mdash; the Memory Array Redcode Simulator &mdash; and watch your
-        warriors battle for control of the core.
+        <strong>Redcode</strong> assembly, load them into <strong>MARS</strong> &mdash; the Memory
+        Array Redcode Simulator &mdash; and watch your warriors battle for control of the core.
       </p>
       <div style={BUTTONS_STYLE}>
         <Link to="/battle" style={linkButton('#e94560')}>

--- a/frontend/src/pages/LearnPage.tsx
+++ b/frontend/src/pages/LearnPage.tsx
@@ -106,31 +106,29 @@ export default function LearnPage() {
     <div style={PAGE_STYLE}>
       <h1 style={H1_STYLE}>LEARN REDCODE</h1>
       <p style={LEDE_STYLE}>
-        A practical introduction to writing warriors for Core War. By the end
-        of this page you should understand the machine, be able to read the
-        classic warriors, and have the vocabulary to start writing your own.
+        A practical introduction to writing warriors for Core War. By the end of this page you
+        should understand the machine, be able to read the classic warriors, and have the vocabulary
+        to start writing your own.
       </p>
 
       <h2 style={H2_STYLE}>1. The machine: MARS</h2>
       <p>
-        MARS — the <strong>Memory Array Redcode Simulator</strong> — is a
-        virtual computer with a <em>circular</em> memory of {8000} cells. Every
-        cell is the same size and holds one Redcode instruction. Address 0 and
-        address 7999 are adjacent; when you walk off the end, you wrap back
-        around.
+        MARS — the <strong>Memory Array Redcode Simulator</strong> — is a virtual computer with a{' '}
+        <em>circular</em> memory of {8000} cells. Every cell is the same size and holds one Redcode
+        instruction. Address 0 and address 7999 are adjacent; when you walk off the end, you wrap
+        back around.
       </p>
       <p>
-        A <strong>warrior</strong> is a Redcode program. Two warriors are
-        loaded into different spots in the core, each with one
-        <em> process</em> — essentially a program counter (PC) — pointing at
-        its first instruction. The simulator ticks round-robin: one
-        instruction from warrior A, then one from warrior B, then back to A.
+        A <strong>warrior</strong> is a Redcode program. Two warriors are loaded into different
+        spots in the core, each with one
+        <em> process</em> — essentially a program counter (PC) — pointing at its first instruction.
+        The simulator ticks round-robin: one instruction from warrior A, then one from warrior B,
+        then back to A.
       </p>
       <p>
-        You <strong>win</strong> by being the last warrior with at least one
-        live process. A process <strong>dies</strong> if it tries to execute a{' '}
-        <C>DAT</C>, does an illegal divide-by-zero, or if the whole match
-        hits the step limit without a winner (a tie).
+        You <strong>win</strong> by being the last warrior with at least one live process. A process{' '}
+        <strong>dies</strong> if it tries to execute a <C>DAT</C>, does an illegal divide-by-zero,
+        or if the whole match hits the step limit without a winner (a tie).
       </p>
 
       <h2 style={H2_STYLE}>2. Anatomy of an instruction</h2>
@@ -142,9 +140,9 @@ export default function LearnPage() {
         │   └────────── modifier (which fields to touch)
         └────────────── opcode (what to do)`}</pre>
       <p>
-        Each of the four pieces is independent, which is why Redcode has so
-        many variants: {'~16 opcodes × 7 modifiers × 8 addressing modes'} per
-        operand adds up to a <em>lot</em> of possible instructions.
+        Each of the four pieces is independent, which is why Redcode has so many variants:{' '}
+        {'~16 opcodes × 7 modifiers × 8 addressing modes'} per operand adds up to a <em>lot</em> of
+        possible instructions.
       </p>
 
       <h3 style={H3_STYLE}>Labels, comments, and pseudo-ops</h3>
@@ -154,17 +152,16 @@ export default function LearnPage() {
 bomb    DAT.F  #0, #0  ; "bomb" is a label for this line
 start   JMP    bomb    ; labels turn into relative offsets`}</pre>
       <p>
-        Anything after a <C>;</C> is a comment. <C>;name</C> and <C>;author</C>{' '}
-        are magic comments recognized as metadata. <C>ORG label</C> says
-        "start executing at this label." Labels can also appear as the value
-        of an operand — the assembler converts them into a relative offset
+        Anything after a <C>;</C> is a comment. <C>;name</C> and <C>;author</C> are magic comments
+        recognized as metadata. <C>ORG label</C> says "start executing at this label." Labels can
+        also appear as the value of an operand — the assembler converts them into a relative offset
         from the line that uses them.
       </p>
 
       <h2 style={H2_STYLE}>3. Addressing modes</h2>
       <p>
-        Each operand carries an addressing mode that decides how its numeric
-        value is interpreted. This is where Redcode gets weird and fun.
+        Each operand carries an addressing mode that decides how its numeric value is interpreted.
+        This is where Redcode gets weird and fun.
       </p>
       <table style={TABLE_STYLE}>
         <thead>
@@ -197,8 +194,7 @@ start   JMP    bomb    ; labels turn into relative offsets`}</pre>
             </td>
             <td style={TD_STYLE}>A-indirect</td>
             <td style={TD_STYLE}>
-              Use operand's value as an offset, go there, then follow{' '}
-              <em>that</em> cell's A-field.
+              Use operand's value as an offset, go there, then follow <em>that</em> cell's A-field.
             </td>
           </tr>
           <tr>
@@ -206,9 +202,7 @@ start   JMP    bomb    ; labels turn into relative offsets`}</pre>
               <C>@</C>
             </td>
             <td style={TD_STYLE}>B-indirect</td>
-            <td style={TD_STYLE}>
-              Same as above, but follow the target cell's B-field.
-            </td>
+            <td style={TD_STYLE}>Same as above, but follow the target cell's B-field.</td>
           </tr>
           <tr>
             <td style={TD_STYLE}>
@@ -216,8 +210,7 @@ start   JMP    bomb    ; labels turn into relative offsets`}</pre>
             </td>
             <td style={TD_STYLE}>A-predecrement</td>
             <td style={TD_STYLE}>
-              Decrement the target cell's A-field <em>first</em>, then use it
-              as the address.
+              Decrement the target cell's A-field <em>first</em>, then use it as the address.
             </td>
           </tr>
           <tr>
@@ -225,9 +218,7 @@ start   JMP    bomb    ; labels turn into relative offsets`}</pre>
               <C>{'<'}</C>
             </td>
             <td style={TD_STYLE}>B-predecrement</td>
-            <td style={TD_STYLE}>
-              Same, but decrement the B-field. Used heavily in replicators.
-            </td>
+            <td style={TD_STYLE}>Same, but decrement the B-field. Used heavily in replicators.</td>
           </tr>
           <tr>
             <td style={TD_STYLE}>
@@ -248,17 +239,16 @@ start   JMP    bomb    ; labels turn into relative offsets`}</pre>
         </tbody>
       </table>
       <div style={CALLOUT_STYLE}>
-        <strong>Key idea:</strong> the predecrement/postincrement modes
-        mutate the memory they look at. They're the backbone of warriors that
-        need to advance a pointer with every copy (e.g. replicators).
+        <strong>Key idea:</strong> the predecrement/postincrement modes mutate the memory they look
+        at. They're the backbone of warriors that need to advance a pointer with every copy (e.g.
+        replicators).
       </div>
 
       <h2 style={H2_STYLE}>4. Modifiers</h2>
       <p>
-        The dot suffix on an opcode decides <em>which fields</em> the
-        operation touches. An instruction has an A-field and a B-field
-        (ignoring opcode/modifier/address-mode bits); modifiers control how
-        data flows between them.
+        The dot suffix on an opcode decides <em>which fields</em> the operation touches. An
+        instruction has an A-field and a B-field (ignoring opcode/modifier/address-mode bits);
+        modifiers control how data flows between them.
       </p>
       <table style={TABLE_STYLE}>
         <thead>
@@ -282,8 +272,8 @@ start   JMP    bomb    ; labels turn into relative offsets`}</pre>
             </td>
             <td style={TD_STYLE}>A→B or B→A across</td>
             <td style={TD_STYLE}>
-              Move a single value from one field into the other of another
-              cell (e.g. <C>MOV.AB #8, ptr</C>).
+              Move a single value from one field into the other of another cell (e.g.{' '}
+              <C>MOV.AB #8, ptr</C>).
             </td>
           </tr>
           <tr>
@@ -306,30 +296,25 @@ start   JMP    bomb    ; labels turn into relative offsets`}</pre>
             </td>
             <td style={TD_STYLE}>Whole instruction</td>
             <td style={TD_STYLE}>
-              Copy opcode + modifier + both operands. The default for{' '}
-              <C>MOV</C>.
+              Copy opcode + modifier + both operands. The default for <C>MOV</C>.
             </td>
           </tr>
         </tbody>
       </table>
 
       <h2 style={H2_STYLE}>5. Walkthrough: Imp</h2>
-      <p>
-        The shortest meaningful warrior in the book. One line:
-      </p>
+      <p>The shortest meaningful warrior in the book. One line:</p>
       <pre style={CODE_BLOCK}>{`        MOV.I $0, $1`}</pre>
       <p>
-        Let's dissect it. <C>MOV.I</C> copies a whole instruction. <C>$0</C>{' '}
-        is "this cell." <C>$1</C> is "the next cell." So on each tick, the
-        Imp copies itself forward by one. The process then advances its PC by
-        one — which lands on a freshly-written Imp, and the whole thing
-        repeats.
+        Let's dissect it. <C>MOV.I</C> copies a whole instruction. <C>$0</C> is "this cell."{' '}
+        <C>$1</C> is "the next cell." So on each tick, the Imp copies itself forward by one. The
+        process then advances its PC by one — which lands on a freshly-written Imp, and the whole
+        thing repeats.
       </p>
       <p>
-        The Imp is <em>hard to kill</em> because it's never standing still.
-        By the time your bomb lands where it was, it has already moved on.
-        It's also <em>hard to kill anything with</em> — it just leaves a
-        trail of MOV.I everywhere.
+        The Imp is <em>hard to kill</em> because it's never standing still. By the time your bomb
+        lands where it was, it has already moved on. It's also <em>hard to kill anything with</em> —
+        it just leaves a trail of MOV.I everywhere.
       </p>
 
       <h2 style={H2_STYLE}>6. Walkthrough: Dwarf</h2>
@@ -339,77 +324,71 @@ start   ADD.AB #4, bomb
         MOV.I  bomb, @bomb
         JMP    start
 bomb    DAT.F  #0, #0`}</pre>
-      <p>
-        Three instructions in a loop plus a payload. Each iteration:
-      </p>
+      <p>Three instructions in a loop plus a payload. Each iteration:</p>
       <ol>
         <li>
-          <C>ADD.AB #4, bomb</C> — add 4 into <em>bomb</em>'s B-field. So the
-          B-field climbs: 0, 4, 8, 12, … Each time we're aiming at a
-          different cell.
+          <C>ADD.AB #4, bomb</C> — add 4 into <em>bomb</em>'s B-field. So the B-field climbs: 0, 4,
+          8, 12, … Each time we're aiming at a different cell.
         </li>
         <li>
-          <C>MOV.I bomb, @bomb</C> — copy bomb (a DAT) to the address stored
-          in bomb's B-field. The <C>@</C> prefix says "look at bomb, then
-          follow its B-field." So the DAT lands 4, 8, 12, … cells past bomb
-          itself, never touching the Dwarf's own code.
+          <C>MOV.I bomb, @bomb</C> — copy bomb (a DAT) to the address stored in bomb's B-field. The{' '}
+          <C>@</C> prefix says "look at bomb, then follow its B-field." So the DAT lands 4, 8, 12, …
+          cells past bomb itself, never touching the Dwarf's own code.
         </li>
         <li>
           <C>JMP start</C> — start over.
         </li>
       </ol>
       <p>
-        Because 4 is coprime with 8000, the Dwarf eventually bombs every
-        single cell. Any enemy process that steps on one of those DATs dies.
-        Simple, slow, effective.
+        Because 4 is coprime with 8000, the Dwarf eventually bombs every single cell. Any enemy
+        process that steps on one of those DATs dies. Simple, slow, effective.
       </p>
 
       <h2 style={H2_STYLE}>7. Three classic strategies</h2>
       <p>
-        Once you're past the toy stage, warriors tend to fall into three
-        broad families — the rock-paper-scissors of Core War.
+        Once you're past the toy stage, warriors tend to fall into three broad families — the
+        rock-paper-scissors of Core War.
       </p>
 
       <h3 style={H3_STYLE}>Stones (bombers)</h3>
       <p>
-        Sit in one place, lob DATs at a fixed stride. Dwarf is the
-        archetype. They beat <strong>papers</strong> by bombing into the
-        replicated copies.
+        Sit in one place, lob DATs at a fixed stride. Dwarf is the archetype. They beat{' '}
+        <strong>papers</strong> by bombing into the replicated copies.
       </p>
 
       <h3 style={H3_STYLE}>Papers (replicators)</h3>
       <p>
-        Copy themselves to another part of the core, spawn a new process
-        there, then do it again. Mice is the archetype. They beat{' '}
-        <strong>scanners</strong> by sheer numbers — the scanner can't find
-        and bomb copies faster than the paper can make them.
+        Copy themselves to another part of the core, spawn a new process there, then do it again.
+        Mice is the archetype. They beat <strong>scanners</strong> by sheer numbers — the scanner
+        can't find and bomb copies faster than the paper can make them.
       </p>
 
       <h3 style={H3_STYLE}>Scanners</h3>
       <p>
-        Walk the core looking for anything non-empty and bomb it. Much more
-        efficient than blind bombing. Scanner is the archetype. They beat
-        <strong> stones</strong> because they can find and kill the bomber's
-        single location before it has bombed enough cells to matter.
+        Walk the core looking for anything non-empty and bomb it. Much more efficient than blind
+        bombing. Scanner is the archetype. They beat
+        <strong> stones</strong> because they can find and kill the bomber's single location before
+        it has bombed enough cells to matter.
       </p>
 
       <div style={CALLOUT_STYLE}>
-        <strong>So:</strong> stones → papers → scanners → stones. Picking a
-        strategy against an unknown opponent is essentially a bet.
+        <strong>So:</strong> stones → papers → scanners → stones. Picking a strategy against an
+        unknown opponent is essentially a bet.
       </div>
 
       <h2 style={H2_STYLE}>8. Where to from here</h2>
       <p>
-        Open the <Link to="/builder" style={LINK_STYLE}>Warrior Builder</Link>{' '}
-        and pick a classic from the sidebar — every one is heavily commented
-        now. Duplicate it, change a number (bomb stride, copy distance,
-        split target), and hit <strong>Test in Battlefield</strong> to see
-        what the change did.
+        Open the{' '}
+        <Link to="/builder" style={LINK_STYLE}>
+          Warrior Builder
+        </Link>{' '}
+        and pick a classic from the sidebar — every one is heavily commented now. Duplicate it,
+        change a number (bomb stride, copy distance, split target), and hit{' '}
+        <strong>Test in Battlefield</strong> to see what the change did.
       </p>
       <p>
-        The cheat sheet on the right of the builder has every opcode,
-        modifier, and addressing mode on one scrollable list. Keep it open
-        while you read code.
+        The cheat sheet on the right of the builder has every opcode, modifier, and addressing mode
+        on one scrollable list. Keep it open while you read code.
       </p>
       <p style={{ marginTop: '2rem' }}>
         <Link to="/builder" style={LINK_STYLE}>

--- a/frontend/src/redcode/CheatSheetPanel.tsx
+++ b/frontend/src/redcode/CheatSheetPanel.tsx
@@ -1,11 +1,5 @@
 import { useState } from 'react';
-import {
-  OPCODES,
-  MODIFIERS,
-  ADDRESSING_MODES,
-  PSEUDO_OPS,
-  type CheatEntry,
-} from './cheatSheet';
+import { OPCODES, MODIFIERS, ADDRESSING_MODES, PSEUDO_OPS, type CheatEntry } from './cheatSheet';
 
 const PANEL_STYLE: React.CSSProperties = {
   flexShrink: 0,
@@ -106,7 +100,11 @@ export default function CheatSheetPanel() {
 
   if (!open) {
     return (
-      <div style={{ ...PANEL_STYLE, width: '36px', cursor: 'pointer' }} onClick={() => setOpen(true)} title="Show cheat sheet">
+      <div
+        style={{ ...PANEL_STYLE, width: '36px', cursor: 'pointer' }}
+        onClick={() => setOpen(true)}
+        title="Show cheat sheet"
+      >
         <div
           style={{
             writingMode: 'vertical-rl',

--- a/frontend/src/redcode/cheatSheet.ts
+++ b/frontend/src/redcode/cheatSheet.ts
@@ -9,10 +9,26 @@ export const OPCODES: CheatEntry[] = [
   { symbol: 'DIV', name: 'divide', desc: 'dst /= src. Divide-by-zero kills the process.' },
   { symbol: 'MOD', name: 'modulo', desc: 'dst %= src. Mod-by-zero kills the process.' },
   { symbol: 'JMP', name: 'jump', desc: 'Jump to the A operand address.' },
-  { symbol: 'JMZ', name: 'jump if zero', desc: 'Jump if the selected field(s) of B operand are zero.' },
-  { symbol: 'JMN', name: 'jump if non-zero', desc: 'Jump if any selected field of B operand is non-zero.' },
-  { symbol: 'DJN', name: 'decrement & jump if non-zero', desc: 'Decrement B operand field(s), then jump if non-zero.' },
-  { symbol: 'SPL', name: 'split', desc: 'Spawn a new process at the A operand address. Original continues.' },
+  {
+    symbol: 'JMZ',
+    name: 'jump if zero',
+    desc: 'Jump if the selected field(s) of B operand are zero.',
+  },
+  {
+    symbol: 'JMN',
+    name: 'jump if non-zero',
+    desc: 'Jump if any selected field of B operand is non-zero.',
+  },
+  {
+    symbol: 'DJN',
+    name: 'decrement & jump if non-zero',
+    desc: 'Decrement B operand field(s), then jump if non-zero.',
+  },
+  {
+    symbol: 'SPL',
+    name: 'split',
+    desc: 'Spawn a new process at the A operand address. Original continues.',
+  },
   { symbol: 'SEQ', name: 'skip if equal', desc: 'Skip the next instruction if A == B.' },
   { symbol: 'SNE', name: 'skip if not equal', desc: 'Skip the next instruction if A != B.' },
   { symbol: 'SLT', name: 'skip if less than', desc: 'Skip the next instruction if A < B.' },
@@ -20,13 +36,25 @@ export const OPCODES: CheatEntry[] = [
 ];
 
 export const MODIFIERS: CheatEntry[] = [
-  { symbol: '.A', name: 'A-field', desc: 'Operate on A-field of A operand → A-field of B operand.' },
-  { symbol: '.B', name: 'B-field', desc: 'Operate on B-field of A operand → B-field of B operand.' },
+  {
+    symbol: '.A',
+    name: 'A-field',
+    desc: 'Operate on A-field of A operand → A-field of B operand.',
+  },
+  {
+    symbol: '.B',
+    name: 'B-field',
+    desc: 'Operate on B-field of A operand → B-field of B operand.',
+  },
   { symbol: '.AB', name: 'A → B', desc: 'A-field of source into B-field of destination.' },
   { symbol: '.BA', name: 'B → A', desc: 'B-field of source into A-field of destination.' },
   { symbol: '.F', name: 'fields', desc: 'Both fields in parallel: A→A and B→B.' },
   { symbol: '.X', name: 'cross', desc: 'Both fields crossed: A→B and B→A.' },
-  { symbol: '.I', name: 'instruction', desc: 'Copy/compare the whole instruction, not just fields.' },
+  {
+    symbol: '.I',
+    name: 'instruction',
+    desc: 'Copy/compare the whole instruction, not just fields.',
+  },
 ];
 
 export const ADDRESSING_MODES: CheatEntry[] = [

--- a/frontend/src/redcode/monaco.ts
+++ b/frontend/src/redcode/monaco.ts
@@ -3,9 +3,23 @@ import type * as MonacoNs from 'monaco-editor';
 export const REDCODE_LANGUAGE_ID = 'redcode';
 
 const OPCODES = [
-  'DAT', 'MOV', 'ADD', 'SUB', 'MUL', 'DIV', 'MOD',
-  'JMP', 'JMZ', 'JMN', 'DJN', 'SPL',
-  'SEQ', 'SNE', 'SLT', 'NOP', 'CMP',
+  'DAT',
+  'MOV',
+  'ADD',
+  'SUB',
+  'MUL',
+  'DIV',
+  'MOD',
+  'JMP',
+  'JMZ',
+  'JMN',
+  'DJN',
+  'SPL',
+  'SEQ',
+  'SNE',
+  'SLT',
+  'NOP',
+  'CMP',
 ];
 
 const PSEUDO = ['ORG', 'END', 'EQU'];
@@ -83,9 +97,7 @@ export function parseErrorToMarker(
   sourceLineCount: number,
 ): MonacoNs.editor.IMarkerData {
   const lineMatch = message.match(/line\s+(\d+)/i);
-  const line = lineMatch
-    ? Math.min(Math.max(parseInt(lineMatch[1], 10), 1), sourceLineCount)
-    : 1;
+  const line = lineMatch ? Math.min(Math.max(parseInt(lineMatch[1], 10), 1), sourceLineCount) : 1;
   return {
     severity: monaco.MarkerSeverity.Error,
     message,

--- a/frontend/src/warriors/library.ts
+++ b/frontend/src/warriors/library.ts
@@ -194,13 +194,8 @@ export function createUserWarrior(label: string, source: string): Warrior {
   return w;
 }
 
-export function updateUserWarrior(
-  id: string,
-  patch: { label?: string; source?: string },
-): void {
-  userWarriors = userWarriors.map((w) =>
-    w.id === id && !w.isPreset ? { ...w, ...patch } : w,
-  );
+export function updateUserWarrior(id: string, patch: { label?: string; source?: string }): void {
+  userWarriors = userWarriors.map((w) => (w.id === id && !w.isPreset ? { ...w, ...patch } : w));
   emit();
 }
 


### PR DESCRIPTION
## Summary
- Add ESLint with `@typescript-eslint`, `react-hooks`, `react-refresh` plugins and flat config
- Add Prettier with `eslint-config-prettier` to avoid rule conflicts
- Config matches existing code style: single quotes, semicolons, 2-space indent, trailing commas
- Add `npm run lint`, `npm run format`, and `npm run format:check` scripts
- Fix all lint violations with proper React patterns — no project/folder-level rule suppression

### Code fixes (not suppressions)
- **BattlefieldPage**: Remove `redIdRef`/`blueIdRef` — `loadBattle` now takes IDs as parameters, called from event handlers and the wasm init callback
- **BattlefieldPage**: Update `spfRef` in slider/input `onChange` handlers instead of during render
- **BattlefieldPage**: Move `tickRef.current` assignment into `useEffect`
- **BattlefieldPage**: `resultBanner` reads from `warriors` state instead of ref during render
- **BuilderPage**: Replace `useEffect` state sync with `syncFromWarrior` called from event handlers
- **BuilderPage**: Remove unused `canDelete` variable
- **Prettier**: Auto-format 11 files to match configured style

One inline `eslint-disable-next-line` for the mount-once wasm init effect (legitimate mount-only pattern).

Closes #13

## Test plan
- [x] `npm run lint` — zero errors, zero warnings
- [x] `npm run format:check` — all files formatted
- [x] `npm run build` — production build succeeds
- [x] Manual browser testing — battle page, builder page, warrior selection, speed slider all work correctly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)