### PR TITLE
Add frontend lint, format, and test checks to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
         run: cargo fmt -- --check
 
   frontend:
-    name: Frontend (build)
+    name: Frontend (lint + format + test + build)
     runs-on: ubuntu-latest
     needs: engine
     defaults:
@@ -124,6 +124,15 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Check formatting
+        run: npm run format:check
+
+      - name: Run tests
+        run: npm run test
 
       - name: Build
         run: npm run build


### PR DESCRIPTION
## Summary
- Adds `npm run lint`, `npm run format:check`, and `npm run test` steps to the frontend CI job
- Steps run before the build step so code quality failures are caught early
- Updates job name to reflect the new checks

Closes #15

## Test plan
- [x] CI `npm run lint` step passes (ESLint)
- [x] CI `npm run format:check` step passes (Prettier)
- [x] CI `npm run test` step passes (Vitest, 49 tests)
- [x] CI `npm run build` step still passes
- [x] Engine and backend CI jobs are unaffected

🤖 Generated with [Claude Code](https://claude.ai/claude-code)