### PR TITLE
Add Playwright MCP for browser-based frontend testing (issue #17)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ node_modules/
 
 # build output
 dist/
+
+# Playwright MCP runtime artifacts
+.playwright-mcp/

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "npx",
+      "args": [
+        "@playwright/mcp@latest",
+        "--headless",
+        "--executable-path",
+        "/home/coltergeizt/.cache/ms-playwright/chromium-1217/chrome-linux64/chrome"
+      ]
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,21 @@ node frontend/scripts/test-backend.mjs
 
 It exits 0 on success, 1 on any failure, and prints the assigned `sid` so you can cross-reference it against the backend's `client connected: <sid>` log line — matching SIDs prove you're talking to the process you think you are (this matters: a stale uvicorn from a previous session once silently answered this test).
 
+### Playwright MCP (browser testing from Claude Code)
+
+The repo includes a `.mcp.json` that configures the Playwright MCP server for headless Chromium. This lets Claude Code launch a browser, navigate pages, click elements, and take accessibility snapshots of the running frontend.
+
+**First-time setup:**
+
+```bash
+# Install Playwright browsers (only needed once)
+npx playwright install chromium
+```
+
+After install, update the `--executable-path` in `.mcp.json` to match the installed Chromium path (check `~/.cache/ms-playwright/` for the exact directory).
+
+**Usage:** Start the frontend dev server (`npm run dev` in `frontend/`), then use Playwright MCP tools (`browser_navigate`, `browser_snapshot`, `browser_click`, etc.) to interact with `http://localhost:5173`. Runtime artifacts are written to `.playwright-mcp/` (gitignored).
+
 Frontend production build: `npm run build` (outputs to `frontend/dist/`); preview with `npm run preview`.
 
 Engine release build: `wasm-pack build --target web --release` (uses `opt-level = "s"` for size).

--- a/README.md
+++ b/README.md
@@ -133,12 +133,19 @@ cd backend
 cargo test
 ```
 
+### Frontend tests
+
+```bash
+cd frontend
+npm test
+```
+
 ### Running all tests
 
 From the repo root:
 
 ```bash
-(cd engine && cargo test) && (cd backend && cargo test)
+(cd engine && cargo test) && (cd backend && cargo test) && (cd frontend && npm test)
 ```
 
 ## Development Workflow
@@ -174,9 +181,55 @@ cd backend && cargo build --release
 # Rust (works in both engine/ and backend/)
 cargo fmt
 cargo clippy --all-targets -- -D warnings
+
+# Frontend (from frontend/)
+npm run lint       # ESLint
+npm run format     # Prettier
+npm test           # Vitest (single run)
+npm run test:watch # Vitest (watch mode)
 ```
 
-No frontend linter is configured yet.
+## Playwright MCP (Browser Testing with Claude Code)
+
+The repo includes a `.mcp.json` that configures the [Playwright MCP server](https://github.com/anthropics/mcp-playwright), allowing Claude Code to launch a headless browser, navigate pages, interact with UI elements, and take accessibility snapshots of the running frontend.
+
+### Setup
+
+1. Install Playwright and its browsers:
+
+```bash
+npx playwright install chromium
+```
+
+2. Find the installed Chromium path:
+
+```bash
+ls ~/.cache/ms-playwright/
+```
+
+3. Update `.mcp.json` at the repo root with the correct path:
+
+```json
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "npx",
+      "args": [
+        "@playwright/mcp@latest",
+        "--headless",
+        "--executable-path",
+        "<your-chromium-path>/chrome"
+      ]
+    }
+  }
+}
+```
+
+### Usage
+
+With the frontend dev server running (`npm run dev` in `frontend/`), Claude Code can use Playwright MCP tools to navigate to `http://localhost:5173`, click through pages, fill inputs, and verify UI state — useful for smoke-testing after refactors or visually verifying new features.
+
+Runtime artifacts are written to `.playwright-mcp/` (gitignored).
 
 ## License
 


### PR DESCRIPTION
## Summary
- Add `.mcp.json` configuring the Playwright MCP server with headless Chromium for Claude Code browser testing
- Add `.playwright-mcp/` to `.gitignore` to exclude runtime artifacts
- Document Playwright MCP setup and usage in both `CLAUDE.md` and `README.md`
- Update README with frontend lint (`eslint`), format (`prettier`), and test (`vitest`) commands that were missing after the earlier CI setup

Closes #17

## Test plan
- [x] Playwright MCP server launches and connects successfully
- [x] Claude Code can navigate to `http://localhost:5173` and snapshot all four routes (Home, Battle, Builder, Learn)
- [x] Claude Code can interact with UI elements (click nav links, press Play, etc.)
- [x] `.playwright-mcp/` runtime artifacts are gitignored
- [x] Setup instructions in README use generic paths (no personal directories)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)