### PR TITLE
Add auth core: argon2id password hashing + JWT encode/decode (issue #3)

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -33,6 +33,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures",
+ "password-hash",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -141,6 +153,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -225,12 +246,17 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 name = "core-war-backend"
 version = "0.1.0"
 dependencies = [
+ "argon2",
  "axum",
  "chrono",
  "dotenvy",
+ "hex",
  "http-body-util",
+ "jsonwebtoken",
+ "rand",
  "serde",
  "serde_json",
+ "sha2",
  "socketioxide",
  "sqlx",
  "tokio",
@@ -304,6 +330,15 @@ dependencies = [
  "const-oid",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
 ]
 
 [[package]]
@@ -529,8 +564,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -853,6 +890,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -986,6 +1038,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint-dig"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1000,6 +1062,12 @@ dependencies = [
  "smallvec",
  "zeroize",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-integer"
@@ -1067,6 +1135,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
+]
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1128,6 +1217,12 @@ checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1450,6 +1545,18 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
  "rand_core",
+]
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.18",
+ "time",
 ]
 
 [[package]]
@@ -1842,6 +1949,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -16,6 +16,11 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres", "migrate", "uuid", "chrono"] }
 uuid = { version = "1", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
+argon2 = "0.5"
+jsonwebtoken = "9"
+rand = "0.8"
+sha2 = "0.10"
+hex = "0.4"
 
 [dev-dependencies]
 http-body-util = "0.1"

--- a/backend/src/auth/jwt.rs
+++ b/backend/src/auth/jwt.rs
@@ -27,8 +27,12 @@ pub fn encode_access_token(
         exp: now + ACCESS_TOKEN_DURATION_SECS,
         iat: now,
     };
-    encode(&Header::default(), &claims, &EncodingKey::from_secret(secret))
-        .map_err(|e| AppError::Internal(format!("JWT encoding failed: {e}")))
+    encode(
+        &Header::default(),
+        &claims,
+        &EncodingKey::from_secret(secret),
+    )
+    .map_err(|e| AppError::Internal(format!("JWT encoding failed: {e}")))
 }
 
 pub fn decode_access_token(token: &str, secret: &[u8]) -> Result<Claims, AppError> {

--- a/backend/src/auth/jwt.rs
+++ b/backend/src/auth/jwt.rs
@@ -1,0 +1,151 @@
+use chrono::Utc;
+use jsonwebtoken::{decode, encode, DecodingKey, EncodingKey, Header, Validation};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::errors::AppError;
+
+const ACCESS_TOKEN_DURATION_SECS: i64 = 15 * 60;
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+pub struct Claims {
+    pub sub: String,
+    pub username: String,
+    pub exp: i64,
+    pub iat: i64,
+}
+
+pub fn encode_access_token(
+    user_id: Uuid,
+    username: &str,
+    secret: &[u8],
+) -> Result<String, AppError> {
+    let now = Utc::now().timestamp();
+    let claims = Claims {
+        sub: user_id.to_string(),
+        username: username.to_string(),
+        exp: now + ACCESS_TOKEN_DURATION_SECS,
+        iat: now,
+    };
+    encode(&Header::default(), &claims, &EncodingKey::from_secret(secret))
+        .map_err(|e| AppError::Internal(format!("JWT encoding failed: {e}")))
+}
+
+pub fn decode_access_token(token: &str, secret: &[u8]) -> Result<Claims, AppError> {
+    decode::<Claims>(
+        token,
+        &DecodingKey::from_secret(secret),
+        &Validation::default(),
+    )
+    .map(|data| data.claims)
+    .map_err(|e| AppError::Unauthorized(format!("Invalid token: {e}")))
+}
+
+pub fn generate_refresh_token() -> String {
+    let bytes: [u8; 32] = rand::random();
+    hex::encode(bytes)
+}
+
+pub fn hash_refresh_token(token: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(token.as_bytes());
+    hex::encode(hasher.finalize())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TEST_SECRET: &[u8] = b"this-is-a-test-secret-at-least-32-bytes!";
+
+    #[test]
+    fn encode_and_decode_roundtrip() {
+        let user_id = Uuid::new_v4();
+        let token = encode_access_token(user_id, "testuser", TEST_SECRET).unwrap();
+        let claims = decode_access_token(&token, TEST_SECRET).unwrap();
+
+        assert_eq!(claims.sub, user_id.to_string());
+        assert_eq!(claims.username, "testuser");
+    }
+
+    #[test]
+    fn expired_token_rejected() {
+        let user_id = Uuid::new_v4();
+        let now = Utc::now().timestamp();
+        let claims = Claims {
+            sub: user_id.to_string(),
+            username: "testuser".into(),
+            exp: now - 120,
+            iat: now - 1020,
+        };
+        let token = encode(
+            &Header::default(),
+            &claims,
+            &EncodingKey::from_secret(TEST_SECRET),
+        )
+        .unwrap();
+
+        let result = decode_access_token(&token, TEST_SECRET);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn wrong_secret_rejected() {
+        let user_id = Uuid::new_v4();
+        let token = encode_access_token(user_id, "testuser", TEST_SECRET).unwrap();
+        let result = decode_access_token(&token, b"wrong-secret-that-is-also-32-bytes!!!");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn tampered_token_rejected() {
+        let user_id = Uuid::new_v4();
+        let token = encode_access_token(user_id, "testuser", TEST_SECRET).unwrap();
+        let tampered = format!("{token}x");
+        let result = decode_access_token(&tampered, TEST_SECRET);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn claims_contain_correct_expiry_window() {
+        let user_id = Uuid::new_v4();
+        let before = Utc::now().timestamp();
+        let token = encode_access_token(user_id, "testuser", TEST_SECRET).unwrap();
+        let claims = decode_access_token(&token, TEST_SECRET).unwrap();
+        let after = Utc::now().timestamp();
+
+        let expected_min = before + ACCESS_TOKEN_DURATION_SECS;
+        let expected_max = after + ACCESS_TOKEN_DURATION_SECS;
+        assert!(claims.exp >= expected_min && claims.exp <= expected_max);
+    }
+
+    #[test]
+    fn refresh_token_is_64_hex_chars() {
+        let token = generate_refresh_token();
+        assert_eq!(token.len(), 64);
+        assert!(token.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn refresh_tokens_are_unique() {
+        let t1 = generate_refresh_token();
+        let t2 = generate_refresh_token();
+        assert_ne!(t1, t2);
+    }
+
+    #[test]
+    fn refresh_token_hash_is_deterministic() {
+        let token = generate_refresh_token();
+        let h1 = hash_refresh_token(&token);
+        let h2 = hash_refresh_token(&token);
+        assert_eq!(h1, h2);
+    }
+
+    #[test]
+    fn different_refresh_tokens_produce_different_hashes() {
+        let t1 = generate_refresh_token();
+        let t2 = generate_refresh_token();
+        assert_ne!(hash_refresh_token(&t1), hash_refresh_token(&t2));
+    }
+}

--- a/backend/src/auth/mod.rs
+++ b/backend/src/auth/mod.rs
@@ -1,0 +1,2 @@
+pub mod jwt;
+pub mod password;

--- a/backend/src/auth/password.rs
+++ b/backend/src/auth/password.rs
@@ -1,0 +1,59 @@
+use argon2::{
+    password_hash::{rand_core::OsRng, PasswordHash, PasswordHasher, PasswordVerifier, SaltString},
+    Argon2,
+};
+
+use crate::errors::AppError;
+
+pub fn hash_password(plain: &str) -> Result<String, AppError> {
+    let salt = SaltString::generate(&mut OsRng);
+    let argon2 = Argon2::default();
+    argon2
+        .hash_password(plain.as_bytes(), &salt)
+        .map(|h| h.to_string())
+        .map_err(|e| AppError::Internal(format!("password hashing failed: {e}")))
+}
+
+pub fn verify_password(plain: &str, hash: &str) -> Result<bool, AppError> {
+    let parsed = PasswordHash::new(hash)
+        .map_err(|e| AppError::Internal(format!("invalid password hash format: {e}")))?;
+    Ok(Argon2::default()
+        .verify_password(plain.as_bytes(), &parsed)
+        .is_ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hash_and_verify_roundtrip() {
+        let hash = hash_password("hunter2").unwrap();
+        assert!(verify_password("hunter2", &hash).unwrap());
+    }
+
+    #[test]
+    fn wrong_password_fails() {
+        let hash = hash_password("correct-password").unwrap();
+        assert!(!verify_password("wrong-password", &hash).unwrap());
+    }
+
+    #[test]
+    fn different_calls_produce_different_hashes() {
+        let h1 = hash_password("same-password").unwrap();
+        let h2 = hash_password("same-password").unwrap();
+        assert_ne!(h1, h2);
+    }
+
+    #[test]
+    fn hash_contains_argon2id_identifier() {
+        let hash = hash_password("test").unwrap();
+        assert!(hash.starts_with("$argon2id$"));
+    }
+
+    #[test]
+    fn invalid_hash_format_returns_error() {
+        let result = verify_password("test", "not-a-valid-hash");
+        assert!(result.is_err());
+    }
+}

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -7,9 +7,10 @@ use tower_http::cors::{Any, CorsLayer};
 use tracing::info;
 use tracing_subscriber::EnvFilter;
 
+pub mod auth;
 mod config;
 mod db;
-mod errors;
+pub mod errors;
 mod models;
 
 use config::Config;


### PR DESCRIPTION
## Summary
- Add `auth/password.rs` with argon2id `hash_password` and `verify_password` (OWASP-compliant defaults)
- Add `auth/jwt.rs` with JWT `encode_access_token`/`decode_access_token` (HS256, 15-min expiry), `generate_refresh_token` (32 random bytes → hex), and `hash_refresh_token` (SHA-256)
- Add `argon2`, `jsonwebtoken`, `rand`, `sha2`, `hex` dependencies

## Test plan
- [x] Password hash round-trip (hash then verify)
- [x] Wrong password fails verification
- [x] Different hashes produced for same password (unique salts)
- [x] Hash output contains argon2id identifier
- [x] Invalid hash format returns error
- [x] JWT encodes and decodes with correct claims
- [x] Expired JWTs rejected
- [x] Tampered JWTs rejected
- [x] Wrong secret rejected
- [x] Correct 15-min expiry window
- [x] Refresh tokens are 64 hex chars, unique, and hash deterministically
- [x] `cargo clippy -- -D warnings` passes clean

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)