### PR TITLE
Add auth endpoints: register, login, refresh, logout (issue #4)

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -132,6 +132,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-extra"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c794b30c904f0a1c2fb7740f7df7f7972dfaa14ef6f57cb6178dc63e5dca2f04"
+dependencies = [
+ "axum",
+ "axum-core",
+ "bytes",
+ "cookie",
+ "fastrand",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "multer",
+ "pin-project-lite",
+ "serde",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -237,6 +261,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -248,6 +283,7 @@ version = "0.1.0"
 dependencies = [
  "argon2",
  "axum",
+ "axum-extra",
  "chrono",
  "dotenvy",
  "hex",
@@ -259,6 +295,7 @@ dependencies = [
  "sha2",
  "socketioxide",
  "sqlx",
+ "time",
  "tokio",
  "tower-http",
  "tracing",
@@ -380,6 +417,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "engineioxide"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -443,6 +489,12 @@ dependencies = [
  "parking",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-msvc-tools"
@@ -1026,6 +1078,23 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin",
+ "version_check",
 ]
 
 [[package]]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -21,6 +21,8 @@ jsonwebtoken = "9"
 rand = "0.8"
 sha2 = "0.10"
 hex = "0.4"
+axum-extra = { version = "0.9", features = ["cookie"] }
+time = "0.3"
 
 [dev-dependencies]
 http-body-util = "0.1"

--- a/backend/src/auth/handlers.rs
+++ b/backend/src/auth/handlers.rs
@@ -1,0 +1,360 @@
+use crate::auth::jwt::{encode_access_token, generate_refresh_token, hash_refresh_token};
+use crate::auth::password::{hash_password, verify_password};
+use crate::errors::AppError;
+use crate::AppState;
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::Json;
+use axum_extra::extract::cookie::{Cookie, CookieJar, SameSite};
+use chrono::{Duration, Utc};
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize)]
+pub struct RegisterRequest {
+    pub username: String,
+    pub email: String,
+    pub password: String,
+}
+
+#[derive(Deserialize)]
+pub struct LoginRequest {
+    pub username_or_email: String,
+    pub password: String,
+}
+
+#[derive(Serialize)]
+pub struct AuthResponse {
+    pub user_id: String,
+    pub username: String,
+}
+
+fn validate_username(username: &str) -> Result<(), AppError> {
+    if username.len() < 3 || username.len() > 32 {
+        return Err(AppError::BadRequest(
+            "Username must be between 3 and 32 characters".into(),
+        ));
+    }
+    if !username
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '_')
+    {
+        return Err(AppError::BadRequest(
+            "Username must contain only alphanumeric characters and underscores".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_email(email: &str) -> Result<(), AppError> {
+    if email.len() > 254 {
+        return Err(AppError::BadRequest("Email is too long".into()));
+    }
+    let parts: Vec<&str> = email.split('@').collect();
+    if parts.len() != 2 || parts[0].is_empty() || parts[1].is_empty() || !parts[1].contains('.') {
+        return Err(AppError::BadRequest("Invalid email format".into()));
+    }
+    Ok(())
+}
+
+fn validate_password(password: &str) -> Result<(), AppError> {
+    if password.len() < 8 {
+        return Err(AppError::BadRequest(
+            "Password must be at least 8 characters".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn build_access_cookie(token: String) -> Cookie<'static> {
+    Cookie::build(("access_token", token))
+        .http_only(true)
+        .secure(true)
+        .same_site(SameSite::Strict)
+        .path("/")
+        .max_age(time::Duration::seconds(900))
+        .build()
+}
+
+fn build_refresh_cookie(token: String) -> Cookie<'static> {
+    Cookie::build(("refresh_token", token))
+        .http_only(true)
+        .secure(true)
+        .same_site(SameSite::Strict)
+        .path("/api/auth/refresh")
+        .max_age(time::Duration::seconds(604800))
+        .build()
+}
+
+fn clear_access_cookie() -> Cookie<'static> {
+    Cookie::build(("access_token", ""))
+        .http_only(true)
+        .secure(true)
+        .same_site(SameSite::Strict)
+        .path("/")
+        .max_age(time::Duration::ZERO)
+        .build()
+}
+
+fn clear_refresh_cookie() -> Cookie<'static> {
+    Cookie::build(("refresh_token", ""))
+        .http_only(true)
+        .secure(true)
+        .same_site(SameSite::Strict)
+        .path("/api/auth/refresh")
+        .max_age(time::Duration::ZERO)
+        .build()
+}
+
+pub async fn register(
+    State(state): State<AppState>,
+    Json(body): Json<RegisterRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    validate_username(&body.username)?;
+    validate_email(&body.email)?;
+    validate_password(&body.password)?;
+
+    let password_hash = hash_password(&body.password)?;
+
+    let row = sqlx::query_as::<_, (uuid::Uuid, String)>(
+        "INSERT INTO users (username, email, password_hash) VALUES ($1, $2, $3) RETURNING id, username",
+    )
+    .bind(&body.username)
+    .bind(&body.email)
+    .bind(&password_hash)
+    .fetch_one(&state.db)
+    .await
+    .map_err(|e| match &e {
+        sqlx::Error::Database(db_err) if db_err.constraint().is_some() => {
+            let constraint = db_err.constraint().unwrap();
+            if constraint.contains("username") {
+                AppError::Conflict("Username is already taken".into())
+            } else if constraint.contains("email") {
+                AppError::Conflict("Email is already registered".into())
+            } else {
+                AppError::Internal(e.to_string())
+            }
+        }
+        _ => AppError::Internal(e.to_string()),
+    })?;
+
+    Ok((
+        StatusCode::CREATED,
+        Json(AuthResponse {
+            user_id: row.0.to_string(),
+            username: row.1,
+        }),
+    ))
+}
+
+pub async fn login(
+    State(state): State<AppState>,
+    jar: CookieJar,
+    Json(body): Json<LoginRequest>,
+) -> Result<(CookieJar, Json<AuthResponse>), AppError> {
+    let user = sqlx::query_as::<_, (uuid::Uuid, String, String)>(
+        "SELECT id, username, password_hash FROM users WHERE username = $1 OR email = $1",
+    )
+    .bind(&body.username_or_email)
+    .fetch_optional(&state.db)
+    .await?
+    .ok_or_else(|| AppError::Unauthorized("Invalid credentials".into()))?;
+
+    let (user_id, username, password_hash) = user;
+
+    if !verify_password(&body.password, &password_hash)? {
+        return Err(AppError::Unauthorized("Invalid credentials".into()));
+    }
+
+    let access_token = encode_access_token(user_id, &username, &state.config.jwt_secret)?;
+    let refresh_token = generate_refresh_token();
+    let token_hash = hash_refresh_token(&refresh_token);
+    let expires_at = Utc::now() + Duration::days(7);
+
+    sqlx::query("INSERT INTO refresh_tokens (user_id, token_hash, expires_at) VALUES ($1, $2, $3)")
+        .bind(user_id)
+        .bind(&token_hash)
+        .bind(expires_at)
+        .execute(&state.db)
+        .await?;
+
+    let jar = jar
+        .add(build_access_cookie(access_token))
+        .add(build_refresh_cookie(refresh_token));
+
+    Ok((
+        jar,
+        Json(AuthResponse {
+            user_id: user_id.to_string(),
+            username,
+        }),
+    ))
+}
+
+pub async fn refresh(
+    State(state): State<AppState>,
+    jar: CookieJar,
+) -> Result<(CookieJar, Json<AuthResponse>), AppError> {
+    let refresh_token = jar
+        .get("refresh_token")
+        .map(|c| c.value().to_string())
+        .ok_or_else(|| AppError::Unauthorized("Missing refresh token".into()))?;
+
+    let token_hash = hash_refresh_token(&refresh_token);
+
+    let row = sqlx::query_as::<_, (uuid::Uuid, uuid::Uuid)>(
+        "DELETE FROM refresh_tokens WHERE token_hash = $1 AND expires_at > now() RETURNING id, user_id",
+    )
+    .bind(&token_hash)
+    .fetch_optional(&state.db)
+    .await?
+    .ok_or_else(|| AppError::Unauthorized("Invalid or expired refresh token".into()))?;
+
+    let user_id = row.1;
+
+    let user = sqlx::query_as::<_, (String,)>("SELECT username FROM users WHERE id = $1")
+        .bind(user_id)
+        .fetch_optional(&state.db)
+        .await?
+        .ok_or_else(|| AppError::Unauthorized("User not found".into()))?;
+
+    let username = user.0;
+
+    let new_access_token = encode_access_token(user_id, &username, &state.config.jwt_secret)?;
+    let new_refresh_token = generate_refresh_token();
+    let new_token_hash = hash_refresh_token(&new_refresh_token);
+    let expires_at = Utc::now() + Duration::days(7);
+
+    sqlx::query("INSERT INTO refresh_tokens (user_id, token_hash, expires_at) VALUES ($1, $2, $3)")
+        .bind(user_id)
+        .bind(&new_token_hash)
+        .bind(expires_at)
+        .execute(&state.db)
+        .await?;
+
+    let jar = jar
+        .add(build_access_cookie(new_access_token))
+        .add(build_refresh_cookie(new_refresh_token));
+
+    Ok((
+        jar,
+        Json(AuthResponse {
+            user_id: user_id.to_string(),
+            username,
+        }),
+    ))
+}
+
+pub async fn logout(
+    State(state): State<AppState>,
+    jar: CookieJar,
+) -> Result<(CookieJar, StatusCode), AppError> {
+    if let Some(refresh_token) = jar.get("refresh_token").map(|c| c.value().to_string()) {
+        let token_hash = hash_refresh_token(&refresh_token);
+        sqlx::query("DELETE FROM refresh_tokens WHERE token_hash = $1")
+            .bind(&token_hash)
+            .execute(&state.db)
+            .await?;
+    }
+
+    let jar = jar.add(clear_access_cookie()).add(clear_refresh_cookie());
+
+    Ok((jar, StatusCode::NO_CONTENT))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_username() {
+        assert!(validate_username("alice").is_ok());
+        assert!(validate_username("bob_123").is_ok());
+        assert!(validate_username("a_b").is_ok());
+    }
+
+    #[test]
+    fn username_too_short() {
+        assert!(validate_username("ab").is_err());
+    }
+
+    #[test]
+    fn username_too_long() {
+        let long = "a".repeat(33);
+        assert!(validate_username(&long).is_err());
+    }
+
+    #[test]
+    fn username_invalid_chars() {
+        assert!(validate_username("alice!").is_err());
+        assert!(validate_username("bob smith").is_err());
+        assert!(validate_username("user@name").is_err());
+    }
+
+    #[test]
+    fn valid_email() {
+        assert!(validate_email("user@example.com").is_ok());
+        assert!(validate_email("a@b.co").is_ok());
+    }
+
+    #[test]
+    fn email_missing_at() {
+        assert!(validate_email("userexample.com").is_err());
+    }
+
+    #[test]
+    fn email_missing_dot_in_domain() {
+        assert!(validate_email("user@localhost").is_err());
+    }
+
+    #[test]
+    fn email_empty_parts() {
+        assert!(validate_email("@example.com").is_err());
+        assert!(validate_email("user@").is_err());
+    }
+
+    #[test]
+    fn email_too_long() {
+        let long = format!("{}@example.com", "a".repeat(250));
+        assert!(validate_email(&long).is_err());
+    }
+
+    #[test]
+    fn valid_password() {
+        assert!(validate_password("12345678").is_ok());
+        assert!(validate_password("a-very-long-password-indeed").is_ok());
+    }
+
+    #[test]
+    fn password_too_short() {
+        assert!(validate_password("1234567").is_err());
+    }
+
+    #[test]
+    fn access_cookie_properties() {
+        let cookie = build_access_cookie("tok".into());
+        assert_eq!(cookie.name(), "access_token");
+        assert_eq!(cookie.value(), "tok");
+        assert!(cookie.http_only().unwrap());
+        assert!(cookie.secure().unwrap());
+        assert_eq!(cookie.same_site().unwrap(), SameSite::Strict);
+        assert_eq!(cookie.path().unwrap(), "/");
+        assert_eq!(cookie.max_age().unwrap(), time::Duration::seconds(900));
+    }
+
+    #[test]
+    fn refresh_cookie_properties() {
+        let cookie = build_refresh_cookie("ref".into());
+        assert_eq!(cookie.name(), "refresh_token");
+        assert_eq!(cookie.path().unwrap(), "/api/auth/refresh");
+        assert_eq!(cookie.max_age().unwrap(), time::Duration::seconds(604800));
+    }
+
+    #[test]
+    fn clear_cookies_have_zero_max_age() {
+        let ac = clear_access_cookie();
+        let rc = clear_refresh_cookie();
+        assert_eq!(ac.max_age().unwrap(), time::Duration::ZERO);
+        assert_eq!(rc.max_age().unwrap(), time::Duration::ZERO);
+    }
+}

--- a/backend/src/auth/mod.rs
+++ b/backend/src/auth/mod.rs
@@ -1,2 +1,3 @@
+pub mod handlers;
 pub mod jwt;
 pub mod password;

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,4 +1,4 @@
-use axum::{routing::get, Json, Router};
+use axum::{routing::get, routing::post, Json, Router};
 use serde_json::{json, Value};
 use socketioxide::{extract::SocketRef, SocketIo};
 use sqlx::PgPool;
@@ -71,6 +71,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let app = Router::new()
         .route("/health", get(health))
+        .route("/api/auth/register", post(auth::handlers::register))
+        .route("/api/auth/login", post(auth::handlers::login))
+        .route("/api/auth/refresh", post(auth::handlers::refresh))
+        .route("/api/auth/logout", post(auth::handlers::logout))
         .with_state(state)
         .layer(socket_layer)
         .layer(cors);


### PR DESCRIPTION
## Summary
- Add `POST /api/auth/register` — input validation (username 3-32 alphanum/underscore, email format, password ≥8), argon2id hash, 409 on duplicate username/email
- Add `POST /api/auth/login` — lookup by username or email, verify password, set HttpOnly access + refresh cookies, generic "Invalid credentials" error
- Add `POST /api/auth/refresh` — rotate refresh token (delete old, issue new), set new cookie pair
- Add `POST /api/auth/logout` — delete refresh token from DB, clear both cookies, return 204

## Test plan
- [x] Username validation: valid names, too short, too long, invalid chars
- [x] Email validation: valid format, missing @, missing dot, empty parts, too long
- [x] Password validation: valid length, too short
- [x] Access cookie: HttpOnly, Secure, SameSite=Strict, Path=/, Max-Age=900
- [x] Refresh cookie: path-scoped to /api/auth/refresh, Max-Age=604800
- [x] Clear cookies have zero max-age
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] All 41 tests pass

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)