### PR TITLE
Add auth middleware: AuthUser extractor + CSRF origin validation (issue #5)

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -282,6 +282,7 @@ name = "core-war-backend"
 version = "0.1.0"
 dependencies = [
  "argon2",
+ "async-trait",
  "axum",
  "axum-extra",
  "chrono",
@@ -297,6 +298,7 @@ dependencies = [
  "sqlx",
  "time",
  "tokio",
+ "tower",
  "tower-http",
  "tracing",
  "tracing-subscriber",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -23,6 +23,8 @@ sha2 = "0.10"
 hex = "0.4"
 axum-extra = { version = "0.9", features = ["cookie"] }
 time = "0.3"
+async-trait = "0.1"
 
 [dev-dependencies]
 http-body-util = "0.1"
+tower = { version = "0.5", features = ["util"] }

--- a/backend/src/auth/middleware.rs
+++ b/backend/src/auth/middleware.rs
@@ -1,0 +1,342 @@
+use async_trait::async_trait;
+use axum::extract::FromRequestParts;
+use axum::http::request::Parts;
+use axum::http::{HeaderMap, Method, StatusCode};
+use axum::middleware::Next;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use axum_extra::extract::cookie::CookieJar;
+use serde_json::json;
+use uuid::Uuid;
+
+use crate::auth::jwt::decode_access_token;
+use crate::AppState;
+
+#[derive(Debug, Clone)]
+pub struct AuthUser {
+    pub user_id: Uuid,
+    pub username: String,
+}
+
+#[async_trait]
+impl FromRequestParts<AppState> for AuthUser {
+    type Rejection = Response;
+
+    async fn from_request_parts(
+        parts: &mut Parts,
+        state: &AppState,
+    ) -> Result<Self, Self::Rejection> {
+        let jar = CookieJar::from_headers(&parts.headers);
+        let token = jar
+            .get("access_token")
+            .map(|c| c.value().to_string())
+            .ok_or_else(|| unauthorized("Missing access token"))?;
+
+        let claims = decode_access_token(&token, &state.config.jwt_secret)
+            .map_err(|_| unauthorized("Invalid or expired token"))?;
+
+        let user_id = claims
+            .sub
+            .parse::<Uuid>()
+            .map_err(|_| unauthorized("Invalid token claims"))?;
+
+        Ok(AuthUser {
+            user_id,
+            username: claims.username,
+        })
+    }
+}
+
+pub struct OptionalAuthUser(pub Option<AuthUser>);
+
+#[async_trait]
+impl FromRequestParts<AppState> for OptionalAuthUser {
+    type Rejection = Response;
+
+    async fn from_request_parts(
+        parts: &mut Parts,
+        state: &AppState,
+    ) -> Result<Self, Self::Rejection> {
+        Ok(OptionalAuthUser(
+            AuthUser::from_request_parts(parts, state).await.ok(),
+        ))
+    }
+}
+
+fn unauthorized(msg: &str) -> Response {
+    (StatusCode::UNAUTHORIZED, Json(json!({ "error": msg }))).into_response()
+}
+
+pub async fn csrf_middleware(
+    headers: HeaderMap,
+    state: axum::extract::State<AppState>,
+    request: axum::extract::Request,
+    next: Next,
+) -> Response {
+    let method = request.method().clone();
+
+    if matches!(method, Method::GET | Method::HEAD | Method::OPTIONS) {
+        return next.run(request).await;
+    }
+
+    let allowed_origin = &state.config.frontend_url;
+
+    let origin_header = headers.get("origin").and_then(|v| v.to_str().ok());
+
+    let referer_origin = headers
+        .get("referer")
+        .and_then(|v| v.to_str().ok())
+        .map(|r| {
+            let parts: Vec<&str> = r.splitn(4, '/').collect();
+            if parts.len() >= 3 {
+                format!("{}//{}", parts[0], parts[2])
+            } else {
+                r.to_string()
+            }
+        });
+
+    let origin = origin_header.map(|s| s.to_string()).or(referer_origin);
+
+    match origin.as_deref() {
+        Some(o) if o == allowed_origin => next.run(request).await,
+        Some(_) => (
+            StatusCode::FORBIDDEN,
+            Json(json!({ "error": "Origin not allowed" })),
+        )
+            .into_response(),
+        None => (
+            StatusCode::FORBIDDEN,
+            Json(json!({ "error": "Missing origin" })),
+        )
+            .into_response(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::Request;
+    use axum::middleware;
+    use axum::routing::{get, post};
+    use axum::Router;
+    use http_body_util::BodyExt;
+    use serde_json::Value;
+    use sqlx::PgPool;
+    use tower::ServiceExt;
+
+    use crate::auth::jwt::encode_access_token;
+
+    fn test_state() -> AppState {
+        let pool = PgPool::connect_lazy("postgresql://localhost/fake").unwrap();
+        AppState {
+            db: pool,
+            config: crate::AppConfig {
+                frontend_url: "http://localhost:5173".into(),
+                jwt_secret: b"this-is-a-test-secret-at-least-32-bytes!".to_vec(),
+            },
+        }
+    }
+
+    fn app_with_csrf() -> Router {
+        let state = test_state();
+        Router::new()
+            .route("/test", post(|| async { "ok" }))
+            .route("/test", get(|| async { "ok" }))
+            .layer(middleware::from_fn_with_state(
+                state.clone(),
+                csrf_middleware,
+            ))
+            .with_state(state)
+    }
+
+    fn app_with_auth() -> Router {
+        let state = test_state();
+        Router::new()
+            .route(
+                "/protected",
+                get(|user: AuthUser| async move { format!("hello {}", user.username) }),
+            )
+            .route(
+                "/optional",
+                get(|OptionalAuthUser(user): OptionalAuthUser| async move {
+                    match user {
+                        Some(u) => format!("hello {}", u.username),
+                        None => "anonymous".into(),
+                    }
+                }),
+            )
+            .with_state(state)
+    }
+
+    async fn response_status_and_body(response: Response) -> (StatusCode, Value) {
+        let status = response.status();
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let json: Value = serde_json::from_slice(&body).unwrap_or_else(|_| json!(body.to_vec()));
+        (status, json)
+    }
+
+    // --- CSRF tests ---
+
+    #[tokio::test]
+    async fn csrf_allows_get_without_origin() {
+        let app = app_with_csrf();
+        let req = Request::get("/test").body(Body::empty()).unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn csrf_allows_post_with_correct_origin() {
+        let app = app_with_csrf();
+        let req = Request::post("/test")
+            .header("origin", "http://localhost:5173")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn csrf_rejects_post_with_wrong_origin() {
+        let app = app_with_csrf();
+        let req = Request::post("/test")
+            .header("origin", "http://evil.com")
+            .body(Body::empty())
+            .unwrap();
+        let (status, json) = response_status_and_body(app.oneshot(req).await.unwrap()).await;
+        assert_eq!(status, StatusCode::FORBIDDEN);
+        assert_eq!(json["error"], "Origin not allowed");
+    }
+
+    #[tokio::test]
+    async fn csrf_rejects_post_without_origin() {
+        let app = app_with_csrf();
+        let req = Request::post("/test").body(Body::empty()).unwrap();
+        let (status, json) = response_status_and_body(app.oneshot(req).await.unwrap()).await;
+        assert_eq!(status, StatusCode::FORBIDDEN);
+        assert_eq!(json["error"], "Missing origin");
+    }
+
+    #[tokio::test]
+    async fn csrf_allows_head_without_origin() {
+        let app = app_with_csrf();
+        let req = Request::head("/test").body(Body::empty()).unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn csrf_does_not_block_options_without_origin() {
+        let app = app_with_csrf();
+        let req = Request::options("/test").body(Body::empty()).unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        // 405 comes from the router (no OPTIONS handler), not 403 from CSRF
+        assert_ne!(resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn csrf_accepts_referer_as_fallback() {
+        let app = app_with_csrf();
+        let req = Request::post("/test")
+            .header("referer", "http://localhost:5173/some/page")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn csrf_rejects_wrong_referer() {
+        let app = app_with_csrf();
+        let req = Request::post("/test")
+            .header("referer", "http://evil.com/attack")
+            .body(Body::empty())
+            .unwrap();
+        let (status, json) = response_status_and_body(app.oneshot(req).await.unwrap()).await;
+        assert_eq!(status, StatusCode::FORBIDDEN);
+        assert_eq!(json["error"], "Origin not allowed");
+    }
+
+    // --- AuthUser extractor tests ---
+
+    #[tokio::test]
+    async fn auth_rejects_missing_cookie() {
+        let app = app_with_auth();
+        let req = Request::get("/protected").body(Body::empty()).unwrap();
+        let (status, json) = response_status_and_body(app.oneshot(req).await.unwrap()).await;
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+        assert_eq!(json["error"], "Missing access token");
+    }
+
+    #[tokio::test]
+    async fn auth_rejects_invalid_token() {
+        let app = app_with_auth();
+        let req = Request::get("/protected")
+            .header("cookie", "access_token=garbage")
+            .body(Body::empty())
+            .unwrap();
+        let (status, json) = response_status_and_body(app.oneshot(req).await.unwrap()).await;
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+        assert_eq!(json["error"], "Invalid or expired token");
+    }
+
+    #[tokio::test]
+    async fn auth_extracts_valid_user() {
+        let state = test_state();
+        let user_id = Uuid::new_v4();
+        let token = encode_access_token(user_id, "alice", &state.config.jwt_secret).unwrap();
+
+        let app = app_with_auth();
+        let req = Request::get("/protected")
+            .header("cookie", format!("access_token={token}"))
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        assert_eq!(std::str::from_utf8(&body).unwrap(), "hello alice");
+    }
+
+    // --- OptionalAuthUser tests ---
+
+    #[tokio::test]
+    async fn optional_auth_returns_none_without_cookie() {
+        let app = app_with_auth();
+        let req = Request::get("/optional").body(Body::empty()).unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        assert_eq!(std::str::from_utf8(&body).unwrap(), "anonymous");
+    }
+
+    #[tokio::test]
+    async fn optional_auth_returns_user_with_valid_cookie() {
+        let state = test_state();
+        let user_id = Uuid::new_v4();
+        let token = encode_access_token(user_id, "bob", &state.config.jwt_secret).unwrap();
+
+        let app = app_with_auth();
+        let req = Request::get("/optional")
+            .header("cookie", format!("access_token={token}"))
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        assert_eq!(std::str::from_utf8(&body).unwrap(), "hello bob");
+    }
+
+    #[tokio::test]
+    async fn optional_auth_returns_none_with_invalid_cookie() {
+        let app = app_with_auth();
+        let req = Request::get("/optional")
+            .header("cookie", "access_token=bad-token")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        assert_eq!(std::str::from_utf8(&body).unwrap(), "anonymous");
+    }
+}

--- a/backend/src/auth/mod.rs
+++ b/backend/src/auth/mod.rs
@@ -1,3 +1,4 @@
 pub mod handlers;
 pub mod jwt;
+pub mod middleware;
 pub mod password;

--- a/backend/src/errors.rs
+++ b/backend/src/errors.rs
@@ -8,6 +8,7 @@ use serde_json::json;
 pub enum AppError {
     BadRequest(String),
     Unauthorized(String),
+    Forbidden(String),
     Conflict(String),
     Internal(String),
 }
@@ -17,6 +18,7 @@ impl IntoResponse for AppError {
         let (status, message) = match self {
             Self::BadRequest(msg) => (StatusCode::BAD_REQUEST, msg),
             Self::Unauthorized(msg) => (StatusCode::UNAUTHORIZED, msg),
+            Self::Forbidden(msg) => (StatusCode::FORBIDDEN, msg),
             Self::Conflict(msg) => (StatusCode::CONFLICT, msg),
             Self::Internal(msg) => {
                 tracing::error!("internal error: {msg}");
@@ -65,6 +67,13 @@ mod tests {
         let (status, json) = response_parts(AppError::Unauthorized("bad credentials".into())).await;
         assert_eq!(status, StatusCode::UNAUTHORIZED);
         assert_eq!(json["error"], "bad credentials");
+    }
+
+    #[tokio::test]
+    async fn forbidden_returns_403() {
+        let (status, json) = response_parts(AppError::Forbidden("origin not allowed".into())).await;
+        assert_eq!(status, StatusCode::FORBIDDEN);
+        assert_eq!(json["error"], "origin not allowed");
     }
 
     #[tokio::test]

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,4 +1,4 @@
-use axum::{routing::get, routing::post, Json, Router};
+use axum::{middleware, routing::get, routing::post, Json, Router};
 use serde_json::{json, Value};
 use socketioxide::{extract::SocketRef, SocketIo};
 use sqlx::PgPool;
@@ -75,6 +75,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .route("/api/auth/login", post(auth::handlers::login))
         .route("/api/auth/refresh", post(auth::handlers::refresh))
         .route("/api/auth/logout", post(auth::handlers::logout))
+        .layer(middleware::from_fn_with_state(
+            state.clone(),
+            auth::middleware::csrf_middleware,
+        ))
         .with_state(state)
         .layer(socket_layer)
         .layer(cors);


### PR DESCRIPTION
## Summary
- Add `AuthUser` axum extractor — reads `access_token` cookie, decodes JWT, yields `user_id` + `username`. Returns 401 on missing/expired/invalid tokens
- Add `OptionalAuthUser` extractor — wraps `AuthUser` in `Option` for endpoints that serve both authenticated and anonymous users
- Add CSRF middleware layer — validates `Origin` (or `Referer` fallback) header against `FRONTEND_URL` on all state-changing requests (POST/PUT/DELETE/PATCH), bypasses GET/HEAD/OPTIONS
- Add `Forbidden(403)` variant to `AppError`
- Wire CSRF middleware into the router

## Test plan
- [x] Protected route returns 401 when no cookie present
- [x] Protected route returns 401 with invalid/expired JWT
- [x] Protected route extracts user_id and username from valid JWT
- [x] `OptionalAuthUser` returns `None` for unauthenticated requests
- [x] `OptionalAuthUser` returns `None` for invalid cookies (not 401)
- [x] `OptionalAuthUser` returns user for valid cookies
- [x] CSRF allows GET/HEAD without Origin header
- [x] CSRF allows POST with correct Origin
- [x] CSRF rejects POST with wrong Origin (403)
- [x] CSRF rejects POST without Origin (403)
- [x] CSRF does not block OPTIONS (passes through to router)
- [x] CSRF accepts Referer header as fallback
- [x] CSRF rejects wrong Referer
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] All 56 tests pass

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)