### PR TITLE
Add Socket.IO auth: handshake validation + reauthentication (issue #6)

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 axum = "0.7"
 tokio = { version = "1", features = ["full"] }
-socketioxide = "0.15"
+socketioxide = { version = "0.15", features = ["extensions"] }
 tower-http = { version = "0.5", features = ["cors"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/backend/src/auth/mod.rs
+++ b/backend/src/auth/mod.rs
@@ -2,3 +2,4 @@ pub mod handlers;
 pub mod jwt;
 pub mod middleware;
 pub mod password;
+pub mod socket;

--- a/backend/src/auth/socket.rs
+++ b/backend/src/auth/socket.rs
@@ -1,0 +1,138 @@
+use axum_extra::extract::cookie::CookieJar;
+use serde::Serialize;
+use socketioxide::extract::SocketRef;
+use tracing::info;
+use uuid::Uuid;
+
+use crate::auth::jwt::decode_access_token;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SocketAuthUser {
+    pub user_id: Uuid,
+    pub username: String,
+}
+
+pub fn authenticate_socket(socket: &SocketRef, jwt_secret: &[u8]) -> Option<SocketAuthUser> {
+    let jar = CookieJar::from_headers(&socket.req_parts().headers);
+    let token = jar.get("access_token")?.value().to_string();
+    let claims = decode_access_token(&token, jwt_secret).ok()?;
+    let user_id = claims.sub.parse::<Uuid>().ok()?;
+    Some(SocketAuthUser {
+        user_id,
+        username: claims.username,
+    })
+}
+
+pub fn store_auth(socket: &SocketRef, user: Option<SocketAuthUser>) {
+    if let Some(u) = user {
+        socket.extensions.insert(u);
+    }
+}
+
+pub fn get_auth(socket: &SocketRef) -> Option<SocketAuthUser> {
+    socket.extensions.get::<SocketAuthUser>()
+}
+
+pub fn require_auth(socket: &SocketRef) -> Option<SocketAuthUser> {
+    let user = get_auth(socket);
+    if user.is_none() {
+        let _ = socket.emit(
+            "auth_error",
+            &serde_json::json!({"error": "Authentication required"}),
+        );
+    }
+    user
+}
+
+pub fn check_token_expiry(socket: &SocketRef, jwt_secret: &[u8]) {
+    let jar = CookieJar::from_headers(&socket.req_parts().headers);
+    let is_valid = jar
+        .get("access_token")
+        .map(|c| decode_access_token(c.value(), jwt_secret).is_ok())
+        .unwrap_or(false);
+
+    if !is_valid && get_auth(socket).is_some() {
+        let _ = socket.emit(
+            "auth_expired",
+            &serde_json::json!({"message": "Access token expired, please refresh"}),
+        );
+    }
+}
+
+pub fn on_connect(socket: SocketRef, jwt_secret: Vec<u8>) {
+    let user = authenticate_socket(&socket, &jwt_secret);
+
+    match &user {
+        Some(u) => info!(
+            "client connected: {} (user: {}, id: {})",
+            socket.id, u.username, u.user_id
+        ),
+        None => info!("client connected: {} (anonymous)", socket.id),
+    }
+
+    store_auth(&socket, user);
+
+    let secret = jwt_secret.clone();
+    socket.on("reauthenticate", move |socket: SocketRef| {
+        let new_user = authenticate_socket(&socket, &secret);
+        match &new_user {
+            Some(u) => {
+                info!(
+                    "socket {} reauthenticated as {} ({})",
+                    socket.id, u.username, u.user_id
+                );
+                store_auth(&socket, Some(u.clone()));
+                let _ = socket.emit(
+                    "auth_refreshed",
+                    &serde_json::json!({"user_id": u.user_id.to_string(), "username": &u.username}),
+                );
+            }
+            None => {
+                let _ = socket.emit(
+                    "auth_error",
+                    &serde_json::json!({"error": "Reauthentication failed — invalid or missing token"}),
+                );
+            }
+        }
+    });
+
+    socket.on_disconnect(|socket: SocketRef| {
+        let user = get_auth(&socket);
+        match user {
+            Some(u) => info!(
+                "client disconnected: {} (user: {}, id: {})",
+                socket.id, u.username, u.user_id
+            ),
+            None => info!("client disconnected: {} (anonymous)", socket.id),
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn socket_auth_user_is_clone_and_debug() {
+        let user = SocketAuthUser {
+            user_id: Uuid::new_v4(),
+            username: "testuser".into(),
+        };
+        let cloned = user.clone();
+        assert_eq!(user.user_id, cloned.user_id);
+        assert_eq!(user.username, cloned.username);
+        let debug = format!("{:?}", user);
+        assert!(debug.contains("testuser"));
+    }
+
+    #[test]
+    fn socket_auth_user_serializes() {
+        let user = SocketAuthUser {
+            user_id: Uuid::new_v4(),
+            username: "alice".into(),
+        };
+        let json = serde_json::to_value(&user).unwrap();
+        assert_eq!(json["username"], "alice");
+        assert!(json["user_id"].is_string());
+    }
+}

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -31,14 +31,6 @@ async fn health() -> Json<Value> {
     Json(json!({ "status": "ok" }))
 }
 
-fn on_connect(socket: SocketRef) {
-    info!("client connected: {}", socket.id);
-
-    socket.on_disconnect(|socket: SocketRef| {
-        info!("client disconnected: {}", socket.id);
-    });
-}
-
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     dotenvy::dotenv().ok();
@@ -61,8 +53,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         },
     };
 
+    let jwt_secret_for_socket = state.config.jwt_secret.clone();
     let (socket_layer, io) = SocketIo::new_layer();
-    io.ns("/", on_connect);
+    io.ns("/", move |socket: SocketRef| {
+        auth::socket::on_connect(socket, jwt_secret_for_socket.clone());
+    });
 
     let cors = CorsLayer::new()
         .allow_origin(config.frontend_url.parse::<axum::http::HeaderValue>()?)


### PR DESCRIPTION
## Summary
- Authenticate Socket.IO connections via `access_token` cookie during the HTTP upgrade handshake
- Store `SocketAuthUser { user_id, username }` in socket extensions for identity lookup
- Allow anonymous connections — gate state-changing events behind `require_auth()` helper
- Add `reauthenticate` event: client refreshes tokens via HTTP, then emits this to update socket identity without reconnecting
- Add `check_token_expiry()` helper that emits `auth_expired` when the server detects a stale token
- Enable socketioxide `extensions` feature for typed socket state

## Test plan
- [x] `SocketAuthUser` is Clone, Debug, and Serialize
- [x] `SocketAuthUser` serializes to JSON with correct fields
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] All 58 tests pass

**Note:** Full integration tests for Socket.IO auth (handshake with cookies, reauthenticate flow, auth_expired emission) require a running Socket.IO server and client — tracked in #26.

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)