### PR TITLE
Add rate limiting on auth endpoints (issue #7)

### DIFF
--- a/backend/src/auth/middleware.rs
+++ b/backend/src/auth/middleware.rs
@@ -134,6 +134,7 @@ mod tests {
             config: crate::AppConfig {
                 frontend_url: "http://localhost:5173".into(),
                 jwt_secret: b"this-is-a-test-secret-at-least-32-bytes!".to_vec(),
+                trusted_proxies: vec![],
             },
         }
     }

--- a/backend/src/auth/mod.rs
+++ b/backend/src/auth/mod.rs
@@ -2,4 +2,5 @@ pub mod handlers;
 pub mod jwt;
 pub mod middleware;
 pub mod password;
+pub mod rate_limit;
 pub mod socket;

--- a/backend/src/auth/rate_limit.rs
+++ b/backend/src/auth/rate_limit.rs
@@ -1,0 +1,329 @@
+use axum::extract::ConnectInfo;
+use axum::http::StatusCode;
+use axum::middleware::Next;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use serde_json::json;
+use std::collections::HashMap;
+use std::net::{IpAddr, SocketAddr};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+#[derive(Clone)]
+pub struct RateLimiter {
+    state: Arc<Mutex<HashMap<IpAddr, Vec<Instant>>>>,
+    max_requests: u32,
+    window: Duration,
+    trusted_proxies: Arc<Vec<IpAddr>>,
+}
+
+impl RateLimiter {
+    pub fn new(max_requests: u32, window: Duration, trusted_proxies: Vec<IpAddr>) -> Self {
+        Self {
+            state: Arc::new(Mutex::new(HashMap::new())),
+            max_requests,
+            window,
+            trusted_proxies: Arc::new(trusted_proxies),
+        }
+    }
+
+    pub fn check(&self, ip: IpAddr) -> Result<(), Duration> {
+        let mut state = self.state.lock().unwrap();
+        let now = Instant::now();
+        let cutoff = now - self.window;
+
+        let timestamps = state.entry(ip).or_default();
+        timestamps.retain(|t| *t > cutoff);
+
+        if timestamps.len() >= self.max_requests as usize {
+            let oldest = timestamps[0];
+            let retry_after = self.window - (now - oldest);
+            return Err(retry_after);
+        }
+
+        timestamps.push(now);
+        Ok(())
+    }
+}
+
+fn extract_ip(
+    connect_info: Option<&ConnectInfo<SocketAddr>>,
+    headers: &axum::http::HeaderMap,
+    trusted_proxies: &[IpAddr],
+) -> IpAddr {
+    let direct_ip = connect_info.map(|ci| ci.0.ip());
+
+    let is_trusted = direct_ip
+        .map(|ip| trusted_proxies.contains(&ip))
+        .unwrap_or(false);
+
+    if is_trusted {
+        if let Some(forwarded_ip) = headers
+            .get("x-forwarded-for")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.split(',').next())
+            .and_then(|s| s.trim().parse::<IpAddr>().ok())
+        {
+            return forwarded_ip;
+        }
+    }
+
+    direct_ip.unwrap_or(IpAddr::from([127, 0, 0, 1]))
+}
+
+pub fn login_limiter(trusted_proxies: Vec<IpAddr>) -> RateLimiter {
+    RateLimiter::new(5, Duration::from_secs(15 * 60), trusted_proxies)
+}
+
+pub fn register_limiter(trusted_proxies: Vec<IpAddr>) -> RateLimiter {
+    RateLimiter::new(3, Duration::from_secs(60 * 60), trusted_proxies)
+}
+
+pub fn refresh_limiter(trusted_proxies: Vec<IpAddr>) -> RateLimiter {
+    RateLimiter::new(10, Duration::from_secs(15 * 60), trusted_proxies)
+}
+
+pub async fn rate_limit_middleware(
+    connect_info: Option<ConnectInfo<SocketAddr>>,
+    axum::extract::State(limiter): axum::extract::State<RateLimiter>,
+    request: axum::extract::Request,
+    next: Next,
+) -> Response {
+    let ip = extract_ip(
+        connect_info.as_ref(),
+        request.headers(),
+        &limiter.trusted_proxies,
+    );
+
+    match limiter.check(ip) {
+        Ok(()) => next.run(request).await,
+        Err(retry_after) => {
+            let secs = retry_after.as_secs() + 1;
+            (
+                StatusCode::TOO_MANY_REQUESTS,
+                [(axum::http::header::RETRY_AFTER, secs.to_string())],
+                Json(json!({"error": format!("Too many requests. Try again in {secs} seconds.")})),
+            )
+                .into_response()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::Request;
+    use axum::routing::post;
+    use axum::Router;
+    use http_body_util::BodyExt;
+    use serde_json::Value;
+    use tower::ServiceExt;
+
+    fn test_limiter(max: u32, window_secs: u64) -> RateLimiter {
+        RateLimiter::new(max, Duration::from_secs(window_secs), vec![])
+    }
+
+    fn app_with_limiter(limiter: RateLimiter) -> Router {
+        Router::new()
+            .route("/test", post(|| async { "ok" }))
+            .layer(axum::middleware::from_fn_with_state(
+                limiter.clone(),
+                rate_limit_middleware,
+            ))
+            .with_state(limiter)
+    }
+
+    async fn response_parts(resp: Response) -> (StatusCode, Value, Option<String>) {
+        let status = resp.status();
+        let retry_after = resp
+            .headers()
+            .get("retry-after")
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.to_string());
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        let json: Value = serde_json::from_slice(&body).unwrap_or(json!(null));
+        (status, json, retry_after)
+    }
+
+    fn post_request() -> Request<Body> {
+        Request::post("/test").body(Body::empty()).unwrap()
+    }
+
+    // --- Sliding window tests ---
+
+    #[tokio::test]
+    async fn allows_requests_within_limit() {
+        let limiter = test_limiter(3, 60);
+        for _ in 0..3 {
+            let app = app_with_limiter(limiter.clone());
+            let resp = app.oneshot(post_request()).await.unwrap();
+            assert_eq!(resp.status(), StatusCode::OK);
+        }
+    }
+
+    #[tokio::test]
+    async fn blocks_after_limit_exceeded() {
+        let limiter = test_limiter(2, 60);
+        for _ in 0..2 {
+            let app = app_with_limiter(limiter.clone());
+            let resp = app.oneshot(post_request()).await.unwrap();
+            assert_eq!(resp.status(), StatusCode::OK);
+        }
+
+        let app = app_with_limiter(limiter.clone());
+        let (status, json, retry_after) =
+            response_parts(app.oneshot(post_request()).await.unwrap()).await;
+        assert_eq!(status, StatusCode::TOO_MANY_REQUESTS);
+        assert!(json["error"]
+            .as_str()
+            .unwrap()
+            .contains("Too many requests"));
+        assert!(retry_after.is_some());
+    }
+
+    #[tokio::test]
+    async fn retry_after_header_present() {
+        let limiter = test_limiter(1, 300);
+
+        let app = app_with_limiter(limiter.clone());
+        app.oneshot(post_request()).await.unwrap();
+
+        let app = app_with_limiter(limiter.clone());
+        let (_, _, retry_after) = response_parts(app.oneshot(post_request()).await.unwrap()).await;
+        let secs: u64 = retry_after.unwrap().parse().unwrap();
+        assert!(secs > 0 && secs <= 301);
+    }
+
+    #[test]
+    fn check_allows_up_to_max() {
+        let limiter = test_limiter(3, 60);
+        let ip = IpAddr::from([1, 2, 3, 4]);
+        assert!(limiter.check(ip).is_ok());
+        assert!(limiter.check(ip).is_ok());
+        assert!(limiter.check(ip).is_ok());
+        assert!(limiter.check(ip).is_err());
+    }
+
+    #[test]
+    fn check_returns_retry_duration() {
+        let limiter = test_limiter(1, 300);
+        let ip = IpAddr::from([5, 6, 7, 8]);
+        assert!(limiter.check(ip).is_ok());
+        let retry = limiter.check(ip).unwrap_err();
+        assert!(retry.as_secs() > 0 && retry.as_secs() <= 300);
+    }
+
+    // --- IP extraction + trust boundary tests ---
+
+    #[test]
+    fn direct_ip_used_when_no_trusted_proxies() {
+        let headers = axum::http::HeaderMap::new();
+        let ci = ConnectInfo(SocketAddr::from(([192, 168, 1, 1], 12345)));
+        let ip = extract_ip(Some(&ci), &headers, &[]);
+        assert_eq!(ip, IpAddr::from([192, 168, 1, 1]));
+    }
+
+    #[test]
+    fn xff_ignored_when_no_trusted_proxies() {
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert("x-forwarded-for", "10.0.0.5".parse().unwrap());
+        let ci = ConnectInfo(SocketAddr::from(([192, 168, 1, 1], 12345)));
+        let ip = extract_ip(Some(&ci), &headers, &[]);
+        assert_eq!(ip, IpAddr::from([192, 168, 1, 1]));
+    }
+
+    #[test]
+    fn xff_ignored_when_direct_ip_not_trusted() {
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert("x-forwarded-for", "10.0.0.5".parse().unwrap());
+        let ci = ConnectInfo(SocketAddr::from(([192, 168, 1, 1], 12345)));
+        let trusted = vec![IpAddr::from([172, 16, 0, 1])];
+        let ip = extract_ip(Some(&ci), &headers, &trusted);
+        assert_eq!(ip, IpAddr::from([192, 168, 1, 1]));
+    }
+
+    #[test]
+    fn xff_used_when_direct_ip_is_trusted() {
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert(
+            "x-forwarded-for",
+            "203.0.113.50, 70.41.3.18".parse().unwrap(),
+        );
+        let ci = ConnectInfo(SocketAddr::from(([172, 16, 0, 1], 12345)));
+        let trusted = vec![IpAddr::from([172, 16, 0, 1])];
+        let ip = extract_ip(Some(&ci), &headers, &trusted);
+        assert_eq!(ip, IpAddr::from([203, 0, 113, 50]));
+    }
+
+    #[test]
+    fn falls_back_to_direct_ip_when_trusted_but_no_xff() {
+        let headers = axum::http::HeaderMap::new();
+        let ci = ConnectInfo(SocketAddr::from(([172, 16, 0, 1], 12345)));
+        let trusted = vec![IpAddr::from([172, 16, 0, 1])];
+        let ip = extract_ip(Some(&ci), &headers, &trusted);
+        assert_eq!(ip, IpAddr::from([172, 16, 0, 1]));
+    }
+
+    #[test]
+    fn defaults_to_localhost_when_no_connect_info() {
+        let headers = axum::http::HeaderMap::new();
+        let ip = extract_ip(None, &headers, &[]);
+        assert_eq!(ip, IpAddr::from([127, 0, 0, 1]));
+    }
+
+    #[test]
+    fn xff_spoofing_blocked_without_trusted_proxy() {
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert("x-forwarded-for", "1.1.1.1".parse().unwrap());
+        let attacker = [66, 77, 88, 99];
+        let ci = ConnectInfo(SocketAddr::from((attacker, 9999)));
+        let ip = extract_ip(Some(&ci), &headers, &[]);
+        assert_eq!(ip, IpAddr::from(attacker));
+    }
+
+    // --- Per-IP isolation (middleware-level) ---
+
+    #[tokio::test]
+    async fn different_ips_tracked_separately_via_connect_info() {
+        let limiter = test_limiter(1, 60);
+
+        let app = app_with_limiter(limiter.clone());
+        let resp = app.oneshot(post_request()).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let app = app_with_limiter(limiter.clone());
+        let resp = app.oneshot(post_request()).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
+    }
+
+    // --- Limiter config tests ---
+
+    #[test]
+    fn login_limiter_config() {
+        let l = login_limiter(vec![]);
+        assert_eq!(l.max_requests, 5);
+        assert_eq!(l.window, Duration::from_secs(15 * 60));
+    }
+
+    #[test]
+    fn register_limiter_config() {
+        let l = register_limiter(vec![]);
+        assert_eq!(l.max_requests, 3);
+        assert_eq!(l.window, Duration::from_secs(60 * 60));
+    }
+
+    #[test]
+    fn refresh_limiter_config() {
+        let l = refresh_limiter(vec![]);
+        assert_eq!(l.max_requests, 10);
+        assert_eq!(l.window, Duration::from_secs(15 * 60));
+    }
+
+    #[test]
+    fn limiter_carries_trusted_proxies() {
+        let proxies = vec![IpAddr::from([10, 0, 0, 1]), IpAddr::from([10, 0, 0, 2])];
+        let l = login_limiter(proxies.clone());
+        assert_eq!(*l.trusted_proxies, proxies);
+    }
+}

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -1,4 +1,5 @@
 use std::env;
+use std::net::IpAddr;
 
 #[derive(Debug)]
 pub struct Config {
@@ -6,6 +7,7 @@ pub struct Config {
     pub frontend_url: String,
     pub port: u16,
     pub jwt_secret: Vec<u8>,
+    pub trusted_proxies: Vec<IpAddr>,
 }
 
 impl Config {
@@ -29,11 +31,20 @@ impl Config {
             return Err(ConfigError::WeakJwtSecret);
         }
 
+        let trusted_proxies = get("TRUSTED_PROXIES")
+            .map(|s| {
+                s.split(',')
+                    .filter_map(|entry| entry.trim().parse::<IpAddr>().ok())
+                    .collect()
+            })
+            .unwrap_or_default();
+
         Ok(Self {
             database_url,
             frontend_url,
             port,
             jwt_secret,
+            trusted_proxies,
         })
     }
 }
@@ -103,6 +114,7 @@ mod tests {
 
         assert_eq!(config.frontend_url, "http://localhost:5173");
         assert_eq!(config.port, 3001);
+        assert!(config.trusted_proxies.is_empty());
     }
 
     #[test]
@@ -148,6 +160,34 @@ mod tests {
         ]);
         let config = Config::from_lookup(lookup).unwrap();
         assert_eq!(config.jwt_secret.len(), 32);
+    }
+
+    #[test]
+    fn trusted_proxies_parsed() {
+        let lookup = make_lookup(&[
+            ("DATABASE_URL", "postgresql://localhost/test"),
+            ("JWT_SECRET", "this-is-a-secret-that-is-at-least-32-bytes!"),
+            ("TRUSTED_PROXIES", "10.0.0.1, 172.16.0.1"),
+        ]);
+        let config = Config::from_lookup(lookup).unwrap();
+        assert_eq!(
+            config.trusted_proxies,
+            vec![IpAddr::from([10, 0, 0, 1]), IpAddr::from([172, 16, 0, 1]),]
+        );
+    }
+
+    #[test]
+    fn trusted_proxies_skips_invalid_entries() {
+        let lookup = make_lookup(&[
+            ("DATABASE_URL", "postgresql://localhost/test"),
+            ("JWT_SECRET", "this-is-a-secret-that-is-at-least-32-bytes!"),
+            ("TRUSTED_PROXIES", "10.0.0.1, not-an-ip, 192.168.1.1"),
+        ]);
+        let config = Config::from_lookup(lookup).unwrap();
+        assert_eq!(
+            config.trusted_proxies,
+            vec![IpAddr::from([10, 0, 0, 1]), IpAddr::from([192, 168, 1, 1]),]
+        );
     }
 
     #[test]

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -2,7 +2,7 @@ use axum::{middleware, routing::get, routing::post, Json, Router};
 use serde_json::{json, Value};
 use socketioxide::{extract::SocketRef, SocketIo};
 use sqlx::PgPool;
-use std::net::SocketAddr;
+use std::net::{IpAddr, SocketAddr};
 use tower_http::cors::{Any, CorsLayer};
 use tracing::info;
 use tracing_subscriber::EnvFilter;
@@ -25,6 +25,7 @@ pub struct AppState {
 pub struct AppConfig {
     pub frontend_url: String,
     pub jwt_secret: Vec<u8>,
+    pub trusted_proxies: Vec<IpAddr>,
 }
 
 async fn health() -> Json<Value> {
@@ -50,6 +51,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         config: AppConfig {
             frontend_url: config.frontend_url.clone(),
             jwt_secret: config.jwt_secret,
+            trusted_proxies: config.trusted_proxies,
         },
     };
 
@@ -64,11 +66,34 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .allow_methods(Any)
         .allow_headers(Any);
 
+    let proxies = state.config.trusted_proxies.clone();
+    let login_limiter = auth::rate_limit::login_limiter(proxies.clone());
+    let register_limiter = auth::rate_limit::register_limiter(proxies.clone());
+    let refresh_limiter = auth::rate_limit::refresh_limiter(proxies);
+
     let app = Router::new()
         .route("/health", get(health))
-        .route("/api/auth/register", post(auth::handlers::register))
-        .route("/api/auth/login", post(auth::handlers::login))
-        .route("/api/auth/refresh", post(auth::handlers::refresh))
+        .route(
+            "/api/auth/register",
+            post(auth::handlers::register).layer(middleware::from_fn_with_state(
+                register_limiter,
+                auth::rate_limit::rate_limit_middleware,
+            )),
+        )
+        .route(
+            "/api/auth/login",
+            post(auth::handlers::login).layer(middleware::from_fn_with_state(
+                login_limiter,
+                auth::rate_limit::rate_limit_middleware,
+            )),
+        )
+        .route(
+            "/api/auth/refresh",
+            post(auth::handlers::refresh).layer(middleware::from_fn_with_state(
+                refresh_limiter,
+                auth::rate_limit::rate_limit_middleware,
+            )),
+        )
         .route("/api/auth/logout", post(auth::handlers::logout))
         .layer(middleware::from_fn_with_state(
             state.clone(),


### PR DESCRIPTION
## Summary
- In-memory sliding-window rate limiter keyed by client IP: login (5 req/15 min), register (3 req/1 hr), refresh (10 req/15 min)
- `TRUSTED_PROXIES` env var (comma-separated IPs) gates X-Forwarded-For trust — XFF is ignored unless the direct connection comes from an allowlisted proxy, preventing IP spoofing
- Returns 429 with `Retry-After` header when limit is exceeded

## Test plan
- [x] 17 unit tests covering sliding window, IP extraction, trust boundary, XFF spoofing prevention, and limiter configs
- [x] 2 config tests for TRUSTED_PROXIES parsing (valid entries, invalid entries skipped)
- [x] All 77 backend tests pass
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` clean

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)