### PR TITLE
Add warrior persistence with CRUD API and frontend auth (issue #31)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,4 +35,4 @@ node_modules/
 dist/
 
 # Playwright MCP runtime artifacts
-.playwright-mcp/
+.playwright-mcp/.claude/worktrees/

--- a/backend/migrations/20260510000001_create_warriors.sql
+++ b/backend/migrations/20260510000001_create_warriors.sql
@@ -1,0 +1,10 @@
+CREATE TABLE warriors (
+    id         UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id    UUID        NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    name       VARCHAR(64) NOT NULL,
+    source     TEXT        NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_warriors_user_id ON warriors(user_id);

--- a/backend/src/auth/handlers.rs
+++ b/backend/src/auth/handlers.rs
@@ -113,6 +113,7 @@ fn clear_refresh_cookie() -> Cookie<'static> {
 
 pub async fn register(
     State(state): State<AppState>,
+    jar: CookieJar,
     Json(body): Json<RegisterRequest>,
 ) -> Result<impl IntoResponse, AppError> {
     let username = body.username.trim();
@@ -146,12 +147,33 @@ pub async fn register(
         _ => AppError::Internal(e.to_string()),
     })?;
 
+    let (user_id, username) = row;
+
+    let access_token = encode_access_token(user_id, &username, &state.config.jwt_secret)?;
+    let refresh_token = generate_refresh_token();
+    let token_hash = hash_refresh_token(&refresh_token);
+    let expires_at = Utc::now() + Duration::days(7);
+
+    sqlx::query("INSERT INTO refresh_tokens (user_id, token_hash, expires_at) VALUES ($1, $2, $3)")
+        .bind(user_id)
+        .bind(&token_hash)
+        .bind(expires_at)
+        .execute(&state.db)
+        .await?;
+
+    let jar = jar
+        .add(build_access_cookie(access_token))
+        .add(build_refresh_cookie(refresh_token));
+
     Ok((
-        StatusCode::CREATED,
-        Json(AuthResponse {
-            user_id: row.0.to_string(),
-            username: row.1,
-        }),
+        jar,
+        (
+            StatusCode::CREATED,
+            Json(AuthResponse {
+                user_id: user_id.to_string(),
+                username,
+            }),
+        ),
     ))
 }
 
@@ -255,6 +277,13 @@ pub async fn refresh(
             username,
         }),
     ))
+}
+
+pub async fn me(user: crate::auth::middleware::AuthUser) -> Json<AuthResponse> {
+    Json(AuthResponse {
+        user_id: user.user_id.to_string(),
+        username: user.username,
+    })
 }
 
 pub async fn logout(

--- a/backend/src/errors.rs
+++ b/backend/src/errors.rs
@@ -9,6 +9,7 @@ pub enum AppError {
     BadRequest(String),
     Unauthorized(String),
     Forbidden(String),
+    NotFound(String),
     Conflict(String),
     Internal(String),
 }
@@ -19,6 +20,7 @@ impl IntoResponse for AppError {
             Self::BadRequest(msg) => (StatusCode::BAD_REQUEST, msg),
             Self::Unauthorized(msg) => (StatusCode::UNAUTHORIZED, msg),
             Self::Forbidden(msg) => (StatusCode::FORBIDDEN, msg),
+            Self::NotFound(msg) => (StatusCode::NOT_FOUND, msg),
             Self::Conflict(msg) => (StatusCode::CONFLICT, msg),
             Self::Internal(msg) => {
                 tracing::error!("internal error: {msg}");
@@ -74,6 +76,13 @@ mod tests {
         let (status, json) = response_parts(AppError::Forbidden("origin not allowed".into())).await;
         assert_eq!(status, StatusCode::FORBIDDEN);
         assert_eq!(json["error"], "origin not allowed");
+    }
+
+    #[tokio::test]
+    async fn not_found_returns_404() {
+        let (status, json) = response_parts(AppError::NotFound("warrior not found".into())).await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        assert_eq!(json["error"], "warrior not found");
     }
 
     #[tokio::test]

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -3,6 +3,7 @@ pub mod config;
 pub mod db;
 pub mod errors;
 mod models;
+pub mod warriors;
 
 use sqlx::PgPool;
 use std::net::IpAddr;

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -43,7 +43,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let cors = CorsLayer::new()
         .allow_origin(config.frontend_url.parse::<axum::http::HeaderValue>()?)
-        .allow_methods([Method::GET, Method::POST, Method::PUT, Method::DELETE, Method::OPTIONS])
+        .allow_methods([
+            Method::GET,
+            Method::POST,
+            Method::PUT,
+            Method::DELETE,
+            Method::OPTIONS,
+        ])
         .allow_headers([header::CONTENT_TYPE])
         .allow_credentials(true);
 

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,6 +1,6 @@
 use axum::http::{header, Method};
 use axum::{middleware, routing::get, routing::post, Json, Router};
-use core_war_backend::{auth, config::Config, db, AppConfig, AppState};
+use core_war_backend::{auth, config::Config, db, warriors, AppConfig, AppState};
 use serde_json::{json, Value};
 use socketioxide::{extract::SocketRef, SocketIo};
 use std::net::SocketAddr;
@@ -43,7 +43,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let cors = CorsLayer::new()
         .allow_origin(config.frontend_url.parse::<axum::http::HeaderValue>()?)
-        .allow_methods([Method::GET, Method::POST, Method::OPTIONS])
+        .allow_methods([Method::GET, Method::POST, Method::PUT, Method::DELETE, Method::OPTIONS])
         .allow_headers([header::CONTENT_TYPE])
         .allow_credentials(true);
 
@@ -76,6 +76,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             )),
         )
         .route("/api/auth/logout", post(auth::handlers::logout))
+        .route("/api/auth/me", get(auth::handlers::me))
+        .route(
+            "/api/warriors",
+            get(warriors::handlers::list).post(warriors::handlers::create),
+        )
+        .route(
+            "/api/warriors/:id",
+            get(warriors::handlers::get)
+                .put(warriors::handlers::update)
+                .delete(warriors::handlers::delete),
+        )
         .layer(middleware::from_fn_with_state(
             state.clone(),
             auth::middleware::csrf_middleware,

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -1,1 +1,2 @@
 pub mod user;
+pub mod warrior;

--- a/backend/src/models/warrior.rs
+++ b/backend/src/models/warrior.rs
@@ -1,0 +1,13 @@
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use uuid::Uuid;
+
+#[derive(Debug, sqlx::FromRow, Serialize)]
+pub struct Warrior {
+    pub id: Uuid,
+    pub user_id: Uuid,
+    pub name: String,
+    pub source: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}

--- a/backend/src/warriors/handlers.rs
+++ b/backend/src/warriors/handlers.rs
@@ -1,0 +1,254 @@
+use crate::auth::middleware::AuthUser;
+use crate::errors::AppError;
+use crate::models::warrior::Warrior;
+use crate::AppState;
+use axum::extract::{Path, Query, State};
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::Json;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+const MAX_NAME_LEN: usize = 64;
+const MAX_SOURCE_LEN: usize = 64_000;
+const MAX_PAGE_SIZE: i64 = 100;
+const DEFAULT_PAGE_SIZE: i64 = 50;
+
+#[derive(Deserialize)]
+pub struct CreateWarriorRequest {
+    pub name: String,
+    pub source: String,
+}
+
+#[derive(Deserialize)]
+pub struct UpdateWarriorRequest {
+    pub name: Option<String>,
+    pub source: Option<String>,
+}
+
+#[derive(Deserialize)]
+pub struct ListQuery {
+    pub page: Option<i64>,
+    pub per_page: Option<i64>,
+}
+
+#[derive(Serialize)]
+pub struct WarriorListResponse {
+    pub warriors: Vec<Warrior>,
+    pub total: i64,
+    pub page: i64,
+    pub per_page: i64,
+}
+
+fn validate_name(name: &str) -> Result<(), AppError> {
+    let name = name.trim();
+    if name.is_empty() {
+        return Err(AppError::BadRequest("Warrior name cannot be empty".into()));
+    }
+    if name.len() > MAX_NAME_LEN {
+        return Err(AppError::BadRequest(format!(
+            "Warrior name must not exceed {MAX_NAME_LEN} characters"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_source(source: &str) -> Result<(), AppError> {
+    if source.trim().is_empty() {
+        return Err(AppError::BadRequest(
+            "Warrior source cannot be empty".into(),
+        ));
+    }
+    if source.len() > MAX_SOURCE_LEN {
+        return Err(AppError::BadRequest(format!(
+            "Warrior source must not exceed {MAX_SOURCE_LEN} characters"
+        )));
+    }
+    Ok(())
+}
+
+pub async fn create(
+    State(state): State<AppState>,
+    user: AuthUser,
+    Json(body): Json<CreateWarriorRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    let name = body.name.trim().to_string();
+    let source = body.source.clone();
+
+    validate_name(&name)?;
+    validate_source(&source)?;
+
+    let warrior = sqlx::query_as::<_, Warrior>(
+        "INSERT INTO warriors (user_id, name, source) VALUES ($1, $2, $3) \
+         RETURNING id, user_id, name, source, created_at, updated_at",
+    )
+    .bind(user.user_id)
+    .bind(&name)
+    .bind(&source)
+    .fetch_one(&state.db)
+    .await?;
+
+    Ok((StatusCode::CREATED, Json(warrior)))
+}
+
+pub async fn get(
+    State(state): State<AppState>,
+    user: AuthUser,
+    Path(id): Path<Uuid>,
+) -> Result<Json<Warrior>, AppError> {
+    let warrior = sqlx::query_as::<_, Warrior>(
+        "SELECT id, user_id, name, source, created_at, updated_at \
+         FROM warriors WHERE id = $1 AND user_id = $2",
+    )
+    .bind(id)
+    .bind(user.user_id)
+    .fetch_optional(&state.db)
+    .await?
+    .ok_or_else(|| AppError::NotFound("Warrior not found".into()))?;
+
+    Ok(Json(warrior))
+}
+
+pub async fn list(
+    State(state): State<AppState>,
+    user: AuthUser,
+    Query(query): Query<ListQuery>,
+) -> Result<Json<WarriorListResponse>, AppError> {
+    let page = query.page.unwrap_or(1).max(1);
+    let per_page = query.per_page.unwrap_or(DEFAULT_PAGE_SIZE).clamp(1, MAX_PAGE_SIZE);
+    let offset = (page - 1) * per_page;
+
+    let total = sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM warriors WHERE user_id = $1")
+        .bind(user.user_id)
+        .fetch_one(&state.db)
+        .await?;
+
+    let warriors = sqlx::query_as::<_, Warrior>(
+        "SELECT id, user_id, name, source, created_at, updated_at \
+         FROM warriors WHERE user_id = $1 \
+         ORDER BY updated_at DESC \
+         LIMIT $2 OFFSET $3",
+    )
+    .bind(user.user_id)
+    .bind(per_page)
+    .bind(offset)
+    .fetch_all(&state.db)
+    .await?;
+
+    Ok(Json(WarriorListResponse {
+        warriors,
+        total,
+        page,
+        per_page,
+    }))
+}
+
+pub async fn update(
+    State(state): State<AppState>,
+    user: AuthUser,
+    Path(id): Path<Uuid>,
+    Json(body): Json<UpdateWarriorRequest>,
+) -> Result<Json<Warrior>, AppError> {
+    let existing = sqlx::query_as::<_, Warrior>(
+        "SELECT id, user_id, name, source, created_at, updated_at \
+         FROM warriors WHERE id = $1 AND user_id = $2",
+    )
+    .bind(id)
+    .bind(user.user_id)
+    .fetch_optional(&state.db)
+    .await?
+    .ok_or_else(|| AppError::NotFound("Warrior not found".into()))?;
+
+    let name = match &body.name {
+        Some(n) => {
+            validate_name(n)?;
+            n.trim().to_string()
+        }
+        None => existing.name,
+    };
+
+    let source = match &body.source {
+        Some(s) => {
+            validate_source(s)?;
+            s.clone()
+        }
+        None => existing.source,
+    };
+
+    let warrior = sqlx::query_as::<_, Warrior>(
+        "UPDATE warriors SET name = $1, source = $2, updated_at = now() \
+         WHERE id = $3 AND user_id = $4 \
+         RETURNING id, user_id, name, source, created_at, updated_at",
+    )
+    .bind(&name)
+    .bind(&source)
+    .bind(id)
+    .bind(user.user_id)
+    .fetch_one(&state.db)
+    .await?;
+
+    Ok(Json(warrior))
+}
+
+pub async fn delete(
+    State(state): State<AppState>,
+    user: AuthUser,
+    Path(id): Path<Uuid>,
+) -> Result<StatusCode, AppError> {
+    let result =
+        sqlx::query("DELETE FROM warriors WHERE id = $1 AND user_id = $2")
+            .bind(id)
+            .bind(user.user_id)
+            .execute(&state.db)
+            .await?;
+
+    if result.rows_affected() == 0 {
+        return Err(AppError::NotFound("Warrior not found".into()));
+    }
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_name() {
+        assert!(validate_name("Imp").is_ok());
+        assert!(validate_name("My Warrior 2").is_ok());
+        assert!(validate_name(&"a".repeat(64)).is_ok());
+    }
+
+    #[test]
+    fn name_empty() {
+        assert!(validate_name("").is_err());
+        assert!(validate_name("   ").is_err());
+    }
+
+    #[test]
+    fn name_too_long() {
+        assert!(validate_name(&"a".repeat(65)).is_err());
+    }
+
+    #[test]
+    fn valid_source() {
+        assert!(validate_source("MOV.I $0, $1").is_ok());
+    }
+
+    #[test]
+    fn source_empty() {
+        assert!(validate_source("").is_err());
+        assert!(validate_source("   ").is_err());
+    }
+
+    #[test]
+    fn source_too_long() {
+        assert!(validate_source(&"a".repeat(64_001)).is_err());
+    }
+
+    #[test]
+    fn source_at_max_length() {
+        assert!(validate_source(&"a".repeat(64_000)).is_ok());
+    }
+}

--- a/backend/src/warriors/handlers.rs
+++ b/backend/src/warriors/handlers.rs
@@ -115,7 +115,10 @@ pub async fn list(
     Query(query): Query<ListQuery>,
 ) -> Result<Json<WarriorListResponse>, AppError> {
     let page = query.page.unwrap_or(1).max(1);
-    let per_page = query.per_page.unwrap_or(DEFAULT_PAGE_SIZE).clamp(1, MAX_PAGE_SIZE);
+    let per_page = query
+        .per_page
+        .unwrap_or(DEFAULT_PAGE_SIZE)
+        .clamp(1, MAX_PAGE_SIZE);
     let offset = (page - 1) * per_page;
 
     let total = sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM warriors WHERE user_id = $1")
@@ -195,12 +198,11 @@ pub async fn delete(
     user: AuthUser,
     Path(id): Path<Uuid>,
 ) -> Result<StatusCode, AppError> {
-    let result =
-        sqlx::query("DELETE FROM warriors WHERE id = $1 AND user_id = $2")
-            .bind(id)
-            .bind(user.user_id)
-            .execute(&state.db)
-            .await?;
+    let result = sqlx::query("DELETE FROM warriors WHERE id = $1 AND user_id = $2")
+        .bind(id)
+        .bind(user.user_id)
+        .execute(&state.db)
+        .await?;
 
     if result.rows_affected() == 0 {
         return Err(AppError::NotFound("Warrior not found".into()));

--- a/backend/src/warriors/mod.rs
+++ b/backend/src/warriors/mod.rs
@@ -1,0 +1,1 @@
+pub mod handlers;

--- a/backend/tests/warriors_integration.rs
+++ b/backend/tests/warriors_integration.rs
@@ -1,0 +1,705 @@
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use axum::routing::{get, post};
+use axum::{middleware, Router};
+use core_war_backend::{auth, warriors, AppConfig, AppState};
+use http_body_util::BodyExt;
+use serde_json::{json, Value};
+use sqlx::PgPool;
+use std::collections::HashMap;
+use tower::ServiceExt;
+
+const FRONTEND_URL: &str = "http://localhost:5173";
+const JWT_SECRET: &[u8] = b"integration-test-secret-that-is-at-least-32-bytes!!";
+
+fn test_state(pool: PgPool) -> AppState {
+    AppState {
+        db: pool,
+        config: AppConfig {
+            frontend_url: FRONTEND_URL.into(),
+            jwt_secret: JWT_SECRET.to_vec(),
+            trusted_proxies: vec![],
+        },
+    }
+}
+
+fn app(pool: PgPool) -> Router {
+    let state = test_state(pool);
+    Router::new()
+        .route("/api/auth/register", post(auth::handlers::register))
+        .route("/api/auth/login", post(auth::handlers::login))
+        .route(
+            "/api/warriors",
+            get(warriors::handlers::list).post(warriors::handlers::create),
+        )
+        .route(
+            "/api/warriors/:id",
+            get(warriors::handlers::get)
+                .put(warriors::handlers::update)
+                .delete(warriors::handlers::delete),
+        )
+        .layer(middleware::from_fn_with_state(
+            state.clone(),
+            auth::middleware::csrf_middleware,
+        ))
+        .with_state(state)
+}
+
+// --- Request builders ---
+
+fn post_json(path: &str, body: &Value) -> Request<Body> {
+    Request::post(path)
+        .header("content-type", "application/json")
+        .header("origin", FRONTEND_URL)
+        .body(Body::from(body.to_string()))
+        .unwrap()
+}
+
+fn post_json_with_cookies(path: &str, body: &Value, cookies: &str) -> Request<Body> {
+    Request::post(path)
+        .header("content-type", "application/json")
+        .header("origin", FRONTEND_URL)
+        .header("cookie", cookies)
+        .body(Body::from(body.to_string()))
+        .unwrap()
+}
+
+fn get_with_cookies(path: &str, cookies: &str) -> Request<Body> {
+    Request::get(path)
+        .header("cookie", cookies)
+        .body(Body::empty())
+        .unwrap()
+}
+
+fn put_json_with_cookies(path: &str, body: &Value, cookies: &str) -> Request<Body> {
+    Request::put(path)
+        .header("content-type", "application/json")
+        .header("origin", FRONTEND_URL)
+        .header("cookie", cookies)
+        .body(Body::from(body.to_string()))
+        .unwrap()
+}
+
+fn delete_with_cookies(path: &str, cookies: &str) -> Request<Body> {
+    Request::delete(path)
+        .header("origin", FRONTEND_URL)
+        .header("cookie", cookies)
+        .body(Body::empty())
+        .unwrap()
+}
+
+// --- Response helpers ---
+
+struct TestResponse {
+    status: StatusCode,
+    json: Value,
+}
+
+fn extract_cookies(headers: &axum::http::HeaderMap) -> HashMap<String, String> {
+    let mut map = HashMap::new();
+    for header in headers.get_all("set-cookie") {
+        if let Ok(s) = header.to_str() {
+            if let Some(cookie_part) = s.split(';').next() {
+                if let Some((name, value)) = cookie_part.split_once('=') {
+                    map.insert(name.trim().to_string(), value.trim().to_string());
+                }
+            }
+        }
+    }
+    map
+}
+
+async fn send(router: Router, req: Request<Body>) -> TestResponse {
+    let resp = router.oneshot(req).await.unwrap();
+    let status = resp.status();
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    let json = serde_json::from_slice(&body).unwrap_or(Value::Null);
+    TestResponse { status, json }
+}
+
+async fn send_with_cookies(router: Router, req: Request<Body>) -> (TestResponse, HashMap<String, String>) {
+    let resp = router.oneshot(req).await.unwrap();
+    let status = resp.status();
+    let cookies = extract_cookies(resp.headers());
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    let json = serde_json::from_slice(&body).unwrap_or(Value::Null);
+    (TestResponse { status, json }, cookies)
+}
+
+// --- Auth helper ---
+
+async fn register_and_login(router: &Router) -> String {
+    send(
+        router.clone(),
+        post_json(
+            "/api/auth/register",
+            &json!({"username": "testuser", "email": "test@example.com", "password": "password123"}),
+        ),
+    )
+    .await;
+
+    let (resp, cookies) = send_with_cookies(
+        router.clone(),
+        post_json(
+            "/api/auth/login",
+            &json!({"username_or_email": "testuser", "password": "password123"}),
+        ),
+    )
+    .await;
+    assert_eq!(resp.status, StatusCode::OK);
+    format!("access_token={}", cookies["access_token"])
+}
+
+async fn register_and_login_as(router: &Router, username: &str, email: &str) -> String {
+    send(
+        router.clone(),
+        post_json(
+            "/api/auth/register",
+            &json!({"username": username, "email": email, "password": "password123"}),
+        ),
+    )
+    .await;
+
+    let (resp, cookies) = send_with_cookies(
+        router.clone(),
+        post_json(
+            "/api/auth/login",
+            &json!({"username_or_email": username, "password": "password123"}),
+        ),
+    )
+    .await;
+    assert_eq!(resp.status, StatusCode::OK);
+    format!("access_token={}", cookies["access_token"])
+}
+
+fn warrior_body(name: &str, source: &str) -> Value {
+    json!({"name": name, "source": source})
+}
+
+// =============================================================================
+// Create tests
+// =============================================================================
+
+#[sqlx::test]
+async fn create_warrior(pool: PgPool) {
+    let router = app(pool);
+    let cookies = register_and_login(&router).await;
+
+    let resp = send(
+        router,
+        post_json_with_cookies(
+            "/api/warriors",
+            &warrior_body("Imp", "MOV.I $0, $1"),
+            &cookies,
+        ),
+    )
+    .await;
+
+    assert_eq!(resp.status, StatusCode::CREATED);
+    assert_eq!(resp.json["name"], "Imp");
+    assert_eq!(resp.json["source"], "MOV.I $0, $1");
+    assert!(resp.json["id"].is_string());
+    assert!(resp.json["user_id"].is_string());
+    assert!(resp.json["created_at"].is_string());
+    assert!(resp.json["updated_at"].is_string());
+}
+
+#[sqlx::test]
+async fn create_warrior_unauthenticated(pool: PgPool) {
+    let router = app(pool);
+    let resp = send(
+        router,
+        post_json(
+            "/api/warriors",
+            &warrior_body("Imp", "MOV.I $0, $1"),
+        ),
+    )
+    .await;
+    assert_eq!(resp.status, StatusCode::UNAUTHORIZED);
+}
+
+#[sqlx::test]
+async fn create_warrior_empty_name(pool: PgPool) {
+    let router = app(pool);
+    let cookies = register_and_login(&router).await;
+
+    let resp = send(
+        router,
+        post_json_with_cookies(
+            "/api/warriors",
+            &warrior_body("", "MOV.I $0, $1"),
+            &cookies,
+        ),
+    )
+    .await;
+    assert_eq!(resp.status, StatusCode::BAD_REQUEST);
+}
+
+#[sqlx::test]
+async fn create_warrior_name_too_long(pool: PgPool) {
+    let router = app(pool);
+    let cookies = register_and_login(&router).await;
+
+    let long_name = "a".repeat(65);
+    let resp = send(
+        router,
+        post_json_with_cookies(
+            "/api/warriors",
+            &warrior_body(&long_name, "MOV.I $0, $1"),
+            &cookies,
+        ),
+    )
+    .await;
+    assert_eq!(resp.status, StatusCode::BAD_REQUEST);
+}
+
+#[sqlx::test]
+async fn create_warrior_empty_source(pool: PgPool) {
+    let router = app(pool);
+    let cookies = register_and_login(&router).await;
+
+    let resp = send(
+        router,
+        post_json_with_cookies("/api/warriors", &warrior_body("Imp", ""), &cookies),
+    )
+    .await;
+    assert_eq!(resp.status, StatusCode::BAD_REQUEST);
+}
+
+#[sqlx::test]
+async fn create_warrior_name_trimmed(pool: PgPool) {
+    let router = app(pool);
+    let cookies = register_and_login(&router).await;
+
+    let resp = send(
+        router,
+        post_json_with_cookies(
+            "/api/warriors",
+            &warrior_body("  Imp  ", "MOV.I $0, $1"),
+            &cookies,
+        ),
+    )
+    .await;
+    assert_eq!(resp.status, StatusCode::CREATED);
+    assert_eq!(resp.json["name"], "Imp");
+}
+
+// =============================================================================
+// Get tests
+// =============================================================================
+
+#[sqlx::test]
+async fn get_warrior(pool: PgPool) {
+    let router = app(pool);
+    let cookies = register_and_login(&router).await;
+
+    let create_resp = send(
+        router.clone(),
+        post_json_with_cookies(
+            "/api/warriors",
+            &warrior_body("Imp", "MOV.I $0, $1"),
+            &cookies,
+        ),
+    )
+    .await;
+    let id = create_resp.json["id"].as_str().unwrap();
+
+    let resp = send(
+        router,
+        get_with_cookies(&format!("/api/warriors/{id}"), &cookies),
+    )
+    .await;
+    assert_eq!(resp.status, StatusCode::OK);
+    assert_eq!(resp.json["name"], "Imp");
+    assert_eq!(resp.json["source"], "MOV.I $0, $1");
+}
+
+#[sqlx::test]
+async fn get_warrior_not_found(pool: PgPool) {
+    let router = app(pool);
+    let cookies = register_and_login(&router).await;
+
+    let fake_id = uuid::Uuid::new_v4();
+    let resp = send(
+        router,
+        get_with_cookies(&format!("/api/warriors/{fake_id}"), &cookies),
+    )
+    .await;
+    assert_eq!(resp.status, StatusCode::NOT_FOUND);
+}
+
+#[sqlx::test]
+async fn get_warrior_belongs_to_other_user(pool: PgPool) {
+    let router = app(pool);
+    let cookies_a = register_and_login_as(&router, "alice", "alice@example.com").await;
+    let cookies_b = register_and_login_as(&router, "bob", "bob@example.com").await;
+
+    let create_resp = send(
+        router.clone(),
+        post_json_with_cookies(
+            "/api/warriors",
+            &warrior_body("Alice Imp", "MOV.I $0, $1"),
+            &cookies_a,
+        ),
+    )
+    .await;
+    let id = create_resp.json["id"].as_str().unwrap();
+
+    let resp = send(
+        router,
+        get_with_cookies(&format!("/api/warriors/{id}"), &cookies_b),
+    )
+    .await;
+    assert_eq!(resp.status, StatusCode::NOT_FOUND);
+}
+
+// =============================================================================
+// List tests
+// =============================================================================
+
+#[sqlx::test]
+async fn list_warriors_empty(pool: PgPool) {
+    let router = app(pool);
+    let cookies = register_and_login(&router).await;
+
+    let resp = send(router, get_with_cookies("/api/warriors", &cookies)).await;
+    assert_eq!(resp.status, StatusCode::OK);
+    assert_eq!(resp.json["warriors"].as_array().unwrap().len(), 0);
+    assert_eq!(resp.json["total"], 0);
+    assert_eq!(resp.json["page"], 1);
+}
+
+#[sqlx::test]
+async fn list_warriors_returns_own_only(pool: PgPool) {
+    let router = app(pool);
+    let cookies_a = register_and_login_as(&router, "alice", "alice@example.com").await;
+    let cookies_b = register_and_login_as(&router, "bob", "bob@example.com").await;
+
+    send(
+        router.clone(),
+        post_json_with_cookies(
+            "/api/warriors",
+            &warrior_body("Alice Imp", "MOV.I $0, $1"),
+            &cookies_a,
+        ),
+    )
+    .await;
+    send(
+        router.clone(),
+        post_json_with_cookies(
+            "/api/warriors",
+            &warrior_body("Bob Dwarf", "ADD.AB #4, $3"),
+            &cookies_b,
+        ),
+    )
+    .await;
+
+    let resp = send(
+        router.clone(),
+        get_with_cookies("/api/warriors", &cookies_a),
+    )
+    .await;
+    assert_eq!(resp.json["total"], 1);
+    assert_eq!(resp.json["warriors"][0]["name"], "Alice Imp");
+
+    let resp = send(router, get_with_cookies("/api/warriors", &cookies_b)).await;
+    assert_eq!(resp.json["total"], 1);
+    assert_eq!(resp.json["warriors"][0]["name"], "Bob Dwarf");
+}
+
+#[sqlx::test]
+async fn list_warriors_pagination(pool: PgPool) {
+    let router = app(pool);
+    let cookies = register_and_login(&router).await;
+
+    for i in 0..5 {
+        send(
+            router.clone(),
+            post_json_with_cookies(
+                "/api/warriors",
+                &warrior_body(&format!("Warrior {i}"), "MOV.I $0, $1"),
+                &cookies,
+            ),
+        )
+        .await;
+    }
+
+    let resp = send(
+        router.clone(),
+        get_with_cookies("/api/warriors?page=1&per_page=2", &cookies),
+    )
+    .await;
+    assert_eq!(resp.json["warriors"].as_array().unwrap().len(), 2);
+    assert_eq!(resp.json["total"], 5);
+    assert_eq!(resp.json["page"], 1);
+    assert_eq!(resp.json["per_page"], 2);
+
+    let resp = send(
+        router,
+        get_with_cookies("/api/warriors?page=3&per_page=2", &cookies),
+    )
+    .await;
+    assert_eq!(resp.json["warriors"].as_array().unwrap().len(), 1);
+}
+
+// =============================================================================
+// Update tests
+// =============================================================================
+
+#[sqlx::test]
+async fn update_warrior_name(pool: PgPool) {
+    let router = app(pool);
+    let cookies = register_and_login(&router).await;
+
+    let create_resp = send(
+        router.clone(),
+        post_json_with_cookies(
+            "/api/warriors",
+            &warrior_body("Imp", "MOV.I $0, $1"),
+            &cookies,
+        ),
+    )
+    .await;
+    let id = create_resp.json["id"].as_str().unwrap();
+
+    let resp = send(
+        router,
+        put_json_with_cookies(
+            &format!("/api/warriors/{id}"),
+            &json!({"name": "Super Imp"}),
+            &cookies,
+        ),
+    )
+    .await;
+    assert_eq!(resp.status, StatusCode::OK);
+    assert_eq!(resp.json["name"], "Super Imp");
+    assert_eq!(resp.json["source"], "MOV.I $0, $1");
+}
+
+#[sqlx::test]
+async fn update_warrior_source(pool: PgPool) {
+    let router = app(pool);
+    let cookies = register_and_login(&router).await;
+
+    let create_resp = send(
+        router.clone(),
+        post_json_with_cookies(
+            "/api/warriors",
+            &warrior_body("Imp", "MOV.I $0, $1"),
+            &cookies,
+        ),
+    )
+    .await;
+    let id = create_resp.json["id"].as_str().unwrap();
+
+    let resp = send(
+        router,
+        put_json_with_cookies(
+            &format!("/api/warriors/{id}"),
+            &json!({"source": "ADD.AB #4, $3\nMOV.I $0, $1"}),
+            &cookies,
+        ),
+    )
+    .await;
+    assert_eq!(resp.status, StatusCode::OK);
+    assert_eq!(resp.json["name"], "Imp");
+    assert_eq!(resp.json["source"], "ADD.AB #4, $3\nMOV.I $0, $1");
+}
+
+#[sqlx::test]
+async fn update_warrior_not_found(pool: PgPool) {
+    let router = app(pool);
+    let cookies = register_and_login(&router).await;
+
+    let fake_id = uuid::Uuid::new_v4();
+    let resp = send(
+        router,
+        put_json_with_cookies(
+            &format!("/api/warriors/{fake_id}"),
+            &json!({"name": "New Name"}),
+            &cookies,
+        ),
+    )
+    .await;
+    assert_eq!(resp.status, StatusCode::NOT_FOUND);
+}
+
+#[sqlx::test]
+async fn update_warrior_other_users(pool: PgPool) {
+    let router = app(pool);
+    let cookies_a = register_and_login_as(&router, "alice", "alice@example.com").await;
+    let cookies_b = register_and_login_as(&router, "bob", "bob@example.com").await;
+
+    let create_resp = send(
+        router.clone(),
+        post_json_with_cookies(
+            "/api/warriors",
+            &warrior_body("Alice Imp", "MOV.I $0, $1"),
+            &cookies_a,
+        ),
+    )
+    .await;
+    let id = create_resp.json["id"].as_str().unwrap();
+
+    let resp = send(
+        router,
+        put_json_with_cookies(
+            &format!("/api/warriors/{id}"),
+            &json!({"name": "Hacked!"}),
+            &cookies_b,
+        ),
+    )
+    .await;
+    assert_eq!(resp.status, StatusCode::NOT_FOUND);
+}
+
+// =============================================================================
+// Delete tests
+// =============================================================================
+
+#[sqlx::test]
+async fn delete_warrior(pool: PgPool) {
+    let router = app(pool);
+    let cookies = register_and_login(&router).await;
+
+    let create_resp = send(
+        router.clone(),
+        post_json_with_cookies(
+            "/api/warriors",
+            &warrior_body("Imp", "MOV.I $0, $1"),
+            &cookies,
+        ),
+    )
+    .await;
+    let id = create_resp.json["id"].as_str().unwrap();
+
+    let resp = send(
+        router.clone(),
+        delete_with_cookies(&format!("/api/warriors/{id}"), &cookies),
+    )
+    .await;
+    assert_eq!(resp.status, StatusCode::NO_CONTENT);
+
+    let resp = send(
+        router,
+        get_with_cookies(&format!("/api/warriors/{id}"), &cookies),
+    )
+    .await;
+    assert_eq!(resp.status, StatusCode::NOT_FOUND);
+}
+
+#[sqlx::test]
+async fn delete_warrior_not_found(pool: PgPool) {
+    let router = app(pool);
+    let cookies = register_and_login(&router).await;
+
+    let fake_id = uuid::Uuid::new_v4();
+    let resp = send(
+        router,
+        delete_with_cookies(&format!("/api/warriors/{fake_id}"), &cookies),
+    )
+    .await;
+    assert_eq!(resp.status, StatusCode::NOT_FOUND);
+}
+
+#[sqlx::test]
+async fn delete_warrior_other_users(pool: PgPool) {
+    let router = app(pool);
+    let cookies_a = register_and_login_as(&router, "alice", "alice@example.com").await;
+    let cookies_b = register_and_login_as(&router, "bob", "bob@example.com").await;
+
+    let create_resp = send(
+        router.clone(),
+        post_json_with_cookies(
+            "/api/warriors",
+            &warrior_body("Alice Imp", "MOV.I $0, $1"),
+            &cookies_a,
+        ),
+    )
+    .await;
+    let id = create_resp.json["id"].as_str().unwrap();
+
+    let resp = send(
+        router.clone(),
+        delete_with_cookies(&format!("/api/warriors/{id}"), &cookies_b),
+    )
+    .await;
+    assert_eq!(resp.status, StatusCode::NOT_FOUND);
+
+    // Verify it still exists for alice
+    let resp = send(
+        router,
+        get_with_cookies(&format!("/api/warriors/{id}"), &cookies_a),
+    )
+    .await;
+    assert_eq!(resp.status, StatusCode::OK);
+}
+
+// =============================================================================
+// Full CRUD flow
+// =============================================================================
+
+#[sqlx::test]
+async fn full_crud_flow(pool: PgPool) {
+    let router = app(pool);
+    let cookies = register_and_login(&router).await;
+
+    // Create
+    let resp = send(
+        router.clone(),
+        post_json_with_cookies(
+            "/api/warriors",
+            &warrior_body("Imp", "MOV.I $0, $1"),
+            &cookies,
+        ),
+    )
+    .await;
+    assert_eq!(resp.status, StatusCode::CREATED);
+    let id = resp.json["id"].as_str().unwrap().to_string();
+
+    // Read
+    let resp = send(
+        router.clone(),
+        get_with_cookies(&format!("/api/warriors/{id}"), &cookies),
+    )
+    .await;
+    assert_eq!(resp.status, StatusCode::OK);
+    assert_eq!(resp.json["name"], "Imp");
+
+    // List
+    let resp = send(
+        router.clone(),
+        get_with_cookies("/api/warriors", &cookies),
+    )
+    .await;
+    assert_eq!(resp.json["total"], 1);
+
+    // Update
+    let resp = send(
+        router.clone(),
+        put_json_with_cookies(
+            &format!("/api/warriors/{id}"),
+            &json!({"name": "Super Imp", "source": ";name Super Imp\nMOV.I $0, $1"}),
+            &cookies,
+        ),
+    )
+    .await;
+    assert_eq!(resp.status, StatusCode::OK);
+    assert_eq!(resp.json["name"], "Super Imp");
+
+    // Delete
+    let resp = send(
+        router.clone(),
+        delete_with_cookies(&format!("/api/warriors/{id}"), &cookies),
+    )
+    .await;
+    assert_eq!(resp.status, StatusCode::NO_CONTENT);
+
+    // Confirm deleted
+    let resp = send(
+        router,
+        get_with_cookies(&format!("/api/warriors/{id}"), &cookies),
+    )
+    .await;
+    assert_eq!(resp.status, StatusCode::NOT_FOUND);
+}

--- a/backend/tests/warriors_integration.rs
+++ b/backend/tests/warriors_integration.rs
@@ -117,7 +117,10 @@ async fn send(router: Router, req: Request<Body>) -> TestResponse {
     TestResponse { status, json }
 }
 
-async fn send_with_cookies(router: Router, req: Request<Body>) -> (TestResponse, HashMap<String, String>) {
+async fn send_with_cookies(
+    router: Router,
+    req: Request<Body>,
+) -> (TestResponse, HashMap<String, String>) {
     let resp = router.oneshot(req).await.unwrap();
     let status = resp.status();
     let cookies = extract_cookies(resp.headers());
@@ -209,10 +212,7 @@ async fn create_warrior_unauthenticated(pool: PgPool) {
     let router = app(pool);
     let resp = send(
         router,
-        post_json(
-            "/api/warriors",
-            &warrior_body("Imp", "MOV.I $0, $1"),
-        ),
+        post_json("/api/warriors", &warrior_body("Imp", "MOV.I $0, $1")),
     )
     .await;
     assert_eq!(resp.status, StatusCode::UNAUTHORIZED);
@@ -225,11 +225,7 @@ async fn create_warrior_empty_name(pool: PgPool) {
 
     let resp = send(
         router,
-        post_json_with_cookies(
-            "/api/warriors",
-            &warrior_body("", "MOV.I $0, $1"),
-            &cookies,
-        ),
+        post_json_with_cookies("/api/warriors", &warrior_body("", "MOV.I $0, $1"), &cookies),
     )
     .await;
     assert_eq!(resp.status, StatusCode::BAD_REQUEST);
@@ -667,11 +663,7 @@ async fn full_crud_flow(pool: PgPool) {
     assert_eq!(resp.json["name"], "Imp");
 
     // List
-    let resp = send(
-        router.clone(),
-        get_with_cookies("/api/warriors", &cookies),
-    )
-    .await;
+    let resp = send(router.clone(), get_with_cookies("/api/warriors", &cookies)).await;
     assert_eq!(resp.json["total"], 1);
 
     // Update

--- a/frontend/src/AppLayout.tsx
+++ b/frontend/src/AppLayout.tsx
@@ -123,21 +123,13 @@ export default function AppLayout() {
           {loading ? null : user ? (
             <>
               <span style={USERNAME_STYLE}>{user.username}</span>
-              <button
-                style={AUTH_BTN}
-                onClick={logout}
-                title="Log out"
-              >
+              <button style={AUTH_BTN} onClick={logout} title="Log out">
                 <span style={ICON_STYLE}>{'←'}</span>
                 <span style={LABEL_STYLE}>Logout</span>
               </button>
             </>
           ) : (
-            <button
-              style={AUTH_BTN}
-              onClick={() => setShowAuth(true)}
-              title="Log in or register"
-            >
+            <button style={AUTH_BTN} onClick={() => setShowAuth(true)} title="Log in or register">
               <span style={ICON_STYLE}>{'→'}</span>
               <span style={LABEL_STYLE}>Log In</span>
             </button>

--- a/frontend/src/AppLayout.tsx
+++ b/frontend/src/AppLayout.tsx
@@ -1,4 +1,7 @@
+import { useState } from 'react';
 import { NavLink, Outlet } from 'react-router-dom';
+import { useAuth } from './api/AuthContext';
+import AuthModal from './api/AuthModal';
 
 const SHELL_STYLE: React.CSSProperties = {
   display: 'flex',
@@ -55,13 +58,51 @@ const LABEL_STYLE: React.CSSProperties = {
 type Item = { to: string; label: string; icon: string };
 
 const ITEMS: Item[] = [
-  { to: '/', label: 'Home', icon: '\u2302' },
-  { to: '/battle', label: 'Battle', icon: '\u2694' },
-  { to: '/builder', label: 'Builder', icon: '\u270E' },
-  { to: '/learn', label: 'Learn', icon: '\u2139' },
+  { to: '/', label: 'Home', icon: '⌂' },
+  { to: '/battle', label: 'Battle', icon: '⚔' },
+  { to: '/builder', label: 'Builder', icon: '✎' },
+  { to: '/learn', label: 'Learn', icon: 'ℹ' },
 ];
 
+const AUTH_SECTION: React.CSSProperties = {
+  marginTop: 'auto',
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  gap: '0.25rem',
+  padding: '0.5rem 0',
+};
+
+const AUTH_BTN: React.CSSProperties = {
+  width: '64px',
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: '0.2rem',
+  padding: '0.5rem 0',
+  borderRadius: '6px',
+  color: '#888',
+  backgroundColor: 'transparent',
+  border: 'none',
+  cursor: 'pointer',
+  fontFamily: 'inherit',
+  transition: 'background-color 0.15s, color 0.15s',
+};
+
+const USERNAME_STYLE: React.CSSProperties = {
+  fontSize: '0.6rem',
+  color: '#4fc3f7',
+  textAlign: 'center',
+  wordBreak: 'break-all',
+  maxWidth: '70px',
+  lineHeight: 1.2,
+};
+
 export default function AppLayout() {
+  const { user, loading, logout } = useAuth();
+  const [showAuth, setShowAuth] = useState(false);
+
   return (
     <div style={SHELL_STYLE}>
       <nav style={SIDEBAR_STYLE}>
@@ -77,10 +118,36 @@ export default function AppLayout() {
             <span style={LABEL_STYLE}>{item.label}</span>
           </NavLink>
         ))}
+
+        <div style={AUTH_SECTION}>
+          {loading ? null : user ? (
+            <>
+              <span style={USERNAME_STYLE}>{user.username}</span>
+              <button
+                style={AUTH_BTN}
+                onClick={logout}
+                title="Log out"
+              >
+                <span style={ICON_STYLE}>{'←'}</span>
+                <span style={LABEL_STYLE}>Logout</span>
+              </button>
+            </>
+          ) : (
+            <button
+              style={AUTH_BTN}
+              onClick={() => setShowAuth(true)}
+              title="Log in or register"
+            >
+              <span style={ICON_STYLE}>{'→'}</span>
+              <span style={LABEL_STYLE}>Log In</span>
+            </button>
+          )}
+        </div>
       </nav>
       <main style={MAIN_STYLE}>
         <Outlet />
       </main>
+      {showAuth && <AuthModal onClose={() => setShowAuth(false)} />}
     </div>
   );
 }

--- a/frontend/src/api/AuthContext.tsx
+++ b/frontend/src/api/AuthContext.tsx
@@ -1,0 +1,53 @@
+import { createContext, useCallback, useContext, useEffect, useState } from 'react';
+import type { ReactNode } from 'react';
+import * as authApi from './auth';
+
+type AuthState = {
+  user: authApi.AuthUser | null;
+  loading: boolean;
+  login: (input: authApi.LoginInput) => Promise<void>;
+  register: (input: authApi.RegisterInput) => Promise<void>;
+  logout: () => Promise<void>;
+};
+
+const AuthContext = createContext<AuthState | null>(null);
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<authApi.AuthUser | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    authApi
+      .getMe()
+      .then(setUser)
+      .catch(() => setUser(null))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const login = useCallback(async (input: authApi.LoginInput) => {
+    const u = await authApi.login(input);
+    setUser(u);
+  }, []);
+
+  const register = useCallback(async (input: authApi.RegisterInput) => {
+    const u = await authApi.register(input);
+    setUser(u);
+  }, []);
+
+  const logout = useCallback(async () => {
+    await authApi.logout();
+    setUser(null);
+  }, []);
+
+  return (
+    <AuthContext.Provider value={{ user, loading, login, register, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth(): AuthState {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error('useAuth must be used within AuthProvider');
+  return ctx;
+}

--- a/frontend/src/api/AuthModal.tsx
+++ b/frontend/src/api/AuthModal.tsx
@@ -1,0 +1,206 @@
+import { useState } from 'react';
+import { useAuth } from './AuthContext';
+import { ApiError } from './client';
+
+type Props = { onClose: () => void };
+
+export default function AuthModal({ onClose }: Props) {
+  const { login, register } = useAuth();
+  const [mode, setMode] = useState<'login' | 'register'>('login');
+  const [username, setUsername] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    setSubmitting(true);
+    try {
+      if (mode === 'login') {
+        await login({ username_or_email: username, password });
+      } else {
+        await register({ username, email, password });
+      }
+      onClose();
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : 'Something went wrong');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div style={OVERLAY}>
+      <div style={MODAL}>
+        <div style={HEADER}>
+          <h2 style={{ margin: 0, fontSize: '1.1rem' }}>
+            {mode === 'login' ? 'Log In' : 'Create Account'}
+          </h2>
+          <button onClick={onClose} style={CLOSE_BTN}>
+            &times;
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} style={FORM}>
+          <label style={LABEL}>
+            {mode === 'login' ? 'Username or Email' : 'Username'}
+            <input
+              style={INPUT}
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+              autoFocus
+              required
+            />
+          </label>
+
+          {mode === 'register' && (
+            <label style={LABEL}>
+              Email
+              <input
+                style={INPUT}
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                required
+              />
+            </label>
+          )}
+
+          <label style={LABEL}>
+            Password
+            <input
+              style={INPUT}
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+              minLength={8}
+            />
+          </label>
+
+          {error && <div style={ERROR}>{error}</div>}
+
+          <button type="submit" disabled={submitting} style={SUBMIT_BTN}>
+            {submitting ? '...' : mode === 'login' ? 'Log In' : 'Register'}
+          </button>
+        </form>
+
+        <div style={TOGGLE}>
+          {mode === 'login' ? (
+            <>
+              No account?{' '}
+              <button style={LINK_BTN} onClick={() => { setMode('register'); setError(''); }}>
+                Register
+              </button>
+            </>
+          ) : (
+            <>
+              Already have an account?{' '}
+              <button style={LINK_BTN} onClick={() => { setMode('login'); setError(''); }}>
+                Log in
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const OVERLAY: React.CSSProperties = {
+  position: 'fixed',
+  inset: 0,
+  backgroundColor: 'rgba(0,0,0,0.6)',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  zIndex: 1000,
+};
+
+const MODAL: React.CSSProperties = {
+  backgroundColor: '#1a1a1a',
+  border: '1px solid #333',
+  borderRadius: '8px',
+  padding: '1.5rem',
+  width: '340px',
+  maxWidth: '90vw',
+  fontFamily: '"JetBrains Mono", "Fira Code", monospace',
+};
+
+const HEADER: React.CSSProperties = {
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  marginBottom: '1rem',
+};
+
+const CLOSE_BTN: React.CSSProperties = {
+  background: 'none',
+  border: 'none',
+  color: '#888',
+  fontSize: '1.5rem',
+  cursor: 'pointer',
+  padding: '0 0.25rem',
+};
+
+const FORM: React.CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.75rem',
+};
+
+const LABEL: React.CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.25rem',
+  fontSize: '0.8rem',
+  color: '#aaa',
+};
+
+const INPUT: React.CSSProperties = {
+  backgroundColor: '#111',
+  border: '1px solid #333',
+  borderRadius: '4px',
+  padding: '0.5rem',
+  color: '#e0e0e0',
+  fontSize: '0.85rem',
+  fontFamily: 'inherit',
+  outline: 'none',
+};
+
+const ERROR: React.CSSProperties = {
+  color: '#e94560',
+  fontSize: '0.8rem',
+};
+
+const SUBMIT_BTN: React.CSSProperties = {
+  backgroundColor: '#e94560',
+  color: '#fff',
+  border: 'none',
+  borderRadius: '4px',
+  padding: '0.6rem',
+  fontSize: '0.85rem',
+  fontFamily: 'inherit',
+  cursor: 'pointer',
+  marginTop: '0.25rem',
+};
+
+const TOGGLE: React.CSSProperties = {
+  marginTop: '1rem',
+  textAlign: 'center',
+  fontSize: '0.75rem',
+  color: '#888',
+};
+
+const LINK_BTN: React.CSSProperties = {
+  background: 'none',
+  border: 'none',
+  color: '#4fc3f7',
+  cursor: 'pointer',
+  fontFamily: 'inherit',
+  fontSize: '0.75rem',
+  textDecoration: 'underline',
+  padding: 0,
+};

--- a/frontend/src/api/AuthModal.tsx
+++ b/frontend/src/api/AuthModal.tsx
@@ -91,14 +91,26 @@ export default function AuthModal({ onClose }: Props) {
           {mode === 'login' ? (
             <>
               No account?{' '}
-              <button style={LINK_BTN} onClick={() => { setMode('register'); setError(''); }}>
+              <button
+                style={LINK_BTN}
+                onClick={() => {
+                  setMode('register');
+                  setError('');
+                }}
+              >
                 Register
               </button>
             </>
           ) : (
             <>
               Already have an account?{' '}
-              <button style={LINK_BTN} onClick={() => { setMode('login'); setError(''); }}>
+              <button
+                style={LINK_BTN}
+                onClick={() => {
+                  setMode('login');
+                  setError('');
+                }}
+              >
                 Log in
               </button>
             </>

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -1,0 +1,42 @@
+import { api, ApiError } from './client';
+
+export type AuthUser = {
+  user_id: string;
+  username: string;
+};
+
+export type RegisterInput = {
+  username: string;
+  email: string;
+  password: string;
+};
+
+export type LoginInput = {
+  username_or_email: string;
+  password: string;
+};
+
+export async function register(input: RegisterInput): Promise<AuthUser> {
+  return api.post<AuthUser>('/api/auth/register', input);
+}
+
+export async function login(input: LoginInput): Promise<AuthUser> {
+  return api.post<AuthUser>('/api/auth/login', input);
+}
+
+export async function logout(): Promise<void> {
+  return api.post('/api/auth/logout');
+}
+
+export async function getMe(): Promise<AuthUser | null> {
+  try {
+    return await api.get<AuthUser>('/api/auth/me');
+  } catch (e) {
+    if (e instanceof ApiError && e.status === 401) return null;
+    throw e;
+  }
+}
+
+export async function refreshToken(): Promise<AuthUser> {
+  return api.post<AuthUser>('/api/auth/refresh');
+}

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,0 +1,36 @@
+const API_BASE = import.meta.env.VITE_API_URL ?? 'http://localhost:3001';
+
+export class ApiError extends Error {
+  constructor(
+    public status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'ApiError';
+  }
+}
+
+async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
+  const res = await fetch(`${API_BASE}${path}`, {
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json', ...options.headers },
+    ...options,
+  });
+
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({ error: res.statusText }));
+    throw new ApiError(res.status, body.error ?? res.statusText);
+  }
+
+  if (res.status === 204) return undefined as T;
+  return res.json();
+}
+
+export const api = {
+  get: <T>(path: string) => request<T>(path),
+  post: <T>(path: string, body?: unknown) =>
+    request<T>(path, { method: 'POST', body: body ? JSON.stringify(body) : undefined }),
+  put: <T>(path: string, body?: unknown) =>
+    request<T>(path, { method: 'PUT', body: body ? JSON.stringify(body) : undefined }),
+  delete: <T>(path: string) => request<T>(path, { method: 'DELETE' }),
+};

--- a/frontend/src/api/warriors.ts
+++ b/frontend/src/api/warriors.ts
@@ -1,0 +1,40 @@
+import { api } from './client';
+
+export type ServerWarrior = {
+  id: string;
+  user_id: string;
+  name: string;
+  source: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export type WarriorListResponse = {
+  warriors: ServerWarrior[];
+  total: number;
+  page: number;
+  per_page: number;
+};
+
+export async function listWarriors(page = 1, perPage = 100): Promise<WarriorListResponse> {
+  return api.get<WarriorListResponse>(`/api/warriors?page=${page}&per_page=${perPage}`);
+}
+
+export async function getWarrior(id: string): Promise<ServerWarrior> {
+  return api.get<ServerWarrior>(`/api/warriors/${id}`);
+}
+
+export async function createWarrior(name: string, source: string): Promise<ServerWarrior> {
+  return api.post<ServerWarrior>('/api/warriors', { name, source });
+}
+
+export async function updateWarrior(
+  id: string,
+  patch: { name?: string; source?: string },
+): Promise<ServerWarrior> {
+  return api.put<ServerWarrior>(`/api/warriors/${id}`, patch);
+}
+
+export async function deleteWarrior(id: string): Promise<void> {
+  return api.delete(`/api/warriors/${id}`);
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import './index.css';
 import AppLayout from './AppLayout';
+import { AuthProvider } from './api/AuthContext';
 import HomePage from './pages/HomePage';
 
 // eslint-disable-next-line react-refresh/only-export-components
@@ -14,36 +15,38 @@ const LearnPage = React.lazy(() => import('./pages/LearnPage'));
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <BrowserRouter>
-      <Routes>
-        <Route element={<AppLayout />}>
-          <Route path="/" element={<HomePage />} />
-          <Route
-            path="/battle"
-            element={
-              <Suspense>
-                <BattlefieldPage />
-              </Suspense>
-            }
-          />
-          <Route
-            path="/builder"
-            element={
-              <Suspense>
-                <BuilderPage />
-              </Suspense>
-            }
-          />
-          <Route
-            path="/learn"
-            element={
-              <Suspense>
-                <LearnPage />
-              </Suspense>
-            }
-          />
-        </Route>
-      </Routes>
-    </BrowserRouter>
+    <AuthProvider>
+      <BrowserRouter>
+        <Routes>
+          <Route element={<AppLayout />}>
+            <Route path="/" element={<HomePage />} />
+            <Route
+              path="/battle"
+              element={
+                <Suspense>
+                  <BattlefieldPage />
+                </Suspense>
+              }
+            />
+            <Route
+              path="/builder"
+              element={
+                <Suspense>
+                  <BuilderPage />
+                </Suspense>
+              }
+            />
+            <Route
+              path="/learn"
+              element={
+                <Suspense>
+                  <LearnPage />
+                </Suspense>
+              }
+            />
+          </Route>
+        </Routes>
+      </BrowserRouter>
+    </AuthProvider>
   </React.StrictMode>,
 );

--- a/frontend/src/pages/builder/useBuilder.ts
+++ b/frontend/src/pages/builder/useBuilder.ts
@@ -8,14 +8,24 @@ import {
   updateUserWarrior,
   deleteUserWarrior,
   duplicateWarrior,
+  syncFromServer,
+  createServerWarrior,
+  updateServerWarrior,
+  deleteServerWarrior,
   type Warrior,
 } from '../../warriors/library';
 import { registerRedcode, parseErrorToMarker } from '../../redcode/monaco';
+import { useAuth } from '../../api/AuthContext';
 
 export type ParseStatus = { ok: true; name: string | null } | { ok: false; message: string } | null;
 
+function isServerWarrior(id: string): boolean {
+  return id.startsWith('server:');
+}
+
 export function useBuilder() {
   const navigate = useNavigate();
+  const { user } = useAuth();
   const library = useWarriorLibrary();
   const [selectedId, setSelectedId] = useState<string>(() => library[0]?.id ?? '');
   const [source, setSource] = useState<string>('');
@@ -23,6 +33,7 @@ export function useBuilder() {
   const [dirty, setDirty] = useState(false);
   const [wasmReady, setWasmReady] = useState(false);
   const [parseStatus, setParseStatus] = useState<ParseStatus>(null);
+  const [saving, setSaving] = useState(false);
 
   const monacoRef = useRef<Monaco | null>(null);
   const editorRef = useRef<Parameters<OnMount>[0] | null>(null);
@@ -36,6 +47,12 @@ export function useBuilder() {
       cancelled = true;
     };
   }, []);
+
+  useEffect(() => {
+    if (user) {
+      syncFromServer();
+    }
+  }, [user]);
 
   const selected = library.find((w) => w.id === selectedId);
 
@@ -93,31 +110,71 @@ export function useBuilder() {
     if (warrior) syncFromWarrior(warrior);
   };
 
-  const handleSave = () => {
-    if (!selected) return;
-    if (selected.isPreset) {
-      const created = createUserWarrior(label || 'Untitled', source);
-      setSelectedId(created.id);
-      syncFromWarrior(created);
-      return;
+  const handleSave = async () => {
+    if (!selected || saving) return;
+    setSaving(true);
+    try {
+      if (selected.isPreset) {
+        if (user) {
+          const created = await createServerWarrior(label || 'Untitled', source);
+          setSelectedId(created.id);
+          syncFromWarrior(created);
+        } else {
+          const created = createUserWarrior(label || 'Untitled', source);
+          setSelectedId(created.id);
+          syncFromWarrior(created);
+        }
+        return;
+      }
+      if (user && isServerWarrior(selected.id)) {
+        await updateServerWarrior(selected.id, { label: label || 'Untitled', source });
+      } else if (user && !isServerWarrior(selected.id)) {
+        const created = await createServerWarrior(label || 'Untitled', source);
+        setSelectedId(created.id);
+        syncFromWarrior(created);
+      } else {
+        updateUserWarrior(selected.id, { label: label || 'Untitled', source });
+      }
+      setDirty(false);
+    } finally {
+      setSaving(false);
     }
-    updateUserWarrior(selected.id, { label: label || 'Untitled', source });
-    setDirty(false);
   };
 
-  const handleDuplicate = () => {
-    if (!selected) return;
-    const created = duplicateWarrior(selected.id);
-    if (created) {
-      setSelectedId(created.id);
-      syncFromWarrior(created);
+  const handleDuplicate = async () => {
+    if (!selected || saving) return;
+    if (user) {
+      setSaving(true);
+      try {
+        const newLabel = `${selected.label} (copy)`;
+        const created = await createServerWarrior(newLabel, selected.source);
+        setSelectedId(created.id);
+        syncFromWarrior(created);
+      } finally {
+        setSaving(false);
+      }
+    } else {
+      const created = duplicateWarrior(selected.id);
+      if (created) {
+        setSelectedId(created.id);
+        syncFromWarrior(created);
+      }
     }
   };
 
-  const handleDelete = () => {
-    if (!selected || selected.isPreset) return;
+  const handleDelete = async () => {
+    if (!selected || selected.isPreset || saving) return;
     if (!confirm(`Delete "${selected.label}"? This cannot be undone.`)) return;
-    deleteUserWarrior(selected.id);
+    if (user && isServerWarrior(selected.id)) {
+      setSaving(true);
+      try {
+        await deleteServerWarrior(selected.id);
+      } finally {
+        setSaving(false);
+      }
+    } else {
+      deleteUserWarrior(selected.id);
+    }
     const remaining = library.filter((w) => w.id !== selected.id);
     const nextId = remaining[0]?.id ?? '';
     setSelectedId(nextId);
@@ -125,15 +182,26 @@ export function useBuilder() {
     if (next) syncFromWarrior(next);
   };
 
-  const handleNew = () => {
+  const handleNew = async () => {
     const template = `;name New Warrior
 ;author you
         ORG    start
 start   MOV.I  $0, $1
 `;
-    const created = createUserWarrior('New Warrior', template);
-    setSelectedId(created.id);
-    syncFromWarrior(created);
+    if (user) {
+      setSaving(true);
+      try {
+        const created = await createServerWarrior('New Warrior', template);
+        setSelectedId(created.id);
+        syncFromWarrior(created);
+      } finally {
+        setSaving(false);
+      }
+    } else {
+      const created = createUserWarrior('New Warrior', template);
+      setSelectedId(created.id);
+      syncFromWarrior(created);
+    }
   };
 
   const handleTestInBattle = () => {
@@ -173,7 +241,8 @@ start   MOV.I  $0, $1
     parseStatus,
     presets,
     userWarriors,
-    canSave: !!selected && dirty,
+    saving,
+    canSave: !!selected && dirty && !saving,
     handleEditorWillMount,
     handleEditorDidMount,
     handleSelect,

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/frontend/src/warriors/library.ts
+++ b/frontend/src/warriors/library.ts
@@ -1,4 +1,5 @@
 import { useSyncExternalStore } from 'react';
+import * as warriorsApi from '../api/warriors';
 
 export type Warrior = {
   id: string;
@@ -207,6 +208,55 @@ export function deleteUserWarrior(id: string): void {
 export function duplicateWarrior(sourceId: string): Warrior | undefined {
   const src = getWarrior(sourceId);
   if (!src) return undefined;
-  const label = src.isPreset ? `${src.label} (copy)` : `${src.label} (copy)`;
+  const label = `${src.label} (copy)`;
   return createUserWarrior(label, src.source);
+}
+
+export async function syncFromServer(): Promise<void> {
+  try {
+    const resp = await warriorsApi.listWarriors(1, 100);
+    userWarriors = resp.warriors.map((w) => ({
+      id: `server:${w.id}`,
+      label: w.name,
+      source: w.source,
+      isPreset: false,
+    }));
+    snapshot = computeSnapshot();
+    listeners.forEach((l) => l());
+  } catch {
+    // silently fall back to localStorage
+  }
+}
+
+export async function createServerWarrior(label: string, source: string): Promise<Warrior> {
+  const sw = await warriorsApi.createWarrior(label, source);
+  const w: Warrior = { id: `server:${sw.id}`, label: sw.name, source: sw.source, isPreset: false };
+  userWarriors = [...userWarriors, w];
+  snapshot = computeSnapshot();
+  listeners.forEach((l) => l());
+  return w;
+}
+
+export async function updateServerWarrior(
+  localId: string,
+  patch: { label?: string; source?: string },
+): Promise<void> {
+  const serverId = localId.replace('server:', '');
+  const apiPatch: { name?: string; source?: string } = {};
+  if (patch.label !== undefined) apiPatch.name = patch.label;
+  if (patch.source !== undefined) apiPatch.source = patch.source;
+  const sw = await warriorsApi.updateWarrior(serverId, apiPatch);
+  userWarriors = userWarriors.map((w) =>
+    w.id === localId ? { ...w, label: sw.name, source: sw.source } : w,
+  );
+  snapshot = computeSnapshot();
+  listeners.forEach((l) => l());
+}
+
+export async function deleteServerWarrior(localId: string): Promise<void> {
+  const serverId = localId.replace('server:', '');
+  await warriorsApi.deleteWarrior(serverId);
+  userWarriors = userWarriors.filter((w) => w.id !== localId);
+  snapshot = computeSnapshot();
+  listeners.forEach((l) => l());
 }


### PR DESCRIPTION
## Summary
- **Backend:** Warriors table migration, full CRUD endpoints (`/api/warriors`) with auth, validation, pagination. 20 new integration tests. Register now auto-issues auth cookies for immediate post-registration API access. Added `NotFound` error variant, `/api/auth/me` endpoint, expanded CORS to allow PUT/DELETE.
- **Frontend:** API client module, `AuthContext` provider with `useAuth` hook, login/register modal in sidebar, warrior library syncs with server when authenticated (localStorage fallback for guests).

## Test plan
- [x] 87 backend unit tests pass
- [x] 22 auth integration tests pass  
- [x] 20 warrior integration tests pass (CRUD, pagination, ownership isolation, auth enforcement)
- [x] 49 frontend unit tests pass
- [x] TypeScript compiles clean (`tsc --noEmit`)
- [x] ESLint passes (1 warning: fast-refresh on AuthContext — expected)
- [x] Clippy passes (`-D warnings`)
- [x] Visual verification via Playwright: register flow, builder page with server-persisted warriors, DB confirmation

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)