### PR TITLE
Add editor enhancements: autocomplete, hover, import/export (issue #36)

### DIFF
--- a/frontend/src/pages/builder/BuilderPage.tsx
+++ b/frontend/src/pages/builder/BuilderPage.tsx
@@ -11,6 +11,7 @@ export default function BuilderPage() {
   const {
     selectedId,
     selected,
+    source,
     label,
     dirty,
     wasmReady,
@@ -25,6 +26,7 @@ export default function BuilderPage() {
     handleDuplicate,
     handleDelete,
     handleNew,
+    handleImport,
     handleTestInBattle,
     handleLabelChange,
     handleSourceChange,
@@ -45,11 +47,13 @@ export default function BuilderPage() {
           label={label}
           selected={selected}
           canSave={canSave}
+          source={source}
           onLabelChange={handleLabelChange}
           onSave={handleSave}
           onDuplicate={handleDuplicate}
           onDelete={handleDelete}
           onTestInBattle={handleTestInBattle}
+          onImport={handleImport}
         />
 
         <div style={EDITOR_CONTAINER_STYLE}>
@@ -72,6 +76,13 @@ export default function BuilderPage() {
               readOnly: selected?.isPreset ?? false,
               wordWrap: 'off',
               tabSize: 8,
+              quickSuggestions: {
+                other: 'on',
+                comments: 'off',
+                strings: 'off',
+              },
+              suggestOnTriggerCharacters: true,
+              wordBasedSuggestions: 'off',
             }}
           />
         </div>

--- a/frontend/src/pages/builder/EditorToolbar.tsx
+++ b/frontend/src/pages/builder/EditorToolbar.tsx
@@ -1,3 +1,4 @@
+import { useRef } from 'react';
 import type { Warrior } from '../../warriors/library';
 import {
   BUTTON_STYLE,
@@ -16,7 +17,19 @@ type Props = {
   onDuplicate: () => void;
   onDelete: () => void;
   onTestInBattle: () => void;
+  onImport: (name: string, source: string) => void;
+  source: string;
 };
+
+function downloadFile(filename: string, content: string): void {
+  const blob = new Blob([content], { type: 'text/plain' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}
 
 export default function EditorToolbar({
   label,
@@ -27,7 +40,27 @@ export default function EditorToolbar({
   onDuplicate,
   onDelete,
   onTestInBattle,
+  onImport,
+  source,
 }: Props) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleImportClick = () => fileInputRef.current?.click();
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const name = file.name.replace(/\.re?d$/i, '');
+    file.text().then((text) => onImport(name, text));
+    e.target.value = '';
+  };
+
+  const handleExport = () => {
+    if (!selected) return;
+    const filename = `${label || 'warrior'}.red`;
+    downloadFile(filename, source);
+  };
+
   return (
     <div style={TOOLBAR_STYLE}>
       <input
@@ -55,6 +88,19 @@ export default function EditorToolbar({
           Delete
         </button>
       )}
+      <button style={BUTTON_STYLE} onClick={handleExport} disabled={!selected} title="Export .red">
+        Export
+      </button>
+      <button style={BUTTON_STYLE} onClick={handleImportClick} title="Import .red">
+        Import
+      </button>
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept=".red,.rd"
+        style={{ display: 'none' }}
+        onChange={handleFileChange}
+      />
       <button style={BUTTON_STYLE} onClick={onTestInBattle} disabled={!selected}>
         Test in Battlefield &rarr;
       </button>

--- a/frontend/src/pages/builder/useBuilder.ts
+++ b/frontend/src/pages/builder/useBuilder.ts
@@ -182,6 +182,23 @@ export function useBuilder() {
     if (next) syncFromWarrior(next);
   };
 
+  const handleImport = async (name: string, content: string) => {
+    if (user) {
+      setSaving(true);
+      try {
+        const created = await createServerWarrior(name || 'Imported', content);
+        setSelectedId(created.id);
+        syncFromWarrior(created);
+      } finally {
+        setSaving(false);
+      }
+    } else {
+      const created = createUserWarrior(name || 'Imported', content);
+      setSelectedId(created.id);
+      syncFromWarrior(created);
+    }
+  };
+
   const handleNew = async () => {
     const template = `;name New Warrior
 ;author you
@@ -250,6 +267,7 @@ start   MOV.I  $0, $1
     handleDuplicate,
     handleDelete,
     handleNew,
+    handleImport,
     handleTestInBattle,
     handleLabelChange,
     handleSourceChange,

--- a/frontend/src/redcode/cheatSheet.test.ts
+++ b/frontend/src/redcode/cheatSheet.test.ts
@@ -32,11 +32,14 @@ describe('cheatSheet data', () => {
     expect(symbols).toContain('>');
   });
 
-  it('has pseudo-ops', () => {
-    expect(PSEUDO_OPS.length).toBeGreaterThanOrEqual(2);
+  it('has pseudo-ops including FOR/ROF', () => {
+    expect(PSEUDO_OPS).toHaveLength(5);
     const symbols = PSEUDO_OPS.map((e) => e.symbol);
     expect(symbols).toContain('ORG');
     expect(symbols).toContain('END');
+    expect(symbols).toContain('EQU');
+    expect(symbols).toContain('FOR');
+    expect(symbols).toContain('ROF');
   });
 
   it('every entry has non-empty symbol, name, and desc', () => {

--- a/frontend/src/redcode/cheatSheet.ts
+++ b/frontend/src/redcode/cheatSheet.ts
@@ -72,4 +72,6 @@ export const PSEUDO_OPS: CheatEntry[] = [
   { symbol: 'ORG', name: 'origin', desc: 'Set the starting address label for execution.' },
   { symbol: 'END', name: 'end', desc: 'Marks end of source. Optional label sets start like ORG.' },
   { symbol: 'EQU', name: 'equate', desc: 'Define a named constant: `name EQU value`.' },
+  { symbol: 'FOR', name: 'for loop', desc: 'Repeat block N times: `FOR count` … `ROF`.' },
+  { symbol: 'ROF', name: 'end for', desc: 'Closes a FOR block.' },
 ];

--- a/frontend/src/redcode/monaco.ts
+++ b/frontend/src/redcode/monaco.ts
@@ -1,34 +1,20 @@
 import type * as MonacoNs from 'monaco-editor';
+import { OPCODES, MODIFIERS, ADDRESSING_MODES, PSEUDO_OPS, type CheatEntry } from './cheatSheet';
 
 export const REDCODE_LANGUAGE_ID = 'redcode';
 
-const OPCODES = [
-  'DAT',
-  'MOV',
-  'ADD',
-  'SUB',
-  'MUL',
-  'DIV',
-  'MOD',
-  'JMP',
-  'JMZ',
-  'JMN',
-  'DJN',
-  'SPL',
-  'SEQ',
-  'SNE',
-  'SLT',
-  'NOP',
-  'CMP',
-];
+const OPCODE_SYMBOLS = [...OPCODES.map((e) => e.symbol), 'CMP'];
+const PSEUDO_SYMBOLS = PSEUDO_OPS.map((e) => e.symbol);
 
-const PSEUDO = ['ORG', 'END', 'EQU'];
+let providersRegistered = false;
 
 export function registerRedcode(monaco: typeof MonacoNs): void {
   const langs = monaco.languages.getLanguages();
-  if (langs.some((l) => l.id === REDCODE_LANGUAGE_ID)) return;
+  const alreadyRegistered = langs.some((l) => l.id === REDCODE_LANGUAGE_ID);
 
-  monaco.languages.register({ id: REDCODE_LANGUAGE_ID });
+  if (!alreadyRegistered) {
+    monaco.languages.register({ id: REDCODE_LANGUAGE_ID });
+  }
 
   monaco.languages.setLanguageConfiguration(REDCODE_LANGUAGE_ID, {
     comments: { lineComment: ';' },
@@ -40,8 +26,8 @@ export function registerRedcode(monaco: typeof MonacoNs): void {
   monaco.languages.setMonarchTokensProvider(REDCODE_LANGUAGE_ID, {
     ignoreCase: true,
     defaultToken: '',
-    opcodes: OPCODES,
-    pseudo: PSEUDO,
+    opcodes: OPCODE_SYMBOLS,
+    pseudo: PSEUDO_SYMBOLS,
     tokenizer: {
       root: [
         [/;.*$/, 'comment'],
@@ -84,6 +70,131 @@ export function registerRedcode(monaco: typeof MonacoNs): void {
       'editorCursor.foreground': '#e94560',
       'editor.selectionBackground': '#4fc3f733',
       'editor.lineHighlightBackground': '#1a1a1a',
+    },
+  });
+
+  if (!providersRegistered) {
+    registerCompletionProvider(monaco);
+    registerHoverProvider(monaco);
+    providersRegistered = true;
+  }
+}
+
+function entryToCompletion(
+  monaco: typeof MonacoNs,
+  entry: CheatEntry,
+  kind: MonacoNs.languages.CompletionItemKind,
+  range: MonacoNs.IRange,
+): MonacoNs.languages.CompletionItem {
+  return {
+    label: entry.symbol,
+    kind,
+    detail: entry.name,
+    documentation: entry.desc,
+    insertText: entry.symbol,
+    range,
+  };
+}
+
+function registerCompletionProvider(monaco: typeof MonacoNs): void {
+  monaco.languages.registerCompletionItemProvider(REDCODE_LANGUAGE_ID, {
+    triggerCharacters: ['.', '#', '$', '@', '*', '<', '>', '{', '}'],
+    provideCompletionItems(model, position) {
+      const word = model.getWordUntilPosition(position);
+      const range: MonacoNs.IRange = {
+        startLineNumber: position.lineNumber,
+        startColumn: word.startColumn,
+        endLineNumber: position.lineNumber,
+        endColumn: word.endColumn,
+      };
+
+      const lineContent = model.getLineContent(position.lineNumber);
+      const charBefore = lineContent[position.column - 2] ?? '';
+
+      if (charBefore === '.') {
+        const dotRange: MonacoNs.IRange = {
+          ...range,
+          startColumn: position.column - 1,
+        };
+        return {
+          suggestions: MODIFIERS.map((m) =>
+            entryToCompletion(monaco, m, monaco.languages.CompletionItemKind.Enum, dotRange),
+          ),
+        };
+      }
+
+      const suggestions: MonacoNs.languages.CompletionItem[] = [
+        ...OPCODES.map((e) =>
+          entryToCompletion(monaco, e, monaco.languages.CompletionItemKind.Keyword, range),
+        ),
+        ...PSEUDO_OPS.map((e) =>
+          entryToCompletion(monaco, e, monaco.languages.CompletionItemKind.Function, range),
+        ),
+        ...ADDRESSING_MODES.map((e) =>
+          entryToCompletion(monaco, e, monaco.languages.CompletionItemKind.Operator, range),
+        ),
+      ];
+
+      return { suggestions };
+    },
+  });
+}
+
+function registerHoverProvider(monaco: typeof MonacoNs): void {
+  const lookup = new Map<string, CheatEntry>();
+  for (const list of [OPCODES, PSEUDO_OPS]) {
+    for (const e of list) lookup.set(e.symbol.toUpperCase(), e);
+  }
+
+  monaco.languages.registerHoverProvider(REDCODE_LANGUAGE_ID, {
+    provideHover(model, position) {
+      const word = model.getWordAtPosition(position);
+      if (word) {
+        const entry = lookup.get(word.word.toUpperCase());
+        if (entry) {
+          return {
+            range: new monaco.Range(
+              position.lineNumber,
+              word.startColumn,
+              position.lineNumber,
+              word.endColumn,
+            ),
+            contents: [{ value: `**${entry.symbol}** — ${entry.name}` }, { value: entry.desc }],
+          };
+        }
+      }
+
+      const lineContent = model.getLineContent(position.lineNumber);
+      const col = position.column - 1;
+
+      for (const mode of ADDRESSING_MODES) {
+        if (lineContent[col] === mode.symbol) {
+          return {
+            range: new monaco.Range(position.lineNumber, col + 1, position.lineNumber, col + 2),
+            contents: [{ value: `**${mode.symbol}** — ${mode.name}` }, { value: mode.desc }],
+          };
+        }
+      }
+
+      const dotMatch = lineContent.substring(0, position.column).match(/\.([A-Za-z]+)$/);
+      if (dotMatch) {
+        const modSym = '.' + dotMatch[1].toUpperCase();
+        const mod = MODIFIERS.find((m) => m.symbol === modSym);
+        if (mod) {
+          const start = col - dotMatch[0].length + 1;
+          return {
+            range: new monaco.Range(
+              position.lineNumber,
+              start + 1,
+              position.lineNumber,
+              start + dotMatch[0].length + 1,
+            ),
+            contents: [{ value: `**${mod.symbol}** — ${mod.name}` }, { value: mod.desc }],
+          };
+        }
+      }
+
+      return null;
     },
   });
 }


### PR DESCRIPTION
## Summary
- **Autocomplete**: Monaco CompletionItemProvider for all Redcode opcodes, modifiers (triggered on `.`), addressing modes, and pseudo-ops (including FOR/ROF) with detail text and descriptions from the cheat sheet
- **Hover documentation**: HoverProvider shows name and description when hovering over opcodes, pseudo-ops, modifiers (`.I`, `.F`, etc.), and addressing mode symbols (`#`, `$`, `@`, etc.)
- **Import/Export**: Toolbar buttons to export current warrior as `.red` file and import `.red`/`.rd` files as new warriors (with server persistence when authenticated)
- **Cheat sheet update**: Added FOR/ROF pseudo-ops to cheat sheet data and tests

## Test plan
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] All 49 frontend tests pass (`vitest run`)
- [x] Production build succeeds (`npm run build`)
- [x] Autocomplete verified via Playwright — suggestions popup shows opcodes, addressing modes with descriptions
- [x] Hover verified via Playwright — MOV shows "**MOV** — move / Copy source to destination."
- [x] Export and Import buttons render in toolbar
- [x] Cheat sheet tests updated to verify FOR/ROF entries

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)