### PR TITLE
Add battlefield inspector: cell details and process list (issue #37)

### DIFF
--- a/frontend/src/pages/battlefield/BattlefieldPage.tsx
+++ b/frontend/src/pages/battlefield/BattlefieldPage.tsx
@@ -2,13 +2,25 @@ import { useBattle } from './useBattle';
 import WarriorSelector from './WarriorSelector';
 import BattleControls from './BattleControls';
 import BattleStatus from './BattleStatus';
-import {
-  GRID_CONTAINER_STYLE,
-  PARSE_ERROR_STYLE,
-  ROOT_STYLE,
-  TITLE_STYLE,
-  TOOLTIP_STYLE,
-} from './styles';
+import InspectorPanel from './InspectorPanel';
+import { GRID_CONTAINER_STYLE, PARSE_ERROR_STYLE, TITLE_STYLE, TOOLTIP_STYLE } from './styles';
+
+const PAGE_STYLE: React.CSSProperties = {
+  display: 'flex',
+  height: '100vh',
+  minHeight: 0,
+};
+
+const MAIN_STYLE: React.CSSProperties = {
+  flex: 1,
+  minWidth: 0,
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  padding: '1.5rem',
+  gap: '1rem',
+  overflow: 'auto',
+};
 
 export default function BattlefieldPage() {
   const {
@@ -23,11 +35,15 @@ export default function BattlefieldPage() {
     redId,
     blueId,
     warriors,
+    processes,
+    selectedCell,
+    setSelectedCell,
     parseError,
     presets,
     userWarriors,
     gridRef,
     tooltipRef,
+    matchRef,
     play,
     pause,
     stepOnce,
@@ -36,50 +52,62 @@ export default function BattlefieldPage() {
     handlePickChange,
     handleGridMouseMove,
     handleGridMouseLeave,
+    handleGridClick,
   } = useBattle();
 
   return (
-    <div style={ROOT_STYLE}>
-      <h1 style={TITLE_STYLE}>CORE WAR</h1>
+    <div style={PAGE_STYLE}>
+      <div style={MAIN_STYLE}>
+        <h1 style={TITLE_STYLE}>CORE WAR</h1>
 
-      <WarriorSelector
-        redId={redId}
-        blueId={blueId}
-        presets={presets}
-        userWarriors={userWarriors}
-        onPickChange={handlePickChange}
-      />
+        <WarriorSelector
+          redId={redId}
+          blueId={blueId}
+          presets={presets}
+          userWarriors={userWarriors}
+          onPickChange={handlePickChange}
+        />
 
-      {parseError && <div style={PARSE_ERROR_STYLE}>{parseError}</div>}
+        {parseError && <div style={PARSE_ERROR_STYLE}>{parseError}</div>}
 
-      <div
-        ref={gridRef}
-        style={GRID_CONTAINER_STYLE}
-        onMouseMove={handleGridMouseMove}
-        onMouseLeave={handleGridMouseLeave}
-      >
-        <div ref={tooltipRef} style={TOOLTIP_STYLE} />
+        <div
+          ref={gridRef}
+          style={GRID_CONTAINER_STYLE}
+          onMouseMove={handleGridMouseMove}
+          onMouseLeave={handleGridMouseLeave}
+          onClick={handleGridClick}
+        >
+          <div ref={tooltipRef} style={TOOLTIP_STYLE} />
+        </div>
+
+        <BattleControls
+          running={running}
+          resultCode={resultCode}
+          stepsPerFrame={stepsPerFrame}
+          setStepsPerFrame={setStepsPerFrame}
+          spfRef={spfRef}
+          play={play}
+          pause={pause}
+          stepOnce={stepOnce}
+          stepMany={stepMany}
+          reset={reset}
+        />
+
+        <BattleStatus
+          ready={ready}
+          stepCount={stepCount}
+          warriors={warriors}
+          resultCode={resultCode}
+          resultWinner={resultWinner}
+        />
       </div>
 
-      <BattleControls
-        running={running}
-        resultCode={resultCode}
-        stepsPerFrame={stepsPerFrame}
-        setStepsPerFrame={setStepsPerFrame}
-        spfRef={spfRef}
-        play={play}
-        pause={pause}
-        stepOnce={stepOnce}
-        stepMany={stepMany}
-        reset={reset}
-      />
-
-      <BattleStatus
-        ready={ready}
-        stepCount={stepCount}
-        warriors={warriors}
-        resultCode={resultCode}
-        resultWinner={resultWinner}
+      <InspectorPanel
+        selectedCell={selectedCell}
+        match={matchRef.current}
+        warriors={processes}
+        onCellSelect={setSelectedCell}
+        onClearCell={() => setSelectedCell(null)}
       />
     </div>
   );

--- a/frontend/src/pages/battlefield/BattlefieldPage.tsx
+++ b/frontend/src/pages/battlefield/BattlefieldPage.tsx
@@ -36,14 +36,12 @@ export default function BattlefieldPage() {
     blueId,
     warriors,
     processes,
-    selectedCell,
-    setSelectedCell,
+    cellInfo,
     parseError,
     presets,
     userWarriors,
     gridRef,
     tooltipRef,
-    matchRef,
     play,
     pause,
     stepOnce,
@@ -53,6 +51,8 @@ export default function BattlefieldPage() {
     handleGridMouseMove,
     handleGridMouseLeave,
     handleGridClick,
+    selectCell,
+    clearCell,
   } = useBattle();
 
   return (
@@ -103,11 +103,10 @@ export default function BattlefieldPage() {
       </div>
 
       <InspectorPanel
-        selectedCell={selectedCell}
-        match={matchRef.current}
+        cellInfo={cellInfo}
         warriors={processes}
-        onCellSelect={setSelectedCell}
-        onClearCell={() => setSelectedCell(null)}
+        onCellSelect={selectCell}
+        onClearCell={clearCell}
       />
     </div>
   );

--- a/frontend/src/pages/battlefield/InspectorPanel.tsx
+++ b/frontend/src/pages/battlefield/InspectorPanel.tsx
@@ -1,0 +1,251 @@
+import type { MatchState } from 'core-war-engine';
+import { formatInstruction } from '../../core/redcodeFormat';
+import { WARRIOR_HEX } from './styles';
+
+type CellInfo = {
+  addr: number;
+  opcode: number;
+  modifier: number;
+  aMode: number;
+  aValue: number;
+  bMode: number;
+  bValue: number;
+  owner: number;
+};
+
+type ProcessInfo = {
+  warriorIdx: number;
+  name: string;
+  alive: boolean;
+  pcs: number[];
+};
+
+type Props = {
+  selectedCell: number | null;
+  match: MatchState | null;
+  warriors: ProcessInfo[];
+  onCellSelect: (addr: number) => void;
+  onClearCell: () => void;
+};
+
+const PANEL_STYLE: React.CSSProperties = {
+  width: '260px',
+  flexShrink: 0,
+  borderLeft: '1px solid #222',
+  backgroundColor: '#0d0d0d',
+  display: 'flex',
+  flexDirection: 'column',
+  overflow: 'auto',
+  fontSize: '0.8rem',
+};
+
+const SECTION_HEADER_STYLE: React.CSSProperties = {
+  padding: '0.5rem 0.75rem',
+  fontSize: '0.7rem',
+  letterSpacing: '0.1em',
+  color: '#666',
+  textTransform: 'uppercase',
+  borderBottom: '1px solid #222',
+  backgroundColor: '#111',
+};
+
+const CELL_DETAIL_STYLE: React.CSSProperties = {
+  padding: '0.5rem 0.75rem',
+  borderBottom: '1px solid #222',
+};
+
+const ROW_STYLE: React.CSSProperties = {
+  display: 'flex',
+  justifyContent: 'space-between',
+  padding: '0.15rem 0',
+};
+
+const LABEL_STYLE: React.CSSProperties = {
+  color: '#666',
+};
+
+const VALUE_STYLE: React.CSSProperties = {
+  color: '#e0e0e0',
+};
+
+const INSTR_STYLE: React.CSSProperties = {
+  color: '#e94560',
+  fontWeight: 600,
+  fontSize: '0.85rem',
+  padding: '0.3rem 0',
+};
+
+const CLEAR_BUTTON_STYLE: React.CSSProperties = {
+  background: 'none',
+  border: 'none',
+  color: '#666',
+  cursor: 'pointer',
+  fontSize: '0.75rem',
+  padding: 0,
+};
+
+const PROCESS_ITEM_STYLE: React.CSSProperties = {
+  padding: '0.15rem 0.75rem',
+  cursor: 'pointer',
+  fontSize: '0.75rem',
+};
+
+const EMPTY_STYLE: React.CSSProperties = {
+  padding: '0.5rem 0.75rem',
+  color: '#555',
+  fontStyle: 'italic',
+};
+
+const OPCODE_NAMES = [
+  'DAT',
+  'MOV',
+  'ADD',
+  'SUB',
+  'MUL',
+  'DIV',
+  'MOD',
+  'JMP',
+  'JMZ',
+  'JMN',
+  'DJN',
+  'SPL',
+  'SLT',
+  'SEQ',
+  'SNE',
+  'NOP',
+];
+
+const MODIFIER_NAMES = ['A', 'B', 'AB', 'BA', 'F', 'X', 'I'];
+
+const MODE_NAMES = [
+  'Immediate (#)',
+  'Direct ($)',
+  'A-Indirect (*)',
+  'B-Indirect (@)',
+  'A-Predec ({)',
+  'B-Predec (<)',
+  'A-Postinc (})',
+  'B-Postinc (>)',
+];
+
+function readCell(match: MatchState, addr: number): CellInfo {
+  return {
+    addr,
+    opcode: match.cellOpcode(addr),
+    modifier: match.cellModifier(addr),
+    aMode: match.cellAMode(addr),
+    aValue: match.cellAValue(addr),
+    bMode: match.cellBMode(addr),
+    bValue: match.cellBValue(addr),
+    owner: match.coreOwnership()[addr] ?? 0,
+  };
+}
+
+function CellDetail({ cell, onClear }: { cell: CellInfo; onClear: () => void }) {
+  const ownerLabel = cell.owner === 0 ? 'None' : `Warrior ${cell.owner - 1}`;
+  const ownerColor = WARRIOR_HEX[cell.owner] ?? '#888';
+
+  return (
+    <div style={CELL_DETAIL_STYLE}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <span style={{ color: '#4fc3f7' }}>#{String(cell.addr).padStart(4, '0')}</span>
+        <button style={CLEAR_BUTTON_STYLE} onClick={onClear}>
+          clear
+        </button>
+      </div>
+      <div style={INSTR_STYLE}>
+        {formatInstruction(
+          cell.opcode,
+          cell.modifier,
+          cell.aMode,
+          cell.aValue,
+          cell.bMode,
+          cell.bValue,
+        )}
+      </div>
+      <div style={ROW_STYLE}>
+        <span style={LABEL_STYLE}>Opcode</span>
+        <span style={VALUE_STYLE}>{OPCODE_NAMES[cell.opcode] ?? '???'}</span>
+      </div>
+      <div style={ROW_STYLE}>
+        <span style={LABEL_STYLE}>Modifier</span>
+        <span style={VALUE_STYLE}>.{MODIFIER_NAMES[cell.modifier] ?? '?'}</span>
+      </div>
+      <div style={ROW_STYLE}>
+        <span style={LABEL_STYLE}>A-mode</span>
+        <span style={VALUE_STYLE}>{MODE_NAMES[cell.aMode] ?? '?'}</span>
+      </div>
+      <div style={ROW_STYLE}>
+        <span style={LABEL_STYLE}>A-value</span>
+        <span style={VALUE_STYLE}>{cell.aValue}</span>
+      </div>
+      <div style={ROW_STYLE}>
+        <span style={LABEL_STYLE}>B-mode</span>
+        <span style={VALUE_STYLE}>{MODE_NAMES[cell.bMode] ?? '?'}</span>
+      </div>
+      <div style={ROW_STYLE}>
+        <span style={LABEL_STYLE}>B-value</span>
+        <span style={VALUE_STYLE}>{cell.bValue}</span>
+      </div>
+      <div style={ROW_STYLE}>
+        <span style={LABEL_STYLE}>Owner</span>
+        <span style={{ color: ownerColor }}>{ownerLabel}</span>
+      </div>
+    </div>
+  );
+}
+
+export default function InspectorPanel({
+  selectedCell,
+  match,
+  warriors,
+  onCellSelect,
+  onClearCell,
+}: Props) {
+  const cell = selectedCell !== null && match ? readCell(match, selectedCell) : null;
+
+  return (
+    <aside style={PANEL_STYLE}>
+      <div style={SECTION_HEADER_STYLE}>Cell Inspector</div>
+      {cell ? (
+        <CellDetail cell={cell} onClear={onClearCell} />
+      ) : (
+        <div style={EMPTY_STYLE}>Click a cell in the grid to inspect it.</div>
+      )}
+
+      <div style={SECTION_HEADER_STYLE}>Processes</div>
+      {warriors.map((w) => (
+        <div key={w.warriorIdx}>
+          <div
+            style={{
+              padding: '0.3rem 0.75rem',
+              color: WARRIOR_HEX[w.warriorIdx + 1],
+              fontWeight: 600,
+              fontSize: '0.75rem',
+              borderBottom: '1px solid #1a1a1a',
+            }}
+          >
+            {w.name} {w.alive ? `(${w.pcs.length} proc${w.pcs.length !== 1 ? 's' : ''})` : '(dead)'}
+          </div>
+          {w.alive &&
+            w.pcs.map((pc, i) => (
+              <div
+                key={i}
+                style={{
+                  ...PROCESS_ITEM_STYLE,
+                  color: selectedCell === pc ? '#e0e0e0' : '#888',
+                  backgroundColor: selectedCell === pc ? '#1a1a1a' : 'transparent',
+                }}
+                onClick={() => onCellSelect(pc)}
+                title={`Process ${i}: PC = ${pc}`}
+              >
+                [{i}] #{String(pc).padStart(4, '0')}
+              </div>
+            ))}
+        </div>
+      ))}
+    </aside>
+  );
+}
+
+export type { ProcessInfo };

--- a/frontend/src/pages/battlefield/InspectorPanel.tsx
+++ b/frontend/src/pages/battlefield/InspectorPanel.tsx
@@ -180,12 +180,7 @@ function CellDetail({ cell, onClear }: { cell: CellInfo; onClear: () => void }) 
   );
 }
 
-export default function InspectorPanel({
-  cellInfo,
-  warriors,
-  onCellSelect,
-  onClearCell,
-}: Props) {
+export default function InspectorPanel({ cellInfo, warriors, onCellSelect, onClearCell }: Props) {
   return (
     <aside style={PANEL_STYLE}>
       <div style={SECTION_HEADER_STYLE}>Cell Inspector</div>

--- a/frontend/src/pages/battlefield/InspectorPanel.tsx
+++ b/frontend/src/pages/battlefield/InspectorPanel.tsx
@@ -1,8 +1,7 @@
-import type { MatchState } from 'core-war-engine';
 import { formatInstruction } from '../../core/redcodeFormat';
 import { WARRIOR_HEX } from './styles';
 
-type CellInfo = {
+export type CellInfo = {
   addr: number;
   opcode: number;
   modifier: number;
@@ -21,8 +20,7 @@ type ProcessInfo = {
 };
 
 type Props = {
-  selectedCell: number | null;
-  match: MatchState | null;
+  cellInfo: CellInfo | null;
   warriors: ProcessInfo[];
   onCellSelect: (addr: number) => void;
   onClearCell: () => void;
@@ -128,19 +126,6 @@ const MODE_NAMES = [
   'B-Postinc (>)',
 ];
 
-function readCell(match: MatchState, addr: number): CellInfo {
-  return {
-    addr,
-    opcode: match.cellOpcode(addr),
-    modifier: match.cellModifier(addr),
-    aMode: match.cellAMode(addr),
-    aValue: match.cellAValue(addr),
-    bMode: match.cellBMode(addr),
-    bValue: match.cellBValue(addr),
-    owner: match.coreOwnership()[addr] ?? 0,
-  };
-}
-
 function CellDetail({ cell, onClear }: { cell: CellInfo; onClear: () => void }) {
   const ownerLabel = cell.owner === 0 ? 'None' : `Warrior ${cell.owner - 1}`;
   const ownerColor = WARRIOR_HEX[cell.owner] ?? '#888';
@@ -196,19 +181,16 @@ function CellDetail({ cell, onClear }: { cell: CellInfo; onClear: () => void }) 
 }
 
 export default function InspectorPanel({
-  selectedCell,
-  match,
+  cellInfo,
   warriors,
   onCellSelect,
   onClearCell,
 }: Props) {
-  const cell = selectedCell !== null && match ? readCell(match, selectedCell) : null;
-
   return (
     <aside style={PANEL_STYLE}>
       <div style={SECTION_HEADER_STYLE}>Cell Inspector</div>
-      {cell ? (
-        <CellDetail cell={cell} onClear={onClearCell} />
+      {cellInfo ? (
+        <CellDetail cell={cellInfo} onClear={onClearCell} />
       ) : (
         <div style={EMPTY_STYLE}>Click a cell in the grid to inspect it.</div>
       )}
@@ -233,8 +215,8 @@ export default function InspectorPanel({
                 key={i}
                 style={{
                   ...PROCESS_ITEM_STYLE,
-                  color: selectedCell === pc ? '#e0e0e0' : '#888',
-                  backgroundColor: selectedCell === pc ? '#1a1a1a' : 'transparent',
+                  color: cellInfo?.addr === pc ? '#e0e0e0' : '#888',
+                  backgroundColor: cellInfo?.addr === pc ? '#1a1a1a' : 'transparent',
                 }}
                 onClick={() => onCellSelect(pc)}
                 title={`Process ${i}: PC = ${pc}`}

--- a/frontend/src/pages/battlefield/useBattle.ts
+++ b/frontend/src/pages/battlefield/useBattle.ts
@@ -25,6 +25,10 @@ export function useBattle() {
   const [redId, setRedId] = useState(() => pickInitial(library, searchParams.get('red'), 0));
   const [blueId, setBlueId] = useState(() => pickInitial(library, searchParams.get('blue'), 1));
   const [warriors, setWarriors] = useState<{ name: string; alive: boolean; procs: number }[]>([]);
+  const [processes, setProcesses] = useState<
+    { warriorIdx: number; name: string; alive: boolean; pcs: number[] }[]
+  >([]);
+  const [selectedCell, setSelectedCell] = useState<number | null>(null);
   const [parseError, setParseError] = useState<string | null>(null);
 
   const gridRef = useRef<HTMLDivElement>(null);
@@ -88,6 +92,14 @@ export function useBattle() {
     if (tip) tip.style.display = 'none';
   }, []);
 
+  const handleGridClick = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+    const rect = e.currentTarget.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
+    const addr = cellAddressAtPixel(x, y);
+    if (addr >= 0) setSelectedCell(addr);
+  }, []);
+
   useEffect(() => {
     if (!gridRef.current) return;
     const renderer = createCoreRenderer(gridRef.current);
@@ -136,9 +148,14 @@ export function useBattle() {
       setStepCount(0);
       setResultCode(ONGOING);
       setResultWinner(-1);
+      const names = warriorNamesRef.current;
       setWarriors([
-        { name: warriorNamesRef.current[0], alive: true, procs: 1 },
-        { name: warriorNamesRef.current[1], alive: true, procs: 1 },
+        { name: names[0], alive: true, procs: 1 },
+        { name: names[1], alive: true, procs: 1 },
+      ]);
+      setProcesses([
+        { warriorIdx: 0, name: names[0], alive: true, pcs: Array.from(match.warriorProcessPcs(0)) },
+        { warriorIdx: 1, name: names[1], alive: true, pcs: Array.from(match.warriorProcessPcs(1)) },
       ]);
     },
     [libraryById],
@@ -166,15 +183,17 @@ export function useBattle() {
     setResultCode(code);
     setResultWinner(m.resultWinnerId());
     const ws: { name: string; alive: boolean; procs: number }[] = [];
+    const ps: { warriorIdx: number; name: string; alive: boolean; pcs: number[] }[] = [];
     const names = warriorNamesRef.current;
     for (let i = 0; i < m.warriorCount(); i++) {
-      ws.push({
-        name: names[i] ?? `Warrior ${m.warriorId(i)}`,
-        alive: m.warriorIsAlive(i),
-        procs: m.warriorProcessCount(i),
-      });
+      const alive = m.warriorIsAlive(i);
+      const name = names[i] ?? `Warrior ${m.warriorId(i)}`;
+      ws.push({ name, alive, procs: m.warriorProcessCount(i) });
+      const pcsArray = alive ? Array.from(m.warriorProcessPcs(i)) : [];
+      ps.push({ warriorIdx: i, name, alive, pcs: pcsArray });
     }
     setWarriors(ws);
+    setProcesses(ps);
   }, []);
 
   const tickRef = useRef<() => void>(() => {});
@@ -240,6 +259,7 @@ export function useBattle() {
   const reset = useCallback(() => {
     cancelAnimationFrame(rafRef.current);
     setRunning(false);
+    setSelectedCell(null);
     loadBattle(redId, blueId);
   }, [loadBattle, redId, blueId]);
 
@@ -268,11 +288,15 @@ export function useBattle() {
     redId,
     blueId,
     warriors,
+    processes,
+    selectedCell,
+    setSelectedCell,
     parseError,
     presets,
     userWarriors,
     gridRef,
     tooltipRef,
+    matchRef,
     play,
     pause,
     stepOnce,
@@ -281,5 +305,6 @@ export function useBattle() {
     handlePickChange,
     handleGridMouseMove,
     handleGridMouseLeave,
+    handleGridClick,
   };
 }

--- a/frontend/src/pages/battlefield/useBattle.ts
+++ b/frontend/src/pages/battlefield/useBattle.ts
@@ -6,6 +6,20 @@ import { cellAddressAtPixel, formatCellTooltip } from '../../core/redcodeFormat'
 import { CORE_SIZE } from '../../core/constants';
 import { useWarriorLibrary, type Warrior } from '../../warriors/library';
 import { ONGOING } from './styles';
+import type { CellInfo } from './InspectorPanel';
+
+function readCellFromMatch(match: MatchState, addr: number): CellInfo {
+  return {
+    addr,
+    opcode: match.cellOpcode(addr),
+    modifier: match.cellModifier(addr),
+    aMode: match.cellAMode(addr),
+    aValue: match.cellAValue(addr),
+    bMode: match.cellBMode(addr),
+    bValue: match.cellBValue(addr),
+    owner: match.coreOwnership()[addr] ?? 0,
+  };
+}
 
 function pickInitial(library: Warrior[], queryId: string | null, fallbackIdx: number): string {
   if (queryId && library.some((w) => w.id === queryId)) return queryId;
@@ -29,6 +43,7 @@ export function useBattle() {
     { warriorIdx: number; name: string; alive: boolean; pcs: number[] }[]
   >([]);
   const [selectedCell, setSelectedCell] = useState<number | null>(null);
+  const [cellInfo, setCellInfo] = useState<CellInfo | null>(null);
   const [parseError, setParseError] = useState<string | null>(null);
 
   const gridRef = useRef<HTMLDivElement>(null);
@@ -97,7 +112,10 @@ export function useBattle() {
     const x = e.clientX - rect.left;
     const y = e.clientY - rect.top;
     const addr = cellAddressAtPixel(x, y);
-    if (addr >= 0) setSelectedCell(addr);
+    if (addr >= 0) {
+      setSelectedCell(addr);
+      if (matchRef.current) setCellInfo(readCellFromMatch(matchRef.current, addr));
+    }
   }, []);
 
   useEffect(() => {
@@ -194,6 +212,10 @@ export function useBattle() {
     }
     setWarriors(ws);
     setProcesses(ps);
+    setSelectedCell((prev) => {
+      if (prev !== null) setCellInfo(readCellFromMatch(m, prev));
+      return prev;
+    });
   }, []);
 
   const tickRef = useRef<() => void>(() => {});
@@ -260,6 +282,7 @@ export function useBattle() {
     cancelAnimationFrame(rafRef.current);
     setRunning(false);
     setSelectedCell(null);
+    setCellInfo(null);
     loadBattle(redId, blueId);
   }, [loadBattle, redId, blueId]);
 
@@ -276,6 +299,16 @@ export function useBattle() {
     [loadBattle, redId, blueId],
   );
 
+  const selectCell = useCallback((addr: number) => {
+    setSelectedCell(addr);
+    if (matchRef.current) setCellInfo(readCellFromMatch(matchRef.current, addr));
+  }, []);
+
+  const clearCell = useCallback(() => {
+    setSelectedCell(null);
+    setCellInfo(null);
+  }, []);
+
   return {
     ready,
     running,
@@ -290,13 +323,12 @@ export function useBattle() {
     warriors,
     processes,
     selectedCell,
-    setSelectedCell,
+    cellInfo,
     parseError,
     presets,
     userWarriors,
     gridRef,
     tooltipRef,
-    matchRef,
     play,
     pause,
     stepOnce,
@@ -306,5 +338,7 @@ export function useBattle() {
     handleGridMouseMove,
     handleGridMouseLeave,
     handleGridClick,
+    selectCell,
+    clearCell,
   };
 }


### PR DESCRIPTION
## Summary
- **Cell inspector**: Click any cell in the PixiJS grid to pin its details in the right panel — shows full instruction breakdown (opcode, modifier, A/B addressing modes, A/B values, cell ownership)
- **Process list**: Live display of each warrior's active process PCs with count, updated on every UI sync tick. Click a process PC to jump the cell inspector to that address
- **Layout refactor**: Battlefield page changed from vertical stack to horizontal split (main area + 260px inspector panel) matching the builder page pattern

## Test plan
- [x] TypeScript compiles cleanly
- [x] All 49 frontend tests pass
- [x] Production build succeeds
- [x] Visually verified via Playwright: cell click shows correct MOV.I instruction details for Imp at #0000
- [x] Process PCs update correctly after stepping (Imp at #0051, Dwarf at #4002 after 100 steps)
- [x] Process list shows correct warrior names, colors, and proc counts

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)