### PR TITLE
Add server-side match validation with engine integration (issue #33)

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -286,6 +286,7 @@ dependencies = [
  "axum",
  "axum-extra",
  "chrono",
+ "core-war-engine",
  "dotenvy",
  "hex",
  "http-body-util",
@@ -303,6 +304,13 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+]
+
+[[package]]
+name = "core-war-engine"
+version = "0.1.0"
+dependencies = [
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -24,6 +24,7 @@ hex = "0.4"
 axum-extra = { version = "0.9", features = ["cookie"] }
 time = "0.3"
 async-trait = "0.1"
+core-war-engine = { path = "../engine" }
 
 [dev-dependencies]
 http-body-util = "0.1"

--- a/backend/migrations/20260511000001_create_matches.sql
+++ b/backend/migrations/20260511000001_create_matches.sql
@@ -1,0 +1,15 @@
+CREATE TABLE matches (
+    id              UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    red_warrior_id  UUID        NOT NULL REFERENCES warriors(id) ON DELETE CASCADE,
+    blue_warrior_id UUID        NOT NULL REFERENCES warriors(id) ON DELETE CASCADE,
+    red_user_id     UUID        NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    blue_user_id    UUID        NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    core_size       INT         NOT NULL DEFAULT 8000,
+    max_steps       INT         NOT NULL DEFAULT 80000,
+    result          VARCHAR(16) NOT NULL CHECK (result IN ('red_win', 'blue_win', 'tie', 'all_dead')),
+    steps_taken     INT         NOT NULL,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_matches_red_user ON matches(red_user_id);
+CREATE INDEX idx_matches_blue_user ON matches(blue_user_id);

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -2,6 +2,7 @@ pub mod auth;
 pub mod config;
 pub mod db;
 pub mod errors;
+pub mod matches;
 mod models;
 pub mod warriors;
 

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,6 +1,6 @@
 use axum::http::{header, Method};
 use axum::{middleware, routing::get, routing::post, Json, Router};
-use core_war_backend::{auth, config::Config, db, warriors, AppConfig, AppState};
+use core_war_backend::{auth, config::Config, db, matches, warriors, AppConfig, AppState};
 use serde_json::{json, Value};
 use socketioxide::{extract::SocketRef, SocketIo};
 use std::net::SocketAddr;
@@ -93,6 +93,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .put(warriors::handlers::update)
                 .delete(warriors::handlers::delete),
         )
+        .route(
+            "/api/matches",
+            get(matches::handlers::list).post(matches::handlers::submit),
+        )
+        .route("/api/matches/:id", get(matches::handlers::get))
         .layer(middleware::from_fn_with_state(
             state.clone(),
             auth::middleware::csrf_middleware,

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,8 +1,6 @@
 use axum::http::{header, Method};
 use axum::{middleware, routing::get, routing::post, Json, Router};
-use core_war_backend::{
-    auth, config::Config, db, matches, profile, warriors, AppConfig, AppState,
-};
+use core_war_backend::{auth, config::Config, db, matches, profile, warriors, AppConfig, AppState};
 use serde_json::{json, Value};
 use socketioxide::{extract::SocketRef, SocketIo};
 use std::net::SocketAddr;

--- a/backend/src/matches/handlers.rs
+++ b/backend/src/matches/handlers.rs
@@ -1,0 +1,205 @@
+use crate::auth::middleware::AuthUser;
+use crate::errors::AppError;
+use crate::models::match_record::MatchRecord;
+use crate::models::warrior::Warrior;
+use crate::AppState;
+use axum::extract::{Path, Query, State};
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::Json;
+use core_war_engine::{parse_warrior, MatchResult, MatchState};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+const CORE_SIZE: usize = 8000;
+const MAX_STEPS: u64 = 80_000;
+
+#[derive(Deserialize)]
+pub struct SubmitMatchRequest {
+    pub red_warrior_id: Uuid,
+    pub blue_warrior_id: Uuid,
+}
+
+#[derive(Deserialize)]
+pub struct ListQuery {
+    pub page: Option<i64>,
+    pub per_page: Option<i64>,
+}
+
+#[derive(Serialize)]
+pub struct MatchListResponse {
+    pub matches: Vec<MatchRecord>,
+    pub total: i64,
+    pub page: i64,
+    pub per_page: i64,
+}
+
+const MAX_PAGE_SIZE: i64 = 100;
+const DEFAULT_PAGE_SIZE: i64 = 50;
+
+fn run_battle(red_source: &str, blue_source: &str) -> Result<(String, i32), AppError> {
+    let red = parse_warrior(red_source).map_err(|e| {
+        AppError::BadRequest(format!("Red warrior parse error: {e}"))
+    })?;
+    let blue = parse_warrior(blue_source).map_err(|e| {
+        AppError::BadRequest(format!("Blue warrior parse error: {e}"))
+    })?;
+
+    let mut m = MatchState::new(CORE_SIZE, MAX_STEPS);
+    m.load_warrior(0, &red, 0);
+    m.load_warrior(1, &blue, CORE_SIZE / 2);
+
+    while m.step() {}
+
+    let result_str = match m.result() {
+        MatchResult::Victory { winner_id: 0 } => "red_win",
+        MatchResult::Victory { .. } => "blue_win",
+        MatchResult::Tie => "tie",
+        MatchResult::AllDead => "all_dead",
+        MatchResult::Ongoing => unreachable!(),
+    };
+
+    Ok((result_str.to_string(), m.steps() as i32))
+}
+
+pub async fn submit(
+    State(state): State<AppState>,
+    user: AuthUser,
+    Json(body): Json<SubmitMatchRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    let red_warrior = sqlx::query_as::<_, Warrior>(
+        "SELECT id, user_id, name, source, created_at, updated_at \
+         FROM warriors WHERE id = $1",
+    )
+    .bind(body.red_warrior_id)
+    .fetch_optional(&state.db)
+    .await?
+    .ok_or_else(|| AppError::NotFound("Red warrior not found".into()))?;
+
+    let blue_warrior = sqlx::query_as::<_, Warrior>(
+        "SELECT id, user_id, name, source, created_at, updated_at \
+         FROM warriors WHERE id = $1",
+    )
+    .bind(body.blue_warrior_id)
+    .fetch_optional(&state.db)
+    .await?
+    .ok_or_else(|| AppError::NotFound("Blue warrior not found".into()))?;
+
+    if red_warrior.user_id != user.user_id && blue_warrior.user_id != user.user_id {
+        return Err(AppError::Forbidden(
+            "You must own at least one of the warriors".into(),
+        ));
+    }
+
+    let (result, steps_taken) = {
+        let red_src = red_warrior.source.clone();
+        let blue_src = blue_warrior.source.clone();
+        tokio::task::spawn_blocking(move || run_battle(&red_src, &blue_src))
+            .await
+            .map_err(|e| AppError::Internal(format!("Battle task failed: {e}")))?
+    }?;
+
+    let record = sqlx::query_as::<_, MatchRecord>(
+        "INSERT INTO matches \
+           (red_warrior_id, blue_warrior_id, red_user_id, blue_user_id, \
+            core_size, max_steps, result, steps_taken) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8) \
+         RETURNING *",
+    )
+    .bind(red_warrior.id)
+    .bind(blue_warrior.id)
+    .bind(red_warrior.user_id)
+    .bind(blue_warrior.user_id)
+    .bind(CORE_SIZE as i32)
+    .bind(MAX_STEPS as i32)
+    .bind(&result)
+    .bind(steps_taken)
+    .fetch_one(&state.db)
+    .await?;
+
+    Ok((StatusCode::CREATED, Json(record)))
+}
+
+pub async fn get(
+    State(state): State<AppState>,
+    _user: AuthUser,
+    Path(id): Path<Uuid>,
+) -> Result<Json<MatchRecord>, AppError> {
+    let record = sqlx::query_as::<_, MatchRecord>("SELECT * FROM matches WHERE id = $1")
+        .bind(id)
+        .fetch_optional(&state.db)
+        .await?
+        .ok_or_else(|| AppError::NotFound("Match not found".into()))?;
+
+    Ok(Json(record))
+}
+
+pub async fn list(
+    State(state): State<AppState>,
+    user: AuthUser,
+    Query(query): Query<ListQuery>,
+) -> Result<Json<MatchListResponse>, AppError> {
+    let page = query.page.unwrap_or(1).max(1);
+    let per_page = query
+        .per_page
+        .unwrap_or(DEFAULT_PAGE_SIZE)
+        .clamp(1, MAX_PAGE_SIZE);
+    let offset = (page - 1) * per_page;
+
+    let total = sqlx::query_scalar::<_, i64>(
+        "SELECT COUNT(*) FROM matches WHERE red_user_id = $1 OR blue_user_id = $1",
+    )
+    .bind(user.user_id)
+    .fetch_one(&state.db)
+    .await?;
+
+    let matches = sqlx::query_as::<_, MatchRecord>(
+        "SELECT * FROM matches \
+         WHERE red_user_id = $1 OR blue_user_id = $1 \
+         ORDER BY created_at DESC \
+         LIMIT $2 OFFSET $3",
+    )
+    .bind(user.user_id)
+    .bind(per_page)
+    .bind(offset)
+    .fetch_all(&state.db)
+    .await?;
+
+    Ok(Json(MatchListResponse {
+        matches,
+        total,
+        page,
+        per_page,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn run_battle_imp_vs_imp_ties() {
+        let imp = "MOV.I $0, $1";
+        let (result, steps) = run_battle(imp, imp).unwrap();
+        assert_eq!(result, "tie");
+        assert_eq!(steps, MAX_STEPS as i32);
+    }
+
+    #[test]
+    fn run_battle_completes_with_valid_result() {
+        let dwarf = ";name Dwarf\n  ORG start\nstart ADD.AB #4, bomb\n  MOV.I bomb, @bomb\n  JMP start\nbomb DAT.F #0, #0";
+        let imp = "MOV.I $0, $1";
+        let (result, steps) = run_battle(dwarf, imp).unwrap();
+        assert!(
+            ["red_win", "blue_win", "tie", "all_dead"].contains(&result.as_str()),
+            "unexpected result: {result}"
+        );
+        assert!(steps > 0);
+    }
+
+    #[test]
+    fn run_battle_invalid_source() {
+        let result = run_battle("INVALID NONSENSE", "MOV.I $0, $1");
+        assert!(result.is_err());
+    }
+}

--- a/backend/src/matches/handlers.rs
+++ b/backend/src/matches/handlers.rs
@@ -38,12 +38,10 @@ const MAX_PAGE_SIZE: i64 = 100;
 const DEFAULT_PAGE_SIZE: i64 = 50;
 
 fn run_battle(red_source: &str, blue_source: &str) -> Result<(String, i32), AppError> {
-    let red = parse_warrior(red_source).map_err(|e| {
-        AppError::BadRequest(format!("Red warrior parse error: {e}"))
-    })?;
-    let blue = parse_warrior(blue_source).map_err(|e| {
-        AppError::BadRequest(format!("Blue warrior parse error: {e}"))
-    })?;
+    let red = parse_warrior(red_source)
+        .map_err(|e| AppError::BadRequest(format!("Red warrior parse error: {e}")))?;
+    let blue = parse_warrior(blue_source)
+        .map_err(|e| AppError::BadRequest(format!("Blue warrior parse error: {e}")))?;
 
     let mut m = MatchState::new(CORE_SIZE, MAX_STEPS);
     m.load_warrior(0, &red, 0);

--- a/backend/src/matches/mod.rs
+++ b/backend/src/matches/mod.rs
@@ -1,0 +1,1 @@
+pub mod handlers;

--- a/backend/src/models/match_record.rs
+++ b/backend/src/models/match_record.rs
@@ -1,0 +1,17 @@
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use uuid::Uuid;
+
+#[derive(Debug, sqlx::FromRow, Serialize)]
+pub struct MatchRecord {
+    pub id: Uuid,
+    pub red_warrior_id: Uuid,
+    pub blue_warrior_id: Uuid,
+    pub red_user_id: Uuid,
+    pub blue_user_id: Uuid,
+    pub core_size: i32,
+    pub max_steps: i32,
+    pub result: String,
+    pub steps_taken: i32,
+    pub created_at: DateTime<Utc>,
+}

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -1,2 +1,3 @@
+pub mod match_record;
 pub mod user;
 pub mod warrior;


### PR DESCRIPTION
## Summary
- Adds `matches` table with migration tracking red/blue warrior IDs, user IDs, core config, result, and step count
- Implements `POST /api/matches` endpoint that fetches both warriors, runs the engine via `spawn_blocking`, and persists the result
- Implements `GET /api/matches/:id` and `GET /api/matches` (paginated, filtered to user's matches)
- Uses `core-war-engine` as a native Rust crate dependency for server-side battle execution
- Authorization check: submitting user must own at least one of the warriors
- Unit tests for `run_battle` covering imp-vs-imp tie, valid battle completion, and parse error handling

## Test plan
- [x] `cargo test` passes all 90 unit tests + 20 integration tests
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [ ] Verify match submission with valid warrior IDs returns correct result
- [ ] Verify match submission with invalid warrior ID returns 404
- [ ] Verify match listing is filtered to authenticated user's matches

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)