### PR TITLE
Add user profile dashboard and public profiles (issue #32)

### DIFF
--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -3,6 +3,7 @@ pub mod config;
 pub mod db;
 pub mod errors;
 mod models;
+pub mod profile;
 pub mod warriors;
 
 use sqlx::PgPool;

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,6 +1,6 @@
 use axum::http::{header, Method};
 use axum::{middleware, routing::get, routing::post, Json, Router};
-use core_war_backend::{auth, config::Config, db, warriors, AppConfig, AppState};
+use core_war_backend::{auth, config::Config, db, profile, warriors, AppConfig, AppState};
 use serde_json::{json, Value};
 use socketioxide::{extract::SocketRef, SocketIo};
 use std::net::SocketAddr;
@@ -92,6 +92,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             get(warriors::handlers::get)
                 .put(warriors::handlers::update)
                 .delete(warriors::handlers::delete),
+        )
+        .route("/api/profile", get(profile::handlers::me))
+        .route(
+            "/api/users/:username",
+            get(profile::handlers::public_profile),
         )
         .layer(middleware::from_fn_with_state(
             state.clone(),

--- a/backend/src/profile/handlers.rs
+++ b/backend/src/profile/handlers.rs
@@ -1,0 +1,144 @@
+use crate::auth::middleware::{AuthUser, OptionalAuthUser};
+use crate::errors::AppError;
+use crate::AppState;
+use axum::extract::{Path, State};
+use axum::Json;
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use uuid::Uuid;
+
+#[derive(Serialize)]
+pub struct ProfileResponse {
+    pub user_id: String,
+    pub username: String,
+    pub created_at: DateTime<Utc>,
+    pub warrior_count: i64,
+    pub match_count: i64,
+    pub wins: i64,
+    pub losses: i64,
+    pub ties: i64,
+}
+
+#[derive(Serialize)]
+pub struct PublicWarrior {
+    pub id: Uuid,
+    pub name: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Serialize)]
+pub struct PublicProfileResponse {
+    pub user_id: String,
+    pub username: String,
+    pub created_at: DateTime<Utc>,
+    pub warrior_count: i64,
+    pub match_count: i64,
+    pub wins: i64,
+    pub losses: i64,
+    pub ties: i64,
+    pub warriors: Vec<PublicWarrior>,
+}
+
+async fn fetch_match_stats(db: &sqlx::PgPool, user_id: Uuid) -> (i64, i64, i64, i64) {
+    let row = sqlx::query_as::<_, (i64, i64, i64, i64)>(
+        "SELECT \
+           COUNT(*), \
+           COUNT(*) FILTER (WHERE (red_user_id = $1 AND result = 'red_win') \
+                                OR (blue_user_id = $1 AND result = 'blue_win')), \
+           COUNT(*) FILTER (WHERE (red_user_id = $1 AND result = 'blue_win') \
+                                OR (blue_user_id = $1 AND result = 'red_win')), \
+           COUNT(*) FILTER (WHERE result IN ('tie', 'all_dead')) \
+         FROM matches WHERE red_user_id = $1 OR blue_user_id = $1",
+    )
+    .bind(user_id)
+    .fetch_one(db)
+    .await;
+
+    row.unwrap_or_default()
+}
+
+async fn build_profile(
+    db: &sqlx::PgPool,
+    user_id: Uuid,
+    username: &str,
+) -> Result<ProfileResponse, AppError> {
+    let created_at: DateTime<Utc> =
+        sqlx::query_scalar("SELECT created_at FROM users WHERE id = $1")
+            .bind(user_id)
+            .fetch_one(db)
+            .await?;
+
+    let warrior_count =
+        sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM warriors WHERE user_id = $1")
+            .bind(user_id)
+            .fetch_one(db)
+            .await?;
+
+    let (match_count, wins, losses, ties) = fetch_match_stats(db, user_id).await;
+
+    Ok(ProfileResponse {
+        user_id: user_id.to_string(),
+        username: username.to_string(),
+        created_at,
+        warrior_count,
+        match_count,
+        wins,
+        losses,
+        ties,
+    })
+}
+
+pub async fn me(
+    State(state): State<AppState>,
+    user: AuthUser,
+) -> Result<Json<ProfileResponse>, AppError> {
+    let profile = build_profile(&state.db, user.user_id, &user.username).await?;
+    Ok(Json(profile))
+}
+
+pub async fn public_profile(
+    State(state): State<AppState>,
+    _auth: OptionalAuthUser,
+    Path(username): Path<String>,
+) -> Result<Json<PublicProfileResponse>, AppError> {
+    let row = sqlx::query_as::<_, (Uuid, String, DateTime<Utc>)>(
+        "SELECT id, username, created_at FROM users WHERE username = $1",
+    )
+    .bind(&username)
+    .fetch_optional(&state.db)
+    .await?
+    .ok_or_else(|| AppError::NotFound("User not found".into()))?;
+
+    let (user_id, username, created_at) = row;
+
+    let profile = build_profile(&state.db, user_id, &username).await?;
+
+    let warriors = sqlx::query_as::<_, (Uuid, String, DateTime<Utc>, DateTime<Utc>)>(
+        "SELECT id, name, created_at, updated_at FROM warriors \
+         WHERE user_id = $1 ORDER BY updated_at DESC",
+    )
+    .bind(user_id)
+    .fetch_all(&state.db)
+    .await?
+    .into_iter()
+    .map(|(id, name, ca, ua)| PublicWarrior {
+        id,
+        name,
+        created_at: ca,
+        updated_at: ua,
+    })
+    .collect();
+
+    Ok(Json(PublicProfileResponse {
+        user_id: profile.user_id,
+        username: profile.username,
+        created_at,
+        warrior_count: profile.warrior_count,
+        match_count: profile.match_count,
+        wins: profile.wins,
+        losses: profile.losses,
+        ties: profile.ties,
+        warriors,
+    }))
+}

--- a/backend/src/profile/mod.rs
+++ b/backend/src/profile/mod.rs
@@ -1,0 +1,1 @@
+pub mod handlers;

--- a/frontend/src/AppLayout.tsx
+++ b/frontend/src/AppLayout.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { NavLink, Outlet } from 'react-router-dom';
+import { NavLink, Outlet, Link } from 'react-router-dom';
 import { useAuth } from './api/AuthContext';
 import AuthModal from './api/AuthModal';
 
@@ -122,7 +122,13 @@ export default function AppLayout() {
         <div style={AUTH_SECTION}>
           {loading ? null : user ? (
             <>
-              <span style={USERNAME_STYLE}>{user.username}</span>
+              <Link
+                to="/profile"
+                style={{ ...USERNAME_STYLE, textDecoration: 'none' }}
+                title="Dashboard"
+              >
+                {user.username}
+              </Link>
               <button style={AUTH_BTN} onClick={logout} title="Log out">
                 <span style={ICON_STYLE}>{'←'}</span>
                 <span style={LABEL_STYLE}>Logout</span>

--- a/frontend/src/api/profile.ts
+++ b/frontend/src/api/profile.ts
@@ -1,0 +1,31 @@
+import { api } from './client';
+
+export type ProfileStats = {
+  user_id: string;
+  username: string;
+  created_at: string;
+  warrior_count: number;
+  match_count: number;
+  wins: number;
+  losses: number;
+  ties: number;
+};
+
+export type PublicWarrior = {
+  id: string;
+  name: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export type PublicProfile = ProfileStats & {
+  warriors: PublicWarrior[];
+};
+
+export async function getMyProfile(): Promise<ProfileStats> {
+  return api.get<ProfileStats>('/api/profile');
+}
+
+export async function getPublicProfile(username: string): Promise<PublicProfile> {
+  return api.get<PublicProfile>(`/api/users/${encodeURIComponent(username)}`);
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -12,6 +12,8 @@ const BattlefieldPage = React.lazy(() => import('./pages/battlefield/Battlefield
 const BuilderPage = React.lazy(() => import('./pages/builder/BuilderPage'));
 // eslint-disable-next-line react-refresh/only-export-components
 const LearnPage = React.lazy(() => import('./pages/LearnPage'));
+// eslint-disable-next-line react-refresh/only-export-components
+const ProfilePage = React.lazy(() => import('./pages/profile/ProfilePage'));
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
@@ -41,6 +43,22 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
               element={
                 <Suspense>
                   <LearnPage />
+                </Suspense>
+              }
+            />
+            <Route
+              path="/profile"
+              element={
+                <Suspense>
+                  <ProfilePage />
+                </Suspense>
+              }
+            />
+            <Route
+              path="/users/:username"
+              element={
+                <Suspense>
+                  <ProfilePage />
                 </Suspense>
               }
             />

--- a/frontend/src/pages/profile/ProfilePage.tsx
+++ b/frontend/src/pages/profile/ProfilePage.tsx
@@ -1,0 +1,275 @@
+import { useEffect, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { useAuth } from '../../api/AuthContext';
+import {
+  getMyProfile,
+  getPublicProfile,
+  type ProfileStats,
+  type PublicProfile,
+} from '../../api/profile';
+
+const PAGE_STYLE: React.CSSProperties = {
+  minHeight: '100vh',
+  padding: '2rem',
+  maxWidth: '720px',
+  margin: '0 auto',
+};
+
+const HEADER_STYLE: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'baseline',
+  gap: '1rem',
+  marginBottom: '1.5rem',
+};
+
+const USERNAME_STYLE: React.CSSProperties = {
+  margin: 0,
+  fontSize: '1.8rem',
+  color: '#e94560',
+  letterSpacing: '0.08em',
+};
+
+const JOINED_STYLE: React.CSSProperties = {
+  fontSize: '0.75rem',
+  color: '#666',
+};
+
+const STATS_ROW: React.CSSProperties = {
+  display: 'flex',
+  gap: '1.5rem',
+  marginBottom: '2rem',
+  flexWrap: 'wrap',
+};
+
+const STAT_BOX: React.CSSProperties = {
+  flex: '1 1 100px',
+  padding: '0.75rem 1rem',
+  backgroundColor: '#111',
+  border: '1px solid #222',
+  borderRadius: '6px',
+  textAlign: 'center',
+};
+
+const STAT_VALUE: React.CSSProperties = {
+  fontSize: '1.5rem',
+  fontWeight: 700,
+};
+
+const STAT_LABEL: React.CSSProperties = {
+  fontSize: '0.65rem',
+  color: '#888',
+  textTransform: 'uppercase',
+  letterSpacing: '0.1em',
+  marginTop: '0.25rem',
+};
+
+const SECTION_HEADER: React.CSSProperties = {
+  fontSize: '0.7rem',
+  letterSpacing: '0.1em',
+  color: '#666',
+  textTransform: 'uppercase',
+  padding: '0.5rem 0',
+  borderBottom: '1px solid #222',
+  marginBottom: '0.5rem',
+};
+
+const WARRIOR_ROW: React.CSSProperties = {
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  padding: '0.5rem 0',
+  borderBottom: '1px solid #1a1a1a',
+};
+
+const WARRIOR_NAME: React.CSSProperties = {
+  color: '#4fc3f7',
+  fontWeight: 600,
+};
+
+const WARRIOR_DATE: React.CSSProperties = {
+  fontSize: '0.7rem',
+  color: '#555',
+};
+
+const EMPTY_STYLE: React.CSSProperties = {
+  color: '#555',
+  fontStyle: 'italic',
+  padding: '1rem 0',
+};
+
+const LOGIN_PROMPT: React.CSSProperties = {
+  minHeight: '100vh',
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: '1rem',
+  color: '#888',
+};
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+function StatsCards({ stats }: { stats: ProfileStats }) {
+  return (
+    <div style={STATS_ROW}>
+      <div style={STAT_BOX}>
+        <div style={{ ...STAT_VALUE, color: '#4fc3f7' }}>{stats.warrior_count}</div>
+        <div style={STAT_LABEL}>Warriors</div>
+      </div>
+      <div style={STAT_BOX}>
+        <div style={{ ...STAT_VALUE, color: '#4caf50' }}>{stats.wins}</div>
+        <div style={STAT_LABEL}>Wins</div>
+      </div>
+      <div style={STAT_BOX}>
+        <div style={{ ...STAT_VALUE, color: '#e94560' }}>{stats.losses}</div>
+        <div style={STAT_LABEL}>Losses</div>
+      </div>
+      <div style={STAT_BOX}>
+        <div style={{ ...STAT_VALUE, color: '#f0c040' }}>{stats.ties}</div>
+        <div style={STAT_LABEL}>Ties</div>
+      </div>
+      <div style={STAT_BOX}>
+        <div style={{ ...STAT_VALUE, color: '#e0e0e0' }}>{stats.match_count}</div>
+        <div style={STAT_LABEL}>Matches</div>
+      </div>
+    </div>
+  );
+}
+
+function MyDashboard() {
+  const [profile, setProfile] = useState<ProfileStats | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    getMyProfile()
+      .then((p) => {
+        if (!cancelled) setProfile(p);
+      })
+      .catch((e) => {
+        if (!cancelled) setError(e instanceof Error ? e.message : 'Failed to load profile');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (error)
+    return (
+      <div style={PAGE_STYLE}>
+        <p style={{ color: '#e94560' }}>{error}</p>
+      </div>
+    );
+  if (!profile)
+    return (
+      <div style={PAGE_STYLE}>
+        <p style={{ color: '#888' }}>Loading...</p>
+      </div>
+    );
+
+  return (
+    <div style={PAGE_STYLE}>
+      <div style={HEADER_STYLE}>
+        <h1 style={USERNAME_STYLE}>{profile.username}</h1>
+        <span style={JOINED_STYLE}>Joined {formatDate(profile.created_at)}</span>
+      </div>
+      <StatsCards stats={profile} />
+      <div style={SECTION_HEADER}>Quick Actions</div>
+      <div style={{ display: 'flex', gap: '0.75rem', padding: '0.75rem 0' }}>
+        <Link to="/builder" style={actionLink('#4fc3f7')}>
+          New Warrior
+        </Link>
+        <Link to="/battle" style={actionLink('#e94560')}>
+          Start Battle
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+function PublicProfileView({ username }: { username: string }) {
+  const [profile, setProfile] = useState<PublicProfile | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    getPublicProfile(username)
+      .then(setProfile)
+      .catch((e) => setError(e instanceof Error ? e.message : 'Failed to load profile'));
+  }, [username]);
+
+  if (error)
+    return (
+      <div style={PAGE_STYLE}>
+        <p style={{ color: '#e94560' }}>{error}</p>
+      </div>
+    );
+  if (!profile)
+    return (
+      <div style={PAGE_STYLE}>
+        <p style={{ color: '#888' }}>Loading...</p>
+      </div>
+    );
+
+  return (
+    <div style={PAGE_STYLE}>
+      <div style={HEADER_STYLE}>
+        <h1 style={USERNAME_STYLE}>{profile.username}</h1>
+        <span style={JOINED_STYLE}>Joined {formatDate(profile.created_at)}</span>
+      </div>
+      <StatsCards stats={profile} />
+      <div style={SECTION_HEADER}>Warriors ({profile.warriors.length})</div>
+      {profile.warriors.length === 0 ? (
+        <p style={EMPTY_STYLE}>No warriors yet.</p>
+      ) : (
+        profile.warriors.map((w) => (
+          <div key={w.id} style={WARRIOR_ROW}>
+            <span style={WARRIOR_NAME}>{w.name}</span>
+            <span style={WARRIOR_DATE}>{formatDate(w.updated_at)}</span>
+          </div>
+        ))
+      )}
+    </div>
+  );
+}
+
+const actionLink = (color: string): React.CSSProperties => ({
+  padding: '0.5rem 1rem',
+  fontSize: '0.8rem',
+  color,
+  textDecoration: 'none',
+  border: `1px solid ${color}66`,
+  borderRadius: '4px',
+  backgroundColor: `${color}11`,
+});
+
+export default function ProfilePage() {
+  const { username } = useParams<{ username: string }>();
+  const { user, loading } = useAuth();
+
+  if (loading)
+    return (
+      <div style={PAGE_STYLE}>
+        <p style={{ color: '#888' }}>Loading...</p>
+      </div>
+    );
+
+  if (username) {
+    return <PublicProfileView username={username} />;
+  }
+
+  if (!user) {
+    return (
+      <div style={LOGIN_PROMPT}>
+        <p>Log in to view your dashboard.</p>
+      </div>
+    );
+  }
+
+  return <MyDashboard />;
+}


### PR DESCRIPTION
## Summary
- Backend: `GET /api/profile` returns authenticated user's stats (warrior count, W/L/T record, match count) and `GET /api/users/:username` returns public profile with warrior list
- Frontend: `/profile` dashboard with stats cards and quick-action links, `/users/:username` public profile view, username in sidebar now links to dashboard
- Match stats queries handle missing matches table gracefully (returns zeros)

## Test plan
- [x] All backend tests pass (87 unit + 20 integration)
- [x] All frontend tests pass (49)
- [x] `cargo clippy` and `npm run lint` clean
- [ ] Authenticated user sees stats dashboard at /profile
- [ ] Unauthenticated user sees login prompt at /profile
- [ ] Public profile at /users/:username shows warrior list
- [ ] Username in sidebar links to /profile

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)