### PR TITLE
Add ELO rating system and leaderboard (issue #35)

### DIFF
--- a/backend/migrations/20260511000002_add_user_rating.sql
+++ b/backend/migrations/20260511000002_add_user_rating.sql
@@ -1,0 +1,2 @@
+ALTER TABLE users ADD COLUMN rating INT NOT NULL DEFAULT 1200;
+CREATE INDEX idx_users_rating ON users(rating DESC);

--- a/backend/src/leaderboard/elo.rs
+++ b/backend/src/leaderboard/elo.rs
@@ -1,0 +1,66 @@
+const K_FACTOR: f64 = 32.0;
+
+fn expected_score(rating: i32, opponent_rating: i32) -> f64 {
+    1.0 / (1.0 + 10.0_f64.powf((opponent_rating - rating) as f64 / 400.0))
+}
+
+pub fn rating_change(winner_rating: i32, loser_rating: i32) -> (i32, i32) {
+    let e_winner = expected_score(winner_rating, loser_rating);
+    let delta = (K_FACTOR * (1.0 - e_winner)).round() as i32;
+    (winner_rating + delta, loser_rating - delta)
+}
+
+pub fn tie_change(rating_a: i32, rating_b: i32) -> (i32, i32) {
+    let e_a = expected_score(rating_a, rating_b);
+    let delta_a = (K_FACTOR * (0.5 - e_a)).round() as i32;
+    (rating_a + delta_a, rating_b - delta_a)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn equal_ratings_winner_gains() {
+        let (w, l) = rating_change(1200, 1200);
+        assert!(w > 1200);
+        assert!(l < 1200);
+        assert_eq!(w - 1200, 1200 - l);
+    }
+
+    #[test]
+    fn higher_rated_gains_less() {
+        let (w_high, _) = rating_change(1600, 1200);
+        let (w_equal, _) = rating_change(1200, 1200);
+        assert!(w_high - 1600 < w_equal - 1200);
+    }
+
+    #[test]
+    fn upset_yields_larger_swing() {
+        let (w, _) = rating_change(1200, 1600);
+        assert!(w - 1200 > 16);
+    }
+
+    #[test]
+    fn equal_ratings_tie_no_change() {
+        let (a, b) = tie_change(1200, 1200);
+        assert_eq!(a, 1200);
+        assert_eq!(b, 1200);
+    }
+
+    #[test]
+    fn tie_favors_lower_rated() {
+        let (a, b) = tie_change(1600, 1200);
+        assert!(a < 1600);
+        assert!(b > 1200);
+    }
+
+    #[test]
+    fn rating_changes_are_zero_sum() {
+        let (w, l) = rating_change(1500, 1300);
+        assert_eq!((w + l), (1500 + 1300));
+
+        let (a, b) = tie_change(1400, 1100);
+        assert_eq!((a + b), (1400 + 1100));
+    }
+}

--- a/backend/src/leaderboard/handlers.rs
+++ b/backend/src/leaderboard/handlers.rs
@@ -1,0 +1,69 @@
+use crate::errors::AppError;
+use crate::AppState;
+use axum::extract::{Query, State};
+use axum::Json;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Debug, sqlx::FromRow, Serialize)]
+pub struct LeaderboardEntry {
+    pub rank: i64,
+    pub user_id: Uuid,
+    pub username: String,
+    pub rating: i32,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Deserialize)]
+pub struct LeaderboardQuery {
+    pub page: Option<i64>,
+    pub per_page: Option<i64>,
+}
+
+#[derive(Serialize)]
+pub struct LeaderboardResponse {
+    pub entries: Vec<LeaderboardEntry>,
+    pub total: i64,
+    pub page: i64,
+    pub per_page: i64,
+}
+
+const MAX_PAGE_SIZE: i64 = 100;
+const DEFAULT_PAGE_SIZE: i64 = 50;
+
+pub async fn leaderboard(
+    State(state): State<AppState>,
+    Query(query): Query<LeaderboardQuery>,
+) -> Result<Json<LeaderboardResponse>, AppError> {
+    let page = query.page.unwrap_or(1).max(1);
+    let per_page = query
+        .per_page
+        .unwrap_or(DEFAULT_PAGE_SIZE)
+        .clamp(1, MAX_PAGE_SIZE);
+    let offset = (page - 1) * per_page;
+
+    let total = sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM users")
+        .fetch_one(&state.db)
+        .await?;
+
+    let entries = sqlx::query_as::<_, LeaderboardEntry>(
+        "SELECT \
+           ROW_NUMBER() OVER (ORDER BY rating DESC, created_at ASC) AS rank, \
+           id AS user_id, username, rating, created_at \
+         FROM users \
+         ORDER BY rating DESC, created_at ASC \
+         LIMIT $1 OFFSET $2",
+    )
+    .bind(per_page)
+    .bind(offset)
+    .fetch_all(&state.db)
+    .await?;
+
+    Ok(Json(LeaderboardResponse {
+        entries,
+        total,
+        page,
+        per_page,
+    }))
+}

--- a/backend/src/leaderboard/mod.rs
+++ b/backend/src/leaderboard/mod.rs
@@ -1,0 +1,2 @@
+pub mod elo;
+pub mod handlers;

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -2,6 +2,7 @@ pub mod auth;
 pub mod config;
 pub mod db;
 pub mod errors;
+pub mod leaderboard;
 mod models;
 pub mod warriors;
 

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,6 +1,6 @@
 use axum::http::{header, Method};
 use axum::{middleware, routing::get, routing::post, Json, Router};
-use core_war_backend::{auth, config::Config, db, warriors, AppConfig, AppState};
+use core_war_backend::{auth, config::Config, db, leaderboard, warriors, AppConfig, AppState};
 use serde_json::{json, Value};
 use socketioxide::{extract::SocketRef, SocketIo};
 use std::net::SocketAddr;
@@ -93,6 +93,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .put(warriors::handlers::update)
                 .delete(warriors::handlers::delete),
         )
+        .route("/api/leaderboard", get(leaderboard::handlers::leaderboard))
         .layer(middleware::from_fn_with_state(
             state.clone(),
             auth::middleware::csrf_middleware,

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,6 +1,8 @@
 use axum::http::{header, Method};
 use axum::{middleware, routing::get, routing::post, Json, Router};
-use core_war_backend::{auth, config::Config, db, leaderboard, profile, warriors, AppConfig, AppState};
+use core_war_backend::{
+    auth, config::Config, db, leaderboard, profile, warriors, AppConfig, AppState,
+};
 use serde_json::{json, Value};
 use socketioxide::{extract::SocketRef, SocketIo};
 use std::net::SocketAddr;

--- a/frontend/src/AppLayout.tsx
+++ b/frontend/src/AppLayout.tsx
@@ -62,6 +62,7 @@ const ITEMS: Item[] = [
   { to: '/battle', label: 'Battle', icon: '⚔' },
   { to: '/builder', label: 'Builder', icon: '✎' },
   { to: '/learn', label: 'Learn', icon: 'ℹ' },
+  { to: '/leaderboard', label: 'Ranks', icon: '♛' },
 ];
 
 const AUTH_SECTION: React.CSSProperties = {

--- a/frontend/src/api/leaderboard.ts
+++ b/frontend/src/api/leaderboard.ts
@@ -1,0 +1,20 @@
+import { api } from './client';
+
+export type LeaderboardEntry = {
+  rank: number;
+  user_id: string;
+  username: string;
+  rating: number;
+  created_at: string;
+};
+
+export type LeaderboardResponse = {
+  entries: LeaderboardEntry[];
+  total: number;
+  page: number;
+  per_page: number;
+};
+
+export async function getLeaderboard(page = 1, perPage = 50): Promise<LeaderboardResponse> {
+  return api.get<LeaderboardResponse>(`/api/leaderboard?page=${page}&per_page=${perPage}`);
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -12,6 +12,8 @@ const BattlefieldPage = React.lazy(() => import('./pages/battlefield/Battlefield
 const BuilderPage = React.lazy(() => import('./pages/builder/BuilderPage'));
 // eslint-disable-next-line react-refresh/only-export-components
 const LearnPage = React.lazy(() => import('./pages/LearnPage'));
+// eslint-disable-next-line react-refresh/only-export-components
+const LeaderboardPage = React.lazy(() => import('./pages/LeaderboardPage'));
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
@@ -41,6 +43,14 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
               element={
                 <Suspense>
                   <LearnPage />
+                </Suspense>
+              }
+            />
+            <Route
+              path="/leaderboard"
+              element={
+                <Suspense>
+                  <LeaderboardPage />
                 </Suspense>
               }
             />

--- a/frontend/src/pages/LeaderboardPage.tsx
+++ b/frontend/src/pages/LeaderboardPage.tsx
@@ -1,0 +1,183 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import {
+  getLeaderboard,
+  type LeaderboardEntry,
+  type LeaderboardResponse,
+} from '../api/leaderboard';
+
+const PAGE_STYLE: React.CSSProperties = {
+  minHeight: '100vh',
+  padding: '2rem',
+  maxWidth: '720px',
+  margin: '0 auto',
+};
+
+const TITLE_STYLE: React.CSSProperties = {
+  margin: '0 0 1.5rem',
+  fontSize: '1.8rem',
+  color: '#e94560',
+  letterSpacing: '0.08em',
+};
+
+const TABLE_STYLE: React.CSSProperties = {
+  width: '100%',
+  borderCollapse: 'collapse',
+};
+
+const TH_STYLE: React.CSSProperties = {
+  textAlign: 'left',
+  padding: '0.6rem 0.75rem',
+  fontSize: '0.65rem',
+  letterSpacing: '0.1em',
+  color: '#666',
+  textTransform: 'uppercase',
+  borderBottom: '1px solid #333',
+};
+
+const TD_STYLE: React.CSSProperties = {
+  padding: '0.6rem 0.75rem',
+  borderBottom: '1px solid #1a1a1a',
+};
+
+const RANK_STYLE: React.CSSProperties = {
+  color: '#888',
+  fontWeight: 600,
+  width: '50px',
+};
+
+const USERNAME_LINK: React.CSSProperties = {
+  color: '#4fc3f7',
+  textDecoration: 'none',
+  fontWeight: 600,
+};
+
+const RATING_STYLE: React.CSSProperties = {
+  color: '#f0c040',
+  fontWeight: 700,
+  textAlign: 'right',
+};
+
+const PAGINATION_STYLE: React.CSSProperties = {
+  display: 'flex',
+  justifyContent: 'center',
+  gap: '0.75rem',
+  marginTop: '1.5rem',
+};
+
+const PAGE_BTN: React.CSSProperties = {
+  padding: '0.4rem 1rem',
+  fontSize: '0.8rem',
+  fontFamily: 'inherit',
+  color: '#888',
+  backgroundColor: '#111',
+  border: '1px solid #333',
+  borderRadius: '4px',
+  cursor: 'pointer',
+};
+
+const PAGE_BTN_DISABLED: React.CSSProperties = {
+  ...PAGE_BTN,
+  opacity: 0.3,
+  cursor: 'default',
+};
+
+function rankMedal(rank: number): string {
+  if (rank === 1) return '\u{1F947}';
+  if (rank === 2) return '\u{1F948}';
+  if (rank === 3) return '\u{1F949}';
+  return `#${rank}`;
+}
+
+export default function LeaderboardPage() {
+  const [data, setData] = useState<LeaderboardResponse | null>(null);
+  const [page, setPage] = useState(1);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    getLeaderboard(page)
+      .then((d) => {
+        if (!cancelled) setData(d);
+      })
+      .catch((e) => {
+        if (!cancelled) setError(e instanceof Error ? e.message : 'Failed to load');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [page]);
+
+  if (error) {
+    return (
+      <div style={PAGE_STYLE}>
+        <p style={{ color: '#e94560' }}>{error}</p>
+      </div>
+    );
+  }
+
+  if (!data) {
+    return (
+      <div style={PAGE_STYLE}>
+        <p style={{ color: '#888' }}>Loading...</p>
+      </div>
+    );
+  }
+
+  const totalPages = Math.ceil(data.total / data.per_page);
+
+  return (
+    <div style={PAGE_STYLE}>
+      <h1 style={TITLE_STYLE}>Leaderboard</h1>
+
+      {data.entries.length === 0 ? (
+        <p style={{ color: '#555', fontStyle: 'italic' }}>No players yet.</p>
+      ) : (
+        <table style={TABLE_STYLE}>
+          <thead>
+            <tr>
+              <th style={TH_STYLE}>Rank</th>
+              <th style={TH_STYLE}>Player</th>
+              <th style={{ ...TH_STYLE, textAlign: 'right' }}>Rating</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.entries.map((entry: LeaderboardEntry) => (
+              <tr key={entry.user_id}>
+                <td style={{ ...TD_STYLE, ...RANK_STYLE }}>{rankMedal(entry.rank)}</td>
+                <td style={TD_STYLE}>
+                  <Link to={`/users/${entry.username}`} style={USERNAME_LINK}>
+                    {entry.username}
+                  </Link>
+                </td>
+                <td style={{ ...TD_STYLE, ...RATING_STYLE }}>{entry.rating}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+
+      {totalPages > 1 && (
+        <div style={PAGINATION_STYLE}>
+          <button
+            style={page <= 1 ? PAGE_BTN_DISABLED : PAGE_BTN}
+            disabled={page <= 1}
+            onClick={() => setPage((p) => p - 1)}
+          >
+            Prev
+          </button>
+          <span style={{ color: '#666', fontSize: '0.8rem', alignSelf: 'center' }}>
+            {page} / {totalPages}
+          </span>
+          <button
+            style={page >= totalPages ? PAGE_BTN_DISABLED : PAGE_BTN}
+            disabled={page >= totalPages}
+            onClick={() => setPage((p) => p + 1)}
+          >
+            Next
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Backend: ELO rating calculation with K-factor 32, `rating` column on users table (default 1200), `GET /api/leaderboard` endpoint with pagination and rank via SQL window function
- Frontend: `/leaderboard` page with ranked player table, medal icons for top 3, pagination controls, links to public profiles
- Added "Ranks" nav item to sidebar
- ELO module includes unit tests for win/loss/tie rating changes and zero-sum verification

## Test plan
- [x] All backend tests pass (93 unit + 20 integration) — includes 6 new ELO tests
- [x] All frontend tests pass (49)
- [x] `cargo clippy` and `npm run lint` clean
- [ ] Leaderboard page loads and displays ranked players
- [ ] Pagination works when more than 50 players exist
- [ ] Player usernames link to public profile pages

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)