### PR TITLE
Install system binaryen in CI to fix wasm-opt compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Check formatting
         run: cargo fmt -- --check
 
+      - name: Install binaryen (wasm-opt)
+        run: sudo apt-get update && sudo apt-get install -y binaryen
+
       - name: Install wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
 
@@ -134,6 +137,9 @@ jobs:
             engine/target
           key: engine-${{ runner.os }}-cargo-${{ hashFiles('engine/Cargo.lock') }}
           restore-keys: engine-${{ runner.os }}-cargo-
+
+      - name: Install binaryen (wasm-opt)
+        run: sudo apt-get update && sudo apt-get install -y binaryen
 
       - name: Install wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -11,3 +11,6 @@ wasm-bindgen = "0.2"
 
 [profile.release]
 opt-level = "s"
+
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = false

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -11,6 +11,3 @@ wasm-bindgen = "0.2"
 
 [profile.release]
 opt-level = "s"
-
-[package.metadata.wasm-pack.profile.release]
-wasm-opt = false


### PR DESCRIPTION
## Summary
- Installs `binaryen` via apt in both the engine and frontend CI jobs so wasm-pack uses the system `wasm-opt` instead of its bundled (outdated) copy
- The bundled version can't parse Wasm output from newer Rust stable toolchains, causing `"Only 1 table definition allowed in MVP"` errors
- This keeps wasm-opt optimizations enabled (unlike disabling it entirely) while staying compatible with current Rust

## Test plan
- [x] CI engine job passes with wasm-opt still running
- [x] CI frontend job passes (also uses wasm-pack)

🤖 Generated with [Claude Code](https://claude.com/claude-code)