### PR TITLE
Add matchmaking test fixtures and fix room-based delivery (issue #50)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -3,3 +3,4 @@ REDIS_URL=redis://localhost:6379
 FRONTEND_URL=http://localhost:5173
 PORT=3001
 JWT_SECRET=your-secret-here-must-be-at-least-32-bytes
+TEST_USER_PASSWORD=changeme-local-only

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -2,6 +2,15 @@
 name = "core-war-backend"
 version = "0.1.0"
 edition = "2021"
+default-run = "core-war-backend"
+
+[features]
+dev-fixtures = []
+
+[[bin]]
+name = "seed-test-users"
+path = "src/bin/seed_test_users.rs"
+required-features = ["dev-fixtures"]
 
 [dependencies]
 axum = "0.7"

--- a/backend/src/auth/handlers.rs
+++ b/backend/src/auth/handlers.rs
@@ -43,6 +43,11 @@ fn validate_username(username: &str) -> Result<(), AppError> {
             "Username must contain only alphanumeric characters and underscores".into(),
         ));
     }
+    if username.starts_with("_test_") {
+        return Err(AppError::BadRequest(
+            "Username prefix '_test_' is reserved".into(),
+        ));
+    }
     Ok(())
 }
 
@@ -330,6 +335,19 @@ mod tests {
         assert!(validate_username("alice!").is_err());
         assert!(validate_username("bob smith").is_err());
         assert!(validate_username("user@name").is_err());
+    }
+
+    #[test]
+    fn username_reserved_test_prefix_blocked() {
+        assert!(validate_username("_test_red").is_err());
+        assert!(validate_username("_test_blue").is_err());
+        assert!(validate_username("_test_anything").is_err());
+    }
+
+    #[test]
+    fn username_test_prefix_only_blocks_at_start() {
+        assert!(validate_username("not_test_user").is_ok());
+        assert!(validate_username("alice_test_").is_ok());
     }
 
     #[test]

--- a/backend/src/bin/seed_test_users.rs
+++ b/backend/src/bin/seed_test_users.rs
@@ -1,0 +1,110 @@
+use core_war_backend::auth::password::hash_password;
+use sqlx::postgres::PgPoolOptions;
+use std::env;
+use uuid::Uuid;
+
+const IMP_SOURCE: &str = include_str!("../../../engine/tests/warriors/imp.red");
+const DWARF_SOURCE: &str = include_str!("../../../engine/tests/warriors/dwarf.red");
+
+struct SeedUser {
+    username: &'static str,
+    email: &'static str,
+    warrior_name: &'static str,
+    warrior_source: &'static str,
+}
+
+const SEED_USERS: &[SeedUser] = &[
+    SeedUser {
+        username: "_test_red",
+        email: "_test_red@local.test",
+        warrior_name: "Imp",
+        warrior_source: IMP_SOURCE,
+    },
+    SeedUser {
+        username: "_test_blue",
+        email: "_test_blue@local.test",
+        warrior_name: "Dwarf",
+        warrior_source: DWARF_SOURCE,
+    },
+];
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    dotenvy::dotenv().ok();
+
+    let database_url =
+        env::var("DATABASE_URL").map_err(|_| "DATABASE_URL must be set (check backend/.env)")?;
+    let password = env::var("TEST_USER_PASSWORD")
+        .map_err(|_| "TEST_USER_PASSWORD must be set (check backend/.env)")?;
+
+    if password.len() < 8 {
+        return Err("TEST_USER_PASSWORD must be at least 8 characters".into());
+    }
+
+    let pool = PgPoolOptions::new()
+        .max_connections(2)
+        .connect(&database_url)
+        .await?;
+
+    sqlx::migrate!("./migrations").run(&pool).await?;
+
+    let password_hash = hash_password(&password).map_err(|e| format!("hashing failed: {e:?}"))?;
+
+    for seed in SEED_USERS {
+        let existing: Option<(Uuid,)> = sqlx::query_as("SELECT id FROM users WHERE username = $1")
+            .bind(seed.username)
+            .fetch_optional(&pool)
+            .await?;
+
+        let user_id = if let Some((id,)) = existing {
+            println!(
+                "user {} already exists ({id}), skipping user insert",
+                seed.username
+            );
+            id
+        } else {
+            let (id,): (Uuid,) = sqlx::query_as(
+                "INSERT INTO users (username, email, password_hash) \
+                 VALUES ($1, $2, $3) RETURNING id",
+            )
+            .bind(seed.username)
+            .bind(seed.email)
+            .bind(&password_hash)
+            .fetch_one(&pool)
+            .await?;
+            println!("created user {} ({id})", seed.username);
+            id
+        };
+
+        let warrior_exists: Option<(Uuid,)> =
+            sqlx::query_as("SELECT id FROM warriors WHERE user_id = $1 AND name = $2")
+                .bind(user_id)
+                .bind(seed.warrior_name)
+                .fetch_optional(&pool)
+                .await?;
+
+        if let Some((id,)) = warrior_exists {
+            println!(
+                "  warrior {} already exists ({id}) for {}, skipping",
+                seed.warrior_name, seed.username
+            );
+        } else {
+            let (id,): (Uuid,) = sqlx::query_as(
+                "INSERT INTO warriors (user_id, name, source) \
+                 VALUES ($1, $2, $3) RETURNING id",
+            )
+            .bind(user_id)
+            .bind(seed.warrior_name)
+            .bind(seed.warrior_source)
+            .fetch_one(&pool)
+            .await?;
+            println!(
+                "  created warrior {} ({id}) for {}",
+                seed.warrior_name, seed.username
+            );
+        }
+    }
+
+    println!("seed complete");
+    Ok(())
+}

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -46,9 +46,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let queue = matchmaking::queue::RedisQueue::new(redis_conn.clone());
     let db_for_socket = state.db.clone();
     let (socket_layer, io) = SocketIo::new_layer();
+    let io_for_handler = io.clone();
     io.ns("/", move |socket: SocketRef| {
         auth::socket::on_connect(socket.clone(), jwt_secret_for_socket.clone());
-        matchmaking::events::register_events(&socket, queue.clone(), db_for_socket.clone());
+        matchmaking::events::register_events(
+            &socket,
+            io_for_handler.clone(),
+            queue.clone(),
+            db_for_socket.clone(),
+        );
     });
 
     let cors = CorsLayer::new()

--- a/backend/src/matchmaking/events.rs
+++ b/backend/src/matchmaking/events.rs
@@ -4,8 +4,10 @@ use crate::models::warrior::Warrior;
 use core_war_engine::{parse_warrior, MatchResult, MatchState};
 use serde::{Deserialize, Serialize};
 use socketioxide::extract::{Data, SocketRef};
+use socketioxide::{socket::Sid, SocketIo};
 use sqlx::PgPool;
-use tracing::{error, info};
+use std::str::FromStr;
+use tracing::{error, info, warn};
 use uuid::Uuid;
 
 const CORE_SIZE: usize = 8000;
@@ -40,14 +42,20 @@ struct MatchResultEvent {
     blue_username: String,
 }
 
-pub fn register_events(socket: &SocketRef, queue: RedisQueue, db: PgPool) {
+fn match_room(match_id: &str) -> String {
+    format!("match:{match_id}")
+}
+
+pub fn register_events(socket: &SocketRef, io: SocketIo, queue: RedisQueue, db: PgPool) {
     let q = queue.clone();
     let pool = db.clone();
+    let io_for_join = io.clone();
     socket.on(
         "queue:join",
         move |socket: SocketRef, Data(data): Data<QueueJoinData>| {
             let q = q.clone();
             let pool = pool.clone();
+            let io = io_for_join.clone();
             async move {
                 let user = match require_auth(&socket) {
                     Some(u) => u,
@@ -138,7 +146,7 @@ pub fn register_events(socket: &SocketRef, queue: RedisQueue, db: PgPool) {
                     }
                     Some((red, blue)) => {
                         info!("match found: {} vs {}", red.username, blue.username);
-                        run_matched_battle(socket, pool, red, blue).await;
+                        run_matched_battle(io, pool, red, blue).await;
                     }
                 }
             }
@@ -182,15 +190,7 @@ pub fn register_events(socket: &SocketRef, queue: RedisQueue, db: PgPool) {
     });
 }
 
-fn emit_to_socket(socket: &SocketRef, target_sid: &str, event: &str, data: &impl Serialize) {
-    if socket.id.to_string() == target_sid {
-        let _ = socket.emit(event, data);
-    } else {
-        let _ = socket.to(target_sid.to_string()).emit(event, data);
-    }
-}
-
-async fn run_matched_battle(socket: SocketRef, db: PgPool, red: QueueEntry, blue: QueueEntry) {
+async fn run_matched_battle(io: SocketIo, db: PgPool, red: QueueEntry, blue: QueueEntry) {
     let red_source =
         match sqlx::query_scalar::<_, String>("SELECT source FROM warriors WHERE id = $1")
             .bind(red.warrior_id)
@@ -218,6 +218,52 @@ async fn run_matched_battle(socket: SocketRef, db: PgPool, red: QueueEntry, blue
         };
 
     let match_id = Uuid::new_v4().to_string();
+    let room = match_room(&match_id);
+
+    // Join both participants into a dedicated room for this match. socketioxide
+    // does NOT auto-join sockets to a room named after their sid (unlike vanilla
+    // Node socket.io), so we must use explicit room names — that's the root cause
+    // of the prior `socket.to(sid).emit()` silently dropping events on the other
+    // side. Emitting via `io.to(room)` from the SocketIo instance includes all
+    // sockets currently in the room (no self-exclusion semantics).
+    let red_sid = match Sid::from_str(&red.socket_id) {
+        Ok(s) => s,
+        Err(e) => {
+            error!("invalid red socket_id {}: {e}", red.socket_id);
+            return;
+        }
+    };
+    let blue_sid = match Sid::from_str(&blue.socket_id) {
+        Ok(s) => s,
+        Err(e) => {
+            error!("invalid blue socket_id {}: {e}", blue.socket_id);
+            return;
+        }
+    };
+
+    let red_socket = match io.get_socket(red_sid) {
+        Some(s) => s,
+        None => {
+            warn!(
+                "red socket {} no longer connected; aborting match",
+                red.socket_id
+            );
+            return;
+        }
+    };
+    let blue_socket = match io.get_socket(blue_sid) {
+        Some(s) => s,
+        None => {
+            warn!(
+                "blue socket {} no longer connected; aborting match",
+                blue.socket_id
+            );
+            return;
+        }
+    };
+
+    let _ = red_socket.join(room.clone());
+    let _ = blue_socket.join(room.clone());
 
     let found_event = MatchFound {
         match_id: match_id.clone(),
@@ -227,8 +273,7 @@ async fn run_matched_battle(socket: SocketRef, db: PgPool, red: QueueEntry, blue
         blue_warrior: blue.warrior_id.to_string(),
     };
 
-    emit_to_socket(&socket, &red.socket_id, "match:found", &found_event);
-    emit_to_socket(&socket, &blue.socket_id, "match:found", &found_event);
+    let _ = io.to(room.clone()).emit("match:found", &found_event);
 
     let battle_result = tokio::task::spawn_blocking(move || {
         let red_parsed = parse_warrior(&red_source).map_err(|e| format!("Red parse: {e}"))?;
@@ -265,15 +310,14 @@ async fn run_matched_battle(socket: SocketRef, db: PgPool, red: QueueEntry, blue
     };
 
     let result_event = MatchResultEvent {
-        match_id,
+        match_id: match_id.clone(),
         result: result_str.clone(),
         steps_taken,
         red_username: red.username.clone(),
         blue_username: blue.username.clone(),
     };
 
-    emit_to_socket(&socket, &red.socket_id, "match:result", &result_event);
-    emit_to_socket(&socket, &blue.socket_id, "match:result", &result_event);
+    let _ = io.to(room).emit("match:result", &result_event);
 
     let _ = sqlx::query(
         "INSERT INTO matches \

--- a/frontend/scripts/bot-blue.mjs
+++ b/frontend/scripts/bot-blue.mjs
@@ -1,0 +1,22 @@
+// Matchmaking bot — plays as the seeded `_test_blue` user with the Dwarf warrior.
+// Run as a separate Node process. See bot-common.mjs for the shared flow.
+
+import { runBot } from './bot-common.mjs';
+
+const password = process.env.TEST_USER_PASSWORD;
+if (!password) {
+  console.error(
+    JSON.stringify({
+      event: 'config:missing',
+      data: { error: 'TEST_USER_PASSWORD env var required (load from backend/.env)' },
+    }),
+  );
+  process.exit(1);
+}
+
+await runBot({
+  role: 'blue',
+  username: '_test_blue',
+  password,
+  expectedWarriorName: 'Dwarf',
+});

--- a/frontend/scripts/bot-common.mjs
+++ b/frontend/scripts/bot-common.mjs
@@ -1,0 +1,155 @@
+// Shared helpers for the matchmaking bot scripts (bot-red.mjs, bot-blue.mjs).
+//
+// Each bot logs in as a seeded test user (see backend `seed-test-users` binary),
+// fetches its seeded warrior, joins the matchmaking queue over Socket.IO, and
+// emits a JSON-lines event log on stdout for the orchestrator to consume.
+//
+// The bots are intended to run as independent Node processes — the orchestrator
+// in matchmaking-e2e.mjs spawns each via `node bot-{role}.mjs`. Running them as
+// separate processes sidesteps any same-process socket.io-client Manager
+// sharing concerns (the multiplex behavior). `forceNew: true` + websocket-only
+// transports are kept as defense-in-depth.
+
+import { io } from 'socket.io-client';
+
+const BACKEND_URL = process.env.BACKEND_URL ?? 'http://localhost:3001';
+const FRONTEND_URL = process.env.FRONTEND_URL ?? 'http://localhost:5173';
+
+export function logEvent(event, data = {}, extra = {}) {
+  const entry = {
+    timestamp: new Date().toISOString(),
+    event,
+    data,
+    ...extra,
+  };
+  console.log(JSON.stringify(entry));
+}
+
+export async function login(username, password) {
+  const res = await fetch(`${BACKEND_URL}/api/auth/login`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      // CSRF middleware checks Origin against FRONTEND_URL for non-GET requests.
+      Origin: FRONTEND_URL,
+    },
+    body: JSON.stringify({ username_or_email: username, password }),
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`login failed: HTTP ${res.status} ${body}`);
+  }
+
+  // Set-Cookie may arrive as multiple headers; reassemble a Cookie header for replay.
+  const setCookies = res.headers.getSetCookie?.() ?? [];
+  if (setCookies.length === 0) {
+    throw new Error('login: no Set-Cookie headers in response');
+  }
+  const cookieHeader = setCookies.map((c) => c.split(';', 1)[0]).join('; ');
+  const body = await res.json();
+  return { user: body, cookieHeader };
+}
+
+export async function listWarriors(cookieHeader) {
+  const res = await fetch(`${BACKEND_URL}/api/warriors`, {
+    method: 'GET',
+    headers: { Cookie: cookieHeader },
+  });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`list warriors failed: HTTP ${res.status} ${body}`);
+  }
+  return res.json();
+}
+
+export function connectSocket(cookieHeader) {
+  return io(BACKEND_URL, {
+    transports: ['websocket'],
+    forceNew: true,
+    extraHeaders: { Cookie: cookieHeader },
+    timeout: 10_000,
+    reconnection: false,
+  });
+}
+
+export async function runBot({ role, username, password, expectedWarriorName, timeoutMs = 30_000 }) {
+  logEvent('bot:start', { role, username });
+
+  let session;
+  try {
+    session = await login(username, password);
+    logEvent('login:ok', { username: session.user.username, user_id: session.user.user_id });
+  } catch (err) {
+    logEvent('login:fail', { error: err.message });
+    process.exit(1);
+  }
+
+  let warrior;
+  try {
+    const { warriors } = await listWarriors(session.cookieHeader);
+    warrior = warriors.find((w) => w.name === expectedWarriorName);
+    if (!warrior) {
+      logEvent('warrior:missing', {
+        expected: expectedWarriorName,
+        available: warriors.map((w) => w.name),
+      });
+      process.exit(1);
+    }
+    logEvent('warrior:found', { id: warrior.id, name: warrior.name });
+  } catch (err) {
+    logEvent('warriors:fail', { error: err.message });
+    process.exit(1);
+  }
+
+  const socket = connectSocket(session.cookieHeader);
+
+  let exitCode = 2;
+  let timedOut = true;
+
+  const timeout = setTimeout(() => {
+    if (timedOut) {
+      logEvent('timeout', { after_ms: timeoutMs });
+      socket.disconnect();
+      process.exit(2);
+    }
+  }, timeoutMs);
+
+  function finish(code) {
+    timedOut = false;
+    exitCode = code;
+    clearTimeout(timeout);
+    logEvent('bot:done', { exitCode });
+    socket.disconnect();
+    // Give the disconnect packet a tick to flush before exiting.
+    setImmediate(() => process.exit(exitCode));
+  }
+
+  socket.on('connect', () => {
+    logEvent('socket:connect', { sid: socket.id });
+    socket.emit('queue:join', { warrior_id: warrior.id });
+  });
+
+  socket.on('connect_error', (err) => {
+    logEvent('socket:connect_error', { message: err.message ?? String(err) });
+  });
+
+  socket.on('disconnect', (reason) => {
+    logEvent('socket:disconnect', { reason });
+  });
+
+  const passthrough = ['queue:joined', 'queue:left', 'queue:error', 'match:found', 'auth_error'];
+  for (const ev of passthrough) {
+    socket.on(ev, (data) => {
+      logEvent(ev, data, { sid: socket.id });
+      if (ev === 'queue:error' || ev === 'auth_error') {
+        finish(1);
+      }
+    });
+  }
+
+  socket.on('match:result', (data) => {
+    logEvent('match:result', data, { sid: socket.id });
+    finish(0);
+  });
+}

--- a/frontend/scripts/bot-red.mjs
+++ b/frontend/scripts/bot-red.mjs
@@ -1,0 +1,22 @@
+// Matchmaking bot — plays as the seeded `_test_red` user with the Imp warrior.
+// Run as a separate Node process. See bot-common.mjs for the shared flow.
+
+import { runBot } from './bot-common.mjs';
+
+const password = process.env.TEST_USER_PASSWORD;
+if (!password) {
+  console.error(
+    JSON.stringify({
+      event: 'config:missing',
+      data: { error: 'TEST_USER_PASSWORD env var required (load from backend/.env)' },
+    }),
+  );
+  process.exit(1);
+}
+
+await runBot({
+  role: 'red',
+  username: '_test_red',
+  password,
+  expectedWarriorName: 'Imp',
+});

--- a/frontend/scripts/matchmaking-e2e.mjs
+++ b/frontend/scripts/matchmaking-e2e.mjs
@@ -1,0 +1,172 @@
+// End-to-end matchmaking test orchestrator.
+//
+// Spawns bot-red.mjs and bot-blue.mjs as separate Node processes, captures
+// their JSON-lines stdout, and asserts cross-bot properties: both bots got
+// distinct socket sids, both saw match:found for the same match_id, both saw
+// match:result. Exits 0 on pass, non-zero on fail.
+//
+// Prerequisites:
+//   1. docker compose up -d (postgres + redis)
+//   2. cargo run --bin seed-test-users --features dev-fixtures (in backend/) — one-time
+//   3. cargo run (in backend/) — leave running
+//
+// Usage:
+//   node frontend/scripts/matchmaking-e2e.mjs
+
+import { spawn } from 'node:child_process';
+import { readFileSync, existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function loadEnvFile(path) {
+  if (!existsSync(path)) return {};
+  const out = {};
+  for (const line of readFileSync(path, 'utf-8').split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eq = trimmed.indexOf('=');
+    if (eq < 0) continue;
+    out[trimmed.slice(0, eq).trim()] = trimmed.slice(eq + 1).trim();
+  }
+  return out;
+}
+
+const backendEnv = loadEnvFile(resolve(__dirname, '../../backend/.env'));
+const password = process.env.TEST_USER_PASSWORD ?? backendEnv.TEST_USER_PASSWORD;
+if (!password) {
+  console.error(
+    'TEST_USER_PASSWORD not set. Either export it or define it in backend/.env.',
+  );
+  process.exit(1);
+}
+
+function startBot(name) {
+  const script = resolve(__dirname, name);
+  const child = spawn('node', [script], {
+    env: { ...process.env, TEST_USER_PASSWORD: password },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  const events = [];
+  let stderrBuf = '';
+  let stdoutBuf = '';
+
+  child.stdout.setEncoding('utf-8');
+  child.stdout.on('data', (chunk) => {
+    stdoutBuf += chunk;
+    let idx;
+    while ((idx = stdoutBuf.indexOf('\n')) >= 0) {
+      const line = stdoutBuf.slice(0, idx);
+      stdoutBuf = stdoutBuf.slice(idx + 1);
+      if (!line.trim()) continue;
+      try {
+        events.push(JSON.parse(line));
+      } catch {
+        events.push({ raw: line });
+      }
+    }
+  });
+  child.stderr.setEncoding('utf-8');
+  child.stderr.on('data', (chunk) => {
+    stderrBuf += chunk;
+  });
+
+  const exitPromise = new Promise((resolveExit) => {
+    child.on('exit', (code) => resolveExit({ code, events, stderr: stderrBuf }));
+  });
+
+  return { child, exitPromise };
+}
+
+console.log('spawning bot-red and bot-blue as separate Node processes...');
+const red = startBot('bot-red.mjs');
+// Brief stagger to make ordering deterministic (red joins queue first, blue triggers match).
+await new Promise((r) => setTimeout(r, 250));
+const blue = startBot('bot-blue.mjs');
+
+const [redResult, blueResult] = await Promise.all([red.exitPromise, blue.exitPromise]);
+
+function dumpBot(label, r) {
+  console.log(`\n--- ${label} events (${r.events.length}) ---`);
+  for (const e of r.events) console.log('  ' + JSON.stringify(e));
+  console.log(`${label} exit code: ${r.code}`);
+  if (r.stderr) console.log(`${label} stderr:\n${r.stderr}`);
+}
+
+dumpBot('bot-red', redResult);
+dumpBot('bot-blue', blueResult);
+
+function findEvent(events, name) {
+  return events.find((e) => e.event === name);
+}
+
+const failures = [];
+
+if (redResult.code !== 0) failures.push(`bot-red exited with code ${redResult.code}`);
+if (blueResult.code !== 0) failures.push(`bot-blue exited with code ${blueResult.code}`);
+
+const redConnect = findEvent(redResult.events, 'socket:connect');
+const blueConnect = findEvent(blueResult.events, 'socket:connect');
+
+if (!redConnect) failures.push('bot-red never connected');
+if (!blueConnect) failures.push('bot-blue never connected');
+
+if (redConnect && blueConnect) {
+  if (redConnect.data.sid === blueConnect.data.sid) {
+    failures.push(
+      `DISTINCT-SIDS check FAILED — both bots got sid=${redConnect.data.sid}. ` +
+        `Two separate Node processes should never share a sid; if this fires, ` +
+        `something is deeply wrong (server reusing sids, or processes aren't actually separate).`,
+    );
+  } else {
+    console.log(`\n✓ distinct sids — red=${redConnect.data.sid}, blue=${blueConnect.data.sid}`);
+  }
+}
+
+const redFound = findEvent(redResult.events, 'match:found');
+const blueFound = findEvent(blueResult.events, 'match:found');
+
+if (!redFound) failures.push('bot-red never received match:found');
+if (!blueFound) failures.push('bot-blue never received match:found');
+
+if (redFound && blueFound) {
+  if (redFound.data.match_id !== blueFound.data.match_id) {
+    failures.push(
+      `match:found mismatch — red=${redFound.data.match_id}, blue=${blueFound.data.match_id}`,
+    );
+  } else {
+    console.log(`✓ both saw match:found — match_id=${redFound.data.match_id}`);
+  }
+}
+
+const redOutcome = findEvent(redResult.events, 'match:result');
+const blueOutcome = findEvent(blueResult.events, 'match:result');
+
+if (!redOutcome) failures.push('bot-red never received match:result');
+if (!blueOutcome) failures.push('bot-blue never received match:result');
+
+if (redOutcome && blueOutcome) {
+  if (redOutcome.data.match_id !== blueOutcome.data.match_id) {
+    failures.push(
+      `match:result mismatch — red=${redOutcome.data.match_id}, blue=${blueOutcome.data.match_id}`,
+    );
+  } else if (redOutcome.data.result !== blueOutcome.data.result) {
+    failures.push(
+      `match result outcome mismatch — red saw "${redOutcome.data.result}", blue saw "${blueOutcome.data.result}"`,
+    );
+  } else {
+    console.log(
+      `✓ both saw match:result — outcome="${redOutcome.data.result}", steps=${redOutcome.data.steps_taken}`,
+    );
+  }
+}
+
+if (failures.length) {
+  console.log('\n=== FAILED ===');
+  for (const f of failures) console.log(`  - ${f}`);
+  process.exit(1);
+}
+
+console.log('\n=== PASS ===');
+process.exit(0);


### PR DESCRIPTION
## Summary
- Establishes reliable matchmaking infrastructure (test fixtures + end-to-end harness) as the foundation for the live battle viewer (issue #50).
- Fixes a silent delivery bug in matchmaking that blocked the prior #50 attempt: `socket.to(sid).emit()` never reached the other player because socketioxide doesn't auto-join sockets to sid-named rooms.
- All under a `dev-fixtures` cargo feature so release builds neither compile nor ship test infrastructure.

## What's in here

### Test fixtures (gated, dev-only)
- `dev-fixtures` cargo feature on the backend.
- `seed-test-users` binary creates `_test_red` and `_test_blue` users with canonical Imp and Dwarf warriors. Idempotent. Password from `TEST_USER_PASSWORD` in `backend/.env` (placeholder added to `.env.example`).
- Username validation now blocks the `_test_` prefix on normal registration so real users can't squat or collide.

### Bot harness
- `frontend/scripts/bot-red.mjs` and `bot-blue.mjs` each log in as one seeded user, fetch the seeded warrior, open a Socket.IO connection with `forceNew: true` + websocket-only transport, join the queue, and emit JSON-lines events to stdout.
- `frontend/scripts/matchmaking-e2e.mjs` orchestrator spawns the two bots as **separate Node processes** (sidestepping any same-process Manager-sharing concerns), asserts distinct sids, matching `match_id` across `match:found`/`match:result`, and clean exits.

### Room-based delivery fix
The prior `emit_to_socket(sid)` helper at `events.rs:185` used `socket.to(target_sid).emit(...)` to deliver to the other participant. socketioxide does **not** auto-join sockets to a sid-named room (unlike vanilla Node Socket.IO), so this delivered to no one. The harness reproduced it cleanly: bot-blue (the participant whose `queue:join` triggered the pair) received both events; bot-red received nothing and timed out.

The fix threads `SocketIo` through `register_events`, looks up both sockets via `io.get_socket(sid)`, has both `.join(format!(\"match:{match_id}\"))`, and emits via `io.to(room).emit(...)` (namespace-level broadcast, no self-exclusion semantics). The broken helper is removed entirely.

## Test plan
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean (with and without `--features dev-fixtures`)
- [x] `cargo test` — 60+ tests pass including new `username_reserved_test_prefix_blocked` and `username_test_prefix_only_blocks_at_start` cases
- [x] `npm run lint` / `format:check` / `test` clean
- [x] Seed binary runs idempotently against a fresh DB
- [x] Release build (no feature flag) does not compile the seed binary
- [x] `node frontend/scripts/matchmaking-e2e.mjs` end-to-end: both bots get distinct sids, both receive `match:found` and `match:result` with matching `match_id`, exit code 0

## Next up (not in this PR)
- PR 2: emit `match:start` with replay payload (warrior sources + playback timing) so the frontend can render the deterministic battle locally.
- PR 3: BattleViewer frontend page that consumes `match:start` and runs the wasm engine in lockstep.
- PR 4: spectator join-in-progress, reconnection, polish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)