### PR TITLE
Emit match:start with replay payload (issue #50)

### DIFF
--- a/backend/src/matchmaking/events.rs
+++ b/backend/src/matchmaking/events.rs
@@ -1,6 +1,7 @@
 use crate::auth::socket::{get_auth, require_auth};
 use crate::matchmaking::queue::{QueueEntry, RedisQueue};
 use crate::models::warrior::Warrior;
+use chrono::Utc;
 use core_war_engine::{parse_warrior, MatchResult, MatchState};
 use serde::{Deserialize, Serialize};
 use socketioxide::extract::{Data, SocketRef};
@@ -12,6 +13,13 @@ use uuid::Uuid;
 
 const CORE_SIZE: usize = 8000;
 const MAX_STEPS: u64 = 80_000;
+const RED_START: usize = 0;
+const BLUE_START: usize = CORE_SIZE / 2;
+// Playback rate for the client-side replay. Server runs the battle once, the
+// outcome is deterministic, and clients render locally paced from
+// `playback_start_time_ms`. Tuning knob for the live viewer UX — higher is
+// snappier, lower draws out the moment-to-moment activity.
+const STEPS_PER_SEC: u32 = 2000;
 
 #[derive(Deserialize)]
 pub struct QueueJoinData {
@@ -31,6 +39,23 @@ struct MatchFound {
     blue_username: String,
     red_warrior: String,
     blue_warrior: String,
+}
+
+#[derive(Serialize, Clone)]
+struct MatchStart {
+    match_id: String,
+    red_username: String,
+    blue_username: String,
+    red_warrior_source: String,
+    blue_warrior_source: String,
+    core_size: usize,
+    max_steps: u64,
+    red_start: usize,
+    blue_start: usize,
+    steps_taken: u64,
+    result: String,
+    playback_start_time_ms: i64,
+    steps_per_sec: u32,
 }
 
 #[derive(Serialize, Clone)]
@@ -275,13 +300,17 @@ async fn run_matched_battle(io: SocketIo, db: PgPool, red: QueueEntry, blue: Que
 
     let _ = io.to(room.clone()).emit("match:found", &found_event);
 
+    let red_source_for_battle = red_source.clone();
+    let blue_source_for_battle = blue_source.clone();
     let battle_result = tokio::task::spawn_blocking(move || {
-        let red_parsed = parse_warrior(&red_source).map_err(|e| format!("Red parse: {e}"))?;
-        let blue_parsed = parse_warrior(&blue_source).map_err(|e| format!("Blue parse: {e}"))?;
+        let red_parsed =
+            parse_warrior(&red_source_for_battle).map_err(|e| format!("Red parse: {e}"))?;
+        let blue_parsed =
+            parse_warrior(&blue_source_for_battle).map_err(|e| format!("Blue parse: {e}"))?;
 
         let mut m = MatchState::new(CORE_SIZE, MAX_STEPS);
-        m.load_warrior(0, &red_parsed, 0);
-        m.load_warrior(1, &blue_parsed, CORE_SIZE / 2);
+        m.load_warrior(0, &red_parsed, RED_START);
+        m.load_warrior(1, &blue_parsed, BLUE_START);
 
         while m.step() {}
 
@@ -308,6 +337,30 @@ async fn run_matched_battle(io: SocketIo, db: PgPool, red: QueueEntry, blue: Que
             return;
         }
     };
+
+    // Emit the full replay payload. Clients use playback_start_time_ms to
+    // pace the local wasm replay deterministically; match:result follows
+    // immediately as informational confirmation of the canonical outcome.
+    // No server-side scheduling — pacing is purely client-side, which makes
+    // spectator join-in-progress trivial (compute current step from elapsed
+    // time and fast-forward locally).
+    let start_event = MatchStart {
+        match_id: match_id.clone(),
+        red_username: red.username.clone(),
+        blue_username: blue.username.clone(),
+        red_warrior_source: red_source,
+        blue_warrior_source: blue_source,
+        core_size: CORE_SIZE,
+        max_steps: MAX_STEPS,
+        red_start: RED_START,
+        blue_start: BLUE_START,
+        steps_taken,
+        result: result_str.clone(),
+        playback_start_time_ms: Utc::now().timestamp_millis(),
+        steps_per_sec: STEPS_PER_SEC,
+    };
+
+    let _ = io.to(room.clone()).emit("match:start", &start_event);
 
     let result_event = MatchResultEvent {
         match_id: match_id.clone(),

--- a/frontend/scripts/bot-common.mjs
+++ b/frontend/scripts/bot-common.mjs
@@ -138,7 +138,14 @@ export async function runBot({ role, username, password, expectedWarriorName, ti
     logEvent('socket:disconnect', { reason });
   });
 
-  const passthrough = ['queue:joined', 'queue:left', 'queue:error', 'match:found', 'auth_error'];
+  const passthrough = [
+    'queue:joined',
+    'queue:left',
+    'queue:error',
+    'match:found',
+    'match:start',
+    'auth_error',
+  ];
   for (const ev of passthrough) {
     socket.on(ev, (data) => {
       logEvent(ev, data, { sid: socket.id });

--- a/frontend/scripts/matchmaking-e2e.mjs
+++ b/frontend/scripts/matchmaking-e2e.mjs
@@ -140,6 +140,63 @@ if (redFound && blueFound) {
   }
 }
 
+const redStart = findEvent(redResult.events, 'match:start');
+const blueStart = findEvent(blueResult.events, 'match:start');
+
+if (!redStart) failures.push('bot-red never received match:start');
+if (!blueStart) failures.push('bot-blue never received match:start');
+
+if (redStart && blueStart) {
+  const requiredFields = [
+    'match_id',
+    'red_username',
+    'blue_username',
+    'red_warrior_source',
+    'blue_warrior_source',
+    'core_size',
+    'max_steps',
+    'red_start',
+    'blue_start',
+    'steps_taken',
+    'result',
+    'playback_start_time_ms',
+    'steps_per_sec',
+  ];
+  for (const f of requiredFields) {
+    if (!(f in redStart.data)) failures.push(`bot-red match:start missing field "${f}"`);
+    if (!(f in blueStart.data)) failures.push(`bot-blue match:start missing field "${f}"`);
+    if (
+      f in redStart.data &&
+      f in blueStart.data &&
+      JSON.stringify(redStart.data[f]) !== JSON.stringify(blueStart.data[f])
+    ) {
+      failures.push(
+        `match:start field "${f}" differs across bots — red=${JSON.stringify(redStart.data[f])}, blue=${JSON.stringify(blueStart.data[f])}`,
+      );
+    }
+  }
+  if (failures.length === 0 || !failures.some((f) => f.startsWith('match:start'))) {
+    console.log(
+      `✓ both saw match:start — steps_taken=${redStart.data.steps_taken}, steps_per_sec=${redStart.data.steps_per_sec}, playback_start_time_ms=${redStart.data.playback_start_time_ms}`,
+    );
+  }
+}
+
+function eventIndex(events, name) {
+  return events.findIndex((e) => e.event === name);
+}
+
+for (const [label, events] of [
+  ['bot-red', redResult.events],
+  ['bot-blue', blueResult.events],
+]) {
+  const startIdx = eventIndex(events, 'match:start');
+  const resultIdx = eventIndex(events, 'match:result');
+  if (startIdx >= 0 && resultIdx >= 0 && startIdx >= resultIdx) {
+    failures.push(`${label} received match:result before match:start (idx ${resultIdx} vs ${startIdx})`);
+  }
+}
+
 const redOutcome = findEvent(redResult.events, 'match:result');
 const blueOutcome = findEvent(blueResult.events, 'match:result');
 


### PR DESCRIPTION
## Summary
- Adds the `match:start` Socket.IO event that carries everything a client needs to render the battle locally via the wasm engine — red/blue warrior sources, core size, max steps, start positions, the canonical outcome, a server timestamp marking the start of paced replay, and the playback rate.
- Sets up the client-side replay architecture from [project_strategy](#) without requiring any server-side scheduling.

## Design choices

**Immediate-both pattern.** The server emits `match:start` and `match:result` back-to-back as soon as the deterministic battle finishes. Clients own playback pacing locally:
```
current_step = (now - playback_start_time_ms) * steps_per_sec / 1000
```
No server-side scheduling, no per-tick task, no buffered state. Spectator join-in-progress falls out trivially (client computes elapsed time, fast-forwards locally). Server stays stateless between matches.

**2000 steps/sec playback.** At a worst-case 80000-step match, that's a 40-second paced replay — snappy enough to feel responsive while still letting moment-to-moment activity register visually. Hardcoded in `events.rs` as `STEPS_PER_SEC` for now; tune once the frontend visualizer lands.

## What's in the match:start payload

| Field | Type | Purpose |
|---|---|---|
| `match_id` | string | Correlates with `match:found` / `match:result` |
| `red_username` / `blue_username` | string | Display names |
| `red_warrior_source` / `blue_warrior_source` | string | Full `.red` source, parsed client-side via the wasm parser |
| `core_size` | int | 8000 |
| `max_steps` | int | 80000 |
| `red_start` / `blue_start` | int | Load offsets (0 and 4000) |
| `steps_taken` | int | Actual battle length |
| `result` | string | `red_win` / `blue_win` / `tie` / `all_dead` |
| `playback_start_time_ms` | int | Server-side `Utc::now().timestamp_millis()` |
| `steps_per_sec` | int | 2000 |

## Test plan
- [x] `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` (with and without `--features dev-fixtures`)
- [x] `cargo test` — all existing tests pass
- [x] `npm run lint` / `format:check` / `test` clean
- [x] End-to-end harness: both bots receive `match:start` with byte-identical payload across the pair, plus the existing `match:found` / `match:result` assertions

## Next up
- PR 3: Frontend `BattleViewer` page that joins the match room, consumes `match:start`, and renders the deterministic battle via the wasm engine, paced from `playback_start_time_ms`.
- PR 4: Spectator join-in-progress, reconnection, completion UX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)