### PR TITLE
Add MatchViewerPage that replays matches client-side (issue #50)

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -18,6 +18,8 @@ const LeaderboardPage = React.lazy(() => import('./pages/LeaderboardPage'));
 const ProfilePage = React.lazy(() => import('./pages/profile/ProfilePage'));
 // eslint-disable-next-line react-refresh/only-export-components
 const LobbyPage = React.lazy(() => import('./pages/LobbyPage'));
+// eslint-disable-next-line react-refresh/only-export-components
+const MatchViewerPage = React.lazy(() => import('./pages/match/MatchViewerPage'));
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
@@ -79,6 +81,14 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
               element={
                 <Suspense>
                   <LobbyPage />
+                </Suspense>
+              }
+            />
+            <Route
+              path="/match/:matchId"
+              element={
+                <Suspense>
+                  <MatchViewerPage />
                 </Suspense>
               }
             />

--- a/frontend/src/pages/LobbyPage.tsx
+++ b/frontend/src/pages/LobbyPage.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../api/AuthContext';
 import { useWarriorLibrary, type Warrior } from '../warriors/library';
 import { io, type Socket } from 'socket.io-client';
+import type { MatchStartPayload } from './match/useMatchReplay';
 
 const API_BASE = import.meta.env.VITE_API_URL ?? 'http://localhost:3001';
 
@@ -92,6 +94,7 @@ type Phase = 'idle' | 'queued' | 'matched' | 'result';
 
 export default function LobbyPage() {
   const { user } = useAuth();
+  const navigate = useNavigate();
   const library = useWarriorLibrary();
   const userWarriors = library.filter((w: Warrior) => serverUuid(w) !== null);
   const firstUuid = userWarriors.length > 0 ? (serverUuid(userWarriors[0]) ?? '') : '';
@@ -118,6 +121,12 @@ export default function LobbyPage() {
     s.on('match:found', (data: MatchFoundData) => {
       setMatchInfo(data);
       setPhase('matched');
+    });
+    s.on('match:start', (data: MatchStartPayload) => {
+      // Hand off to the dedicated viewer route with the full replay payload.
+      // The lobby's socket gets cleaned up on unmount; the viewer doesn't need
+      // one because match:start carries everything for deterministic replay.
+      navigate(`/match/${data.match_id}`, { state: { matchStart: data } });
     });
     s.on('match:result', (data: MatchResultData) => {
       setResult(data);

--- a/frontend/src/pages/match/MatchViewerPage.tsx
+++ b/frontend/src/pages/match/MatchViewerPage.tsx
@@ -1,0 +1,169 @@
+import { useEffect } from 'react';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import { useAuth } from '../../api/AuthContext';
+import { GRID_CONTAINER_STYLE } from '../battlefield/styles';
+import { useMatchReplay, type MatchStartPayload } from './useMatchReplay';
+
+const PAGE_STYLE: React.CSSProperties = {
+  minHeight: '100vh',
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  padding: '1.5rem',
+  gap: '1rem',
+};
+
+const TITLE_STYLE: React.CSSProperties = {
+  margin: 0,
+  fontSize: '1.6rem',
+  color: '#e94560',
+  letterSpacing: '0.08em',
+};
+
+const VERSUS_STYLE: React.CSSProperties = {
+  margin: 0,
+  fontSize: '1rem',
+  color: '#e0e0e0',
+  letterSpacing: '0.04em',
+};
+
+const STATUS_ROW: React.CSSProperties = {
+  display: 'flex',
+  gap: '2rem',
+  fontSize: '0.85rem',
+  color: '#bbb',
+  fontFamily: '"JetBrains Mono", "Fira Code", monospace',
+};
+
+const RESULT_BOX: React.CSSProperties = {
+  padding: '1rem 1.5rem',
+  backgroundColor: '#111',
+  border: '1px solid #333',
+  borderRadius: '8px',
+  textAlign: 'center',
+  minWidth: '260px',
+};
+
+const WARRIOR_ROW: React.CSSProperties = {
+  display: 'flex',
+  gap: '2rem',
+  fontSize: '0.85rem',
+  fontFamily: '"JetBrains Mono", "Fira Code", monospace',
+};
+
+function resultLabel(result: string, red: string, blue: string, me: string | undefined): string {
+  if (result === 'tie' || result === 'all_dead') return 'Draw';
+  const winner = result === 'red_win' ? red : blue;
+  if (!me) return `${winner} wins`;
+  return winner === me ? 'Victory!' : 'Defeat';
+}
+
+function resultColor(result: string, red: string, blue: string, me: string | undefined): string {
+  if (result === 'tie' || result === 'all_dead') return '#f0c040';
+  const winner = result === 'red_win' ? red : blue;
+  if (!me) return '#e0e0e0';
+  return winner === me ? '#4caf50' : '#e94560';
+}
+
+export default function MatchViewerPage() {
+  const { user } = useAuth();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const params = useParams<{ matchId: string }>();
+
+  // Match payload comes from the lobby via router state. Reload-without-state
+  // bounces back to the lobby (spectator-join via deep-link is PR 4 territory).
+  const payload = (location.state as { matchStart?: MatchStartPayload } | null)?.matchStart ?? null;
+
+  useEffect(() => {
+    if (!payload) {
+      navigate('/lobby', { replace: true });
+    }
+  }, [payload, navigate]);
+
+  const { ready, currentStep, totalSteps, warriors, finished, parseError, gridRef } =
+    useMatchReplay(payload);
+
+  if (!payload) {
+    return (
+      <div style={PAGE_STYLE}>
+        <p style={{ color: '#888' }}>No active match — redirecting to lobby…</p>
+      </div>
+    );
+  }
+
+  const matchIdShort = params.matchId?.slice(0, 8) ?? payload.match_id.slice(0, 8);
+
+  return (
+    <div style={PAGE_STYLE}>
+      <h1 style={TITLE_STYLE}>MATCH {matchIdShort}</h1>
+      <p style={VERSUS_STYLE}>
+        {payload.red_username} vs {payload.blue_username}
+      </p>
+
+      {parseError && <div style={{ color: '#e94560' }}>{parseError}</div>}
+
+      <div ref={gridRef} style={GRID_CONTAINER_STYLE} />
+
+      <div style={STATUS_ROW}>
+        <span>
+          step {currentStep.toLocaleString()} / {totalSteps.toLocaleString()}
+        </span>
+        <span>{payload.steps_per_sec.toLocaleString()} steps/sec</span>
+      </div>
+
+      <div style={WARRIOR_ROW}>
+        {warriors.map((w, i) => (
+          <span key={i} style={{ color: i === 0 ? '#e94560' : '#4fc3f7' }}>
+            {w.name} — {w.alive ? `${w.procs} proc${w.procs === 1 ? '' : 's'}` : 'dead'}
+          </span>
+        ))}
+      </div>
+
+      {finished && (
+        <div style={RESULT_BOX}>
+          <p
+            style={{
+              fontSize: '1.3rem',
+              fontWeight: 700,
+              margin: 0,
+              color: resultColor(
+                payload.result,
+                payload.red_username,
+                payload.blue_username,
+                user?.username,
+              ),
+            }}
+          >
+            {resultLabel(
+              payload.result,
+              payload.red_username,
+              payload.blue_username,
+              user?.username,
+            )}
+          </p>
+          <p style={{ color: '#888', fontSize: '0.85rem', margin: '0.5rem 0 1rem' }}>
+            {totalSteps.toLocaleString()} steps
+          </p>
+          <button
+            style={{
+              padding: '0.5rem 1.5rem',
+              backgroundColor: '#e94560',
+              color: '#fff',
+              border: 'none',
+              borderRadius: '6px',
+              cursor: 'pointer',
+              fontFamily: 'inherit',
+              letterSpacing: '0.05em',
+            }}
+            onClick={() => navigate('/lobby')}
+          >
+            Back to Lobby
+          </button>
+        </div>
+      )}
+
+      {!ready && !parseError && <p style={{ color: '#888' }}>Loading engine…</p>}
+    </div>
+  );
+}

--- a/frontend/src/pages/match/useMatchReplay.test.ts
+++ b/frontend/src/pages/match/useMatchReplay.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { computeTargetStep } from './useMatchReplay';
+
+describe('computeTargetStep', () => {
+  const PLAYBACK_START = 1_000_000;
+  const STEPS_PER_SEC = 2000;
+  const STEPS_TAKEN = 80_000;
+
+  it('returns 0 when wall clock is exactly the playback start', () => {
+    expect(computeTargetStep(PLAYBACK_START, PLAYBACK_START, STEPS_PER_SEC, STEPS_TAKEN)).toBe(0);
+  });
+
+  it('returns 0 for negative elapsed (client clock ahead of server)', () => {
+    expect(
+      computeTargetStep(PLAYBACK_START - 5000, PLAYBACK_START, STEPS_PER_SEC, STEPS_TAKEN),
+    ).toBe(0);
+  });
+
+  it('returns 1000 after 500ms at 2000 steps/sec', () => {
+    expect(
+      computeTargetStep(PLAYBACK_START + 500, PLAYBACK_START, STEPS_PER_SEC, STEPS_TAKEN),
+    ).toBe(1000);
+  });
+
+  it('floors fractional steps (no rounding up)', () => {
+    expect(computeTargetStep(PLAYBACK_START + 1, PLAYBACK_START, STEPS_PER_SEC, STEPS_TAKEN)).toBe(
+      2,
+    );
+    expect(
+      computeTargetStep(PLAYBACK_START + 100, PLAYBACK_START, STEPS_PER_SEC, STEPS_TAKEN),
+    ).toBe(200);
+  });
+
+  it('caps at steps_taken once elapsed time would exceed the canonical match length', () => {
+    // 40s × 2000 steps/s = 80_000 — the exact boundary
+    expect(
+      computeTargetStep(PLAYBACK_START + 40_000, PLAYBACK_START, STEPS_PER_SEC, STEPS_TAKEN),
+    ).toBe(STEPS_TAKEN);
+    // Far past
+    expect(
+      computeTargetStep(PLAYBACK_START + 999_999, PLAYBACK_START, STEPS_PER_SEC, STEPS_TAKEN),
+    ).toBe(STEPS_TAKEN);
+  });
+
+  it('caps correctly for short matches (less than max_steps)', () => {
+    const shortMatch = 3000;
+    expect(
+      computeTargetStep(PLAYBACK_START + 5_000, PLAYBACK_START, STEPS_PER_SEC, shortMatch),
+    ).toBe(shortMatch);
+  });
+
+  it('scales with steps_per_sec', () => {
+    expect(computeTargetStep(PLAYBACK_START + 1000, PLAYBACK_START, 1000, STEPS_TAKEN)).toBe(1000);
+    expect(computeTargetStep(PLAYBACK_START + 1000, PLAYBACK_START, 4000, STEPS_TAKEN)).toBe(4000);
+  });
+});

--- a/frontend/src/pages/match/useMatchReplay.ts
+++ b/frontend/src/pages/match/useMatchReplay.ts
@@ -1,0 +1,175 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import init, { parseWarrior, MatchState } from 'core-war-engine';
+import { createCoreRenderer, type CoreRenderer } from '../../core/coreRenderer';
+
+export type MatchStartPayload = {
+  match_id: string;
+  red_username: string;
+  blue_username: string;
+  red_warrior_source: string;
+  blue_warrior_source: string;
+  core_size: number;
+  max_steps: number;
+  red_start: number;
+  blue_start: number;
+  steps_taken: number;
+  result: string;
+  playback_start_time_ms: number;
+  steps_per_sec: number;
+};
+
+export type WarriorState = {
+  name: string;
+  alive: boolean;
+  procs: number;
+};
+
+/**
+ * Pure pacing function — returns the local replay's target step at a given
+ * wall-clock instant given the server's match:start payload. Clamped to
+ * [0, steps_taken] to tolerate clock skew before the start time and to stop
+ * advancing once the canonical match length is reached.
+ */
+export function computeTargetStep(
+  nowMs: number,
+  playbackStartTimeMs: number,
+  stepsPerSec: number,
+  stepsTaken: number,
+): number {
+  const elapsedMs = nowMs - playbackStartTimeMs;
+  if (elapsedMs <= 0) return 0;
+  const target = Math.floor((elapsedMs * stepsPerSec) / 1000);
+  return target < stepsTaken ? target : stepsTaken;
+}
+
+export function useMatchReplay(payload: MatchStartPayload | null) {
+  const [ready, setReady] = useState(false);
+  const [currentStep, setCurrentStep] = useState(0);
+  const [warriors, setWarriors] = useState<WarriorState[]>([]);
+  const [finished, setFinished] = useState(false);
+  const [parseError, setParseError] = useState<string | null>(null);
+
+  const gridRef = useRef<HTMLDivElement>(null);
+  const rendererRef = useRef<CoreRenderer | null>(null);
+  const matchRef = useRef<MatchState | null>(null);
+  const warriorNamesRef = useRef<string[]>([]);
+  const rafRef = useRef(0);
+  const frameCountRef = useRef(0);
+
+  // Mount the PixiJS grid renderer once.
+  useEffect(() => {
+    if (!gridRef.current) return;
+    const renderer = createCoreRenderer(gridRef.current);
+    rendererRef.current = renderer;
+    return () => {
+      renderer.destroy();
+      rendererRef.current = null;
+    };
+  }, []);
+
+  const syncWarriors = useCallback(() => {
+    const m = matchRef.current;
+    if (!m) return;
+    const names = warriorNamesRef.current;
+    const next: WarriorState[] = [];
+    for (let i = 0; i < m.warriorCount(); i++) {
+      next.push({
+        name: names[i] ?? `Warrior ${i}`,
+        alive: m.warriorIsAlive(i),
+        procs: m.warriorProcessCount(i),
+      });
+    }
+    setWarriors(next);
+  }, []);
+
+  // Initialize the wasm engine and load the warriors once the payload arrives.
+  useEffect(() => {
+    if (!payload) return;
+    let cancelled = false;
+
+    init().then(() => {
+      if (cancelled) return;
+      try {
+        const w1 = parseWarrior(payload.red_warrior_source);
+        const w2 = parseWarrior(payload.blue_warrior_source);
+        const match = new MatchState(payload.core_size, payload.max_steps);
+        match.loadWarrior(0, w1, payload.red_start);
+        match.loadWarrior(1, w2, payload.blue_start);
+        matchRef.current = match;
+        warriorNamesRef.current = [
+          w1.name() ?? payload.red_username,
+          w2.name() ?? payload.blue_username,
+        ];
+        if (rendererRef.current) {
+          rendererRef.current.update(match.coreOwnership());
+        }
+        syncWarriors();
+        setReady(true);
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        setParseError(`Engine init failed: ${msg}`);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [payload, syncWarriors]);
+
+  // Drive the paced replay loop.
+  useEffect(() => {
+    if (!ready || !payload) return;
+
+    function tick() {
+      const m = matchRef.current;
+      const r = rendererRef.current;
+      if (!m || !r || !payload) return;
+
+      const target = computeTargetStep(
+        Date.now(),
+        payload.playback_start_time_ms,
+        payload.steps_per_sec,
+        payload.steps_taken,
+      );
+
+      const cur = m.steps();
+      const delta = target - cur;
+      if (delta > 0) {
+        m.stepN(delta);
+        r.update(m.coreOwnership());
+      }
+
+      // Throttle React state updates — once every ~6 frames is plenty for
+      // the counter/process-count UI; the grid itself updates every frame.
+      frameCountRef.current++;
+      if (frameCountRef.current % 6 === 0) {
+        setCurrentStep(m.steps());
+        syncWarriors();
+      }
+
+      if (target >= payload.steps_taken) {
+        setCurrentStep(m.steps());
+        syncWarriors();
+        setFinished(true);
+        return;
+      }
+
+      rafRef.current = requestAnimationFrame(tick);
+    }
+
+    rafRef.current = requestAnimationFrame(tick);
+    return () => {
+      cancelAnimationFrame(rafRef.current);
+    };
+  }, [ready, payload, syncWarriors]);
+
+  return {
+    ready,
+    currentStep,
+    totalSteps: payload?.steps_taken ?? 0,
+    warriors,
+    finished,
+    parseError,
+    gridRef,
+  };
+}


### PR DESCRIPTION
## Summary
- New `/match/:matchId` route + `MatchViewerPage` that replays the deterministic battle locally via the wasm engine, paced from the server's `playback_start_time_ms`.
- Lobby now navigates to the viewer on `match:start`, handing off the full replay payload via router state — the viewer doesn't need its own Socket.IO connection.
- Reuses the existing PixiJS `createCoreRenderer` and the same `MatchState` patterns as the local-battle page.

## Architecture (per project strategy)

Pure client-side replay:
- No persistent per-match server state.
- No per-tick state events on the wire — the entire replay derives from a single `match:start` payload plus the client's local clock.
- Pacing: `target_step = (now - playback_start_time_ms) * steps_per_sec / 1000`, clamped to `[0, steps_taken]`. The hook catches up via `match.stepN(target - current)` each animation frame, then renders.
- Spectator join-in-progress later (PR 4) just feeds `match:start` in via a different path; the viewer doesn't care where the payload came from.

## Files

| File | Purpose |
|---|---|
| `frontend/src/pages/match/useMatchReplay.ts` | Owns the `MatchState`, the `requestAnimationFrame` loop, and the paced `stepN` catch-up. Exports a pure `computeTargetStep` so the pacing math is testable in isolation. |
| `frontend/src/pages/match/MatchViewerPage.tsx` | Page component. Reads `match:start` from router state, mounts the grid, surfaces step counter / per-warrior process counts / final result reveal. Missing state → bounce to `/lobby`. |
| `frontend/src/pages/match/useMatchReplay.test.ts` | Vitest cases for `computeTargetStep` — clock skew, fractional steps, cap-at-`steps_taken`, `steps_per_sec` scaling. |
| `frontend/src/pages/LobbyPage.tsx` | Adds `match:start` listener that `navigate()`s with the payload. Existing phase transitions unchanged; the \"Running battle…\" UI now only flashes for ~50–150ms. |
| `frontend/src/main.tsx` | Registers the new lazy-loaded `/match/:matchId` route. |

## Test plan
- [x] `npm run lint` / `format:check` clean
- [x] `npm run test` — 56 tests pass (49 prior + 7 new for `computeTargetStep`)
- [x] `npm run build` — clean, MatchViewerPage chunk = 4.51 KB gzipped
- [x] Backend e2e harness from PR 2 still green (no backend changes here)
- [x] **Manual two-tab smoke test** (recommended before merge):
  1. `docker compose up -d`
  2. `cargo run --bin seed-test-users --features dev-fixtures` (in `backend/`) — one-time
  3. `cargo run` (in `backend/`) — leave running
  4. `npm run dev` (in `frontend/`)
  5. Open two browser tabs to `http://localhost:5173`, log in as `_test_red` and `_test_blue` (password in `backend/.env`)
  6. Click \"Find Match\" in both
  7. Both tabs should navigate to `/match/<same-id>` and render the battle paced from the server's `playback_start_time_ms`. Imp vs Dwarf should tie at 80000 steps in ~40s.

## Next
- PR 4: spectator join-in-progress (deep-link to `/match/:id` with no router state → fetch payload), reconnection handling, completion-screen polish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)