### PR TITLE
Polish match viewer completion UX and add Play Again (issue #50)

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -10,3 +10,23 @@ body,
 body {
   overflow: hidden;
 }
+
+@keyframes cw-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes cw-result-pop {
+  from {
+    opacity: 0;
+    transform: scale(0.94);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}

--- a/frontend/src/pages/LobbyPage.tsx
+++ b/frontend/src/pages/LobbyPage.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useRef, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { useAuth } from '../api/AuthContext';
 import { useWarriorLibrary, type Warrior } from '../warriors/library';
 import { io, type Socket } from 'socket.io-client';
@@ -95,6 +95,7 @@ type Phase = 'idle' | 'queued' | 'matched' | 'result';
 export default function LobbyPage() {
   const { user } = useAuth();
   const navigate = useNavigate();
+  const location = useLocation();
   const library = useWarriorLibrary();
   const userWarriors = library.filter((w: Warrior) => serverUuid(w) !== null);
   const firstUuid = userWarriors.length > 0 ? (serverUuid(userWarriors[0]) ?? '') : '';
@@ -104,10 +105,11 @@ export default function LobbyPage() {
   const [result, setResult] = useState<MatchResultData | null>(null);
   const [error, setError] = useState<string | null>(null);
   const socketRef = useRef<Socket | null>(null);
+  const autoQueuedRef = useRef(false);
 
   const effectiveId = selectedId || firstUuid;
 
-  function connect() {
+  const connect = useCallback(() => {
     if (socketRef.current) return socketRef.current;
     const s = io(API_BASE, { withCredentials: true });
     socketRef.current = s;
@@ -134,14 +136,35 @@ export default function LobbyPage() {
     });
 
     return s;
-  }
+  }, [navigate]);
 
-  function joinQueue() {
-    if (!effectiveId) return;
-    setError(null);
-    const s = connect();
-    s.emit('queue:join', { warrior_id: effectiveId });
-  }
+  // Takes the warrior id as an argument (rather than closing over the derived
+  // `effectiveId`) so the callback's deps stay stable values only.
+  const joinQueue = useCallback(
+    (warriorId: string) => {
+      if (!warriorId) return;
+      setError(null);
+      const s = connect();
+      s.emit('queue:join', { warrior_id: warriorId });
+    },
+    [connect],
+  );
+
+  // "Play Again" from the match viewer navigates here with { autoQueue: true }.
+  // Re-join the queue once a warrior is available, then clear the router state
+  // so a refresh or back-navigation doesn't silently re-queue. The latch is
+  // released on cleanup so StrictMode's mount/cleanup/mount cycle (which tears
+  // down the first socket) re-establishes the connection on the second mount.
+  useEffect(() => {
+    const autoQueue = (location.state as { autoQueue?: boolean } | null)?.autoQueue;
+    if (!autoQueue || autoQueuedRef.current || !effectiveId) return;
+    autoQueuedRef.current = true;
+    joinQueue(effectiveId);
+    navigate(location.pathname, { replace: true });
+    return () => {
+      autoQueuedRef.current = false;
+    };
+  }, [location.state, location.pathname, effectiveId, joinQueue, navigate]);
 
   function leaveQueue() {
     socketRef.current?.emit('queue:leave');
@@ -158,6 +181,7 @@ export default function LobbyPage() {
   useEffect(() => {
     return () => {
       socketRef.current?.disconnect();
+      socketRef.current = null;
     };
   }, []);
 
@@ -198,7 +222,7 @@ export default function LobbyPage() {
               </option>
             ))}
           </select>
-          <button style={QUEUE_BTN} onClick={joinQueue}>
+          <button style={QUEUE_BTN} onClick={() => joinQueue(effectiveId)}>
             Find Match
           </button>
         </>

--- a/frontend/src/pages/match/MatchViewerPage.tsx
+++ b/frontend/src/pages/match/MatchViewerPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { useAuth } from '../../api/AuthContext';
-import { GRID_CONTAINER_STYLE } from '../battlefield/styles';
+import { GRID_CONTAINER_STYLE, PARSE_ERROR_STYLE } from '../battlefield/styles';
 import { useMatchReplay, type MatchStartPayload } from './useMatchReplay';
 
 const PAGE_STYLE: React.CSSProperties = {
@@ -35,20 +35,89 @@ const STATUS_ROW: React.CSSProperties = {
   fontFamily: '"JetBrains Mono", "Fira Code", monospace',
 };
 
-const RESULT_BOX: React.CSSProperties = {
-  padding: '1rem 1.5rem',
-  backgroundColor: '#111',
-  border: '1px solid #333',
-  borderRadius: '8px',
-  textAlign: 'center',
-  minWidth: '260px',
-};
-
 const WARRIOR_ROW: React.CSSProperties = {
   display: 'flex',
   gap: '2rem',
   fontSize: '0.85rem',
   fontFamily: '"JetBrains Mono", "Fira Code", monospace',
+};
+
+// Wrap the imperative PixiJS canvas so overlays can be positioned over it.
+// Overlays are siblings of the canvas container (never children of gridRef),
+// so React never reconciles away the canvas Pixi appends imperatively.
+const GRID_WRAP_STYLE: React.CSSProperties = {
+  position: 'relative',
+  display: 'inline-block',
+  lineHeight: 0,
+};
+
+const OVERLAY_BASE: React.CSSProperties = {
+  position: 'absolute',
+  inset: 0,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  lineHeight: 'normal',
+};
+
+const LOADING_OVERLAY_STYLE: React.CSSProperties = {
+  ...OVERLAY_BASE,
+  backgroundColor: 'rgba(10, 10, 12, 0.8)',
+  color: '#888',
+  fontSize: '0.9rem',
+  letterSpacing: '0.05em',
+};
+
+const RESULT_CARD_STYLE: React.CSSProperties = {
+  padding: '1.5rem 2rem',
+  backgroundColor: '#111',
+  border: '1px solid #333',
+  borderRadius: '10px',
+  textAlign: 'center',
+  minWidth: '240px',
+  boxShadow: '0 12px 40px rgba(0, 0, 0, 0.55)',
+};
+
+const RESULT_HEADLINE_STYLE: React.CSSProperties = {
+  fontSize: '1.6rem',
+  fontWeight: 700,
+  margin: 0,
+};
+
+const RESULT_SUB_STYLE: React.CSSProperties = {
+  color: '#888',
+  fontSize: '0.85rem',
+  margin: '0.4rem 0 1.2rem',
+};
+
+const BUTTON_ROW_STYLE: React.CSSProperties = {
+  display: 'flex',
+  gap: '0.6rem',
+  justifyContent: 'center',
+};
+
+const PRIMARY_BTN_STYLE: React.CSSProperties = {
+  padding: '0.5rem 1.3rem',
+  backgroundColor: '#e94560',
+  color: '#fff',
+  border: 'none',
+  borderRadius: '6px',
+  cursor: 'pointer',
+  fontFamily: 'inherit',
+  fontSize: '0.9rem',
+  letterSpacing: '0.04em',
+};
+
+const SECONDARY_BTN_STYLE: React.CSSProperties = {
+  padding: '0.5rem 1.3rem',
+  backgroundColor: 'transparent',
+  color: '#bbb',
+  border: '1px solid #444',
+  borderRadius: '6px',
+  cursor: 'pointer',
+  fontFamily: 'inherit',
+  fontSize: '0.9rem',
+  letterSpacing: '0.04em',
 };
 
 function resultLabel(result: string, red: string, blue: string, me: string | undefined): string {
@@ -72,7 +141,7 @@ export default function MatchViewerPage() {
   const params = useParams<{ matchId: string }>();
 
   // Match payload comes from the lobby via router state. Reload-without-state
-  // bounces back to the lobby (spectator-join via deep-link is PR 4 territory).
+  // bounces back to the lobby (spectator-join via deep-link is issue #51).
   const payload = (location.state as { matchStart?: MatchStartPayload } | null)?.matchStart ?? null;
 
   useEffect(() => {
@@ -101,9 +170,61 @@ export default function MatchViewerPage() {
         {payload.red_username} vs {payload.blue_username}
       </p>
 
-      {parseError && <div style={{ color: '#e94560' }}>{parseError}</div>}
+      {parseError && <div style={PARSE_ERROR_STYLE}>{parseError}</div>}
 
-      <div ref={gridRef} style={GRID_CONTAINER_STYLE} />
+      <div style={GRID_WRAP_STYLE}>
+        <div ref={gridRef} style={GRID_CONTAINER_STYLE} />
+
+        {!ready && !parseError && <div style={LOADING_OVERLAY_STYLE}>Loading engine…</div>}
+
+        {finished && (
+          <div
+            style={{
+              ...OVERLAY_BASE,
+              backgroundColor: 'rgba(10, 10, 12, 0.72)',
+              animation: 'cw-fade-in 200ms ease-out both',
+            }}
+          >
+            <div
+              style={{
+                ...RESULT_CARD_STYLE,
+                animation: 'cw-result-pop 260ms cubic-bezier(0.2, 0.9, 0.3, 1.2) both',
+              }}
+            >
+              <p
+                style={{
+                  ...RESULT_HEADLINE_STYLE,
+                  color: resultColor(
+                    payload.result,
+                    payload.red_username,
+                    payload.blue_username,
+                    user?.username,
+                  ),
+                }}
+              >
+                {resultLabel(
+                  payload.result,
+                  payload.red_username,
+                  payload.blue_username,
+                  user?.username,
+                )}
+              </p>
+              <p style={RESULT_SUB_STYLE}>{totalSteps.toLocaleString()} steps</p>
+              <div style={BUTTON_ROW_STYLE}>
+                <button
+                  style={PRIMARY_BTN_STYLE}
+                  onClick={() => navigate('/lobby', { state: { autoQueue: true } })}
+                >
+                  Play Again
+                </button>
+                <button style={SECONDARY_BTN_STYLE} onClick={() => navigate('/lobby')}>
+                  Back to Lobby
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
 
       <div style={STATUS_ROW}>
         <span>
@@ -119,51 +240,6 @@ export default function MatchViewerPage() {
           </span>
         ))}
       </div>
-
-      {finished && (
-        <div style={RESULT_BOX}>
-          <p
-            style={{
-              fontSize: '1.3rem',
-              fontWeight: 700,
-              margin: 0,
-              color: resultColor(
-                payload.result,
-                payload.red_username,
-                payload.blue_username,
-                user?.username,
-              ),
-            }}
-          >
-            {resultLabel(
-              payload.result,
-              payload.red_username,
-              payload.blue_username,
-              user?.username,
-            )}
-          </p>
-          <p style={{ color: '#888', fontSize: '0.85rem', margin: '0.5rem 0 1rem' }}>
-            {totalSteps.toLocaleString()} steps
-          </p>
-          <button
-            style={{
-              padding: '0.5rem 1.5rem',
-              backgroundColor: '#e94560',
-              color: '#fff',
-              border: 'none',
-              borderRadius: '6px',
-              cursor: 'pointer',
-              fontFamily: 'inherit',
-              letterSpacing: '0.05em',
-            }}
-            onClick={() => navigate('/lobby')}
-          >
-            Back to Lobby
-          </button>
-        </div>
-      )}
-
-      {!ready && !parseError && <p style={{ color: '#888' }}>Loading engine…</p>}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
Final polish PR for issue #50's client-side match viewer (PR 4 of 4). Spectator/deep-link join is intentionally **not** here — that's tracked in #51, whose data architecture was decided in [this comment](https://github.com/Coltosaur/Core-War-Reimagined/issues/51#issuecomment-4497201293).

- **Result reveal**: the outcome now renders as an animated card overlaid on a dimmed grid (CSS keyframes `cw-fade-in` / `cw-result-pop`), instead of a plain box appended below the grid. Reads as a clear end-state card.
- **Loading state**: engine-init "Loading engine…" is centered over the grid area rather than tucked at the bottom.
- **Play Again**: new CTA beside "Back to Lobby". It returns to the lobby and auto-rejoins the queue via `{ autoQueue: true }` router state.

## Implementation notes
- Overlays are siblings of the `gridRef` container (never children), so React never reconciles away the canvas PixiJS appends imperatively.
- The auto-queue effect and socket teardown are **StrictMode-resilient**: the auto-queue latch is released on cleanup and `socketRef` is nulled on disconnect, so dev's mount → cleanup → mount cycle (which tears down the first socket) re-establishes the connection on the second mount. Verified that without this, the dev StrictMode teardown silently dropped the auto-queue socket before it connected.
- `joinQueue` takes the warrior id as an argument so its `useCallback` deps stay stable values — avoids fighting the React Compiler lint rules rather than suppressing them.

## Test plan
- [x] `npm run lint` (0 errors; 1 pre-existing AuthContext warning, untouched)
- [x] `npm run format:check`
- [x] `npm run build` (tsc + vite)
- [x] `npm run test` (56 pass)
- [x] Browser smoke test (bot-red opponent vs `_test_blue`): match → animated result card over dimmed grid → **Play Again** lands on lobby in "Searching for opponent…" (backend confirms authenticated re-queue) → second match forms and opens a new viewer. Back to Lobby and reload-bounce also verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)