### PR TITLE
Add VPS bootstrap runbook + manual deploy script (epic #39, PR 2/5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,16 @@ cd backend && cargo build --release
 # Binary at backend/target/release/core-war-backend
 ```
 
+## Deployment
+
+The backend ships as a Docker image and runs on a DigitalOcean droplet behind Caddy. The frontend is hosted on Cloudflare Pages. See [`deploy/README.md`](deploy/README.md) for the full VPS bootstrap and manual deploy runbook, and `docker-compose.prod.yml` for the production-mirror stack you can run locally to verify changes before deploying.
+
+```bash
+# Push a fresh build to the droplet (from your laptop, after configuring
+# .env.production on the droplet — see deploy/README.md)
+./deploy/deploy.sh user@droplet-ip
+```
+
 ## Linting and Formatting
 
 ```bash

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,262 @@
+# VPS bootstrap & manual deploy runbook
+
+This runbook stands the backend stack up on a fresh DigitalOcean droplet,
+hardens it, configures DNS for `api.corewar.coltcampbell.dev`, and walks
+through the first deploy and the steady-state redeploy.
+
+The deploy is fully manual at this stage. `deploy/deploy.sh` rsyncs the
+project to the droplet and rebuilds the prod compose stack over SSH —
+GitHub Actions automation comes in PR 4.
+
+> All `<placeholder>` values are things you fill in. Wherever the runbook
+> references `coltcampbell.dev`, replace with your domain if you forked.
+
+## Prerequisites
+
+Before starting:
+
+- DigitalOcean account with a payment method on file.
+- Domain `coltcampbell.dev` registered (Porkbun) with DNS management access.
+- Local SSH key pair (`~/.ssh/id_ed25519` + `.pub`). Generate one if needed:
+  ```bash
+  ssh-keygen -t ed25519 -C "colt@coltcampbell.dev"
+  ```
+- Docker installed locally (PR 1's prod-mirror stack already requires this).
+
+## 1. Provision the droplet
+
+DigitalOcean control panel → **Create → Droplets**:
+
+| Setting | Value |
+|---|---|
+| Region | NYC3 (or SFO3 — pick whichever is closest to your users) |
+| OS image | Ubuntu 24.04 (LTS) x64 |
+| Plan | Basic → Regular CPU → **$6/mo (1 GB / 1 CPU / 25 GB SSD / 1 TB transfer)** |
+| Authentication | SSH key — paste the contents of `~/.ssh/id_ed25519.pub`. Do **not** use a password. |
+| Hostname | `corewar-prod` |
+| Backups | Skip for now ($1.20/mo, add later if you want) |
+| Monitoring | Enable (free) |
+
+After creation, copy the droplet's IPv4 (and IPv6 if you want to support it).
+The rest of the runbook calls it `<DROPLET_IP>`.
+
+## 2. First SSH + create a non-root user
+
+DigitalOcean drops the SSH key onto `root@<DROPLET_IP>` for the initial
+connection. The first thing we do is leave that login behind.
+
+```bash
+ssh root@<DROPLET_IP>
+```
+
+On the droplet:
+
+```bash
+# Patch the base image
+apt update && apt upgrade -y
+apt install -y sudo
+
+# Create a non-root user (replace 'colt' with whatever you prefer)
+adduser --disabled-password --gecos "" colt
+usermod -aG sudo colt
+
+# Reuse your existing SSH key for the new user
+rsync --archive --chown=colt:colt ~/.ssh /home/colt
+```
+
+Log out, then SSH back in as the new user from your laptop to confirm it works:
+
+```bash
+ssh colt@<DROPLET_IP>
+```
+
+If that succeeds, lock down SSH on the droplet:
+
+```bash
+sudo sed -i 's/^#\?PermitRootLogin.*/PermitRootLogin no/' /etc/ssh/sshd_config
+sudo sed -i 's/^#\?PasswordAuthentication.*/PasswordAuthentication no/' /etc/ssh/sshd_config
+sudo systemctl restart ssh
+```
+
+Validate from a **separate** terminal that you can still log in as `colt`
+before closing the original session.
+
+## 3. Firewall (ufw)
+
+Only SSH, HTTP, and HTTPS should be reachable from the public internet.
+
+```bash
+sudo ufw default deny incoming
+sudo ufw default allow outgoing
+sudo ufw allow OpenSSH
+sudo ufw allow 80/tcp
+sudo ufw allow 443/tcp
+sudo ufw enable
+sudo ufw status verbose
+```
+
+## 4. fail2ban (SSH brute-force guard)
+
+```bash
+sudo apt install -y fail2ban
+sudo systemctl enable --now fail2ban
+sudo fail2ban-client status sshd
+```
+
+Default config is fine — it watches `sshd` and bans IPs that fail auth too
+often. With password auth already disabled this is belt-and-suspenders, but
+cheap insurance.
+
+## 5. Install Docker Engine
+
+Use Docker's official apt repository — the version in Ubuntu's default repos
+lags. The Snap version is broken for our use case (volume permission issues).
+
+```bash
+# Repo prereqs
+sudo apt install -y ca-certificates curl gnupg
+sudo install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | \
+    sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+sudo chmod a+r /etc/apt/keyrings/docker.gpg
+
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] \
+https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo $VERSION_CODENAME) stable" | \
+    sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+sudo apt update
+sudo apt install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+
+# Run docker without sudo
+sudo usermod -aG docker $USER
+```
+
+Log out and back in to pick up the group change, then verify:
+
+```bash
+docker run --rm hello-world
+docker compose version
+```
+
+## 6. DNS records at Porkbun
+
+In the Porkbun control panel for `coltcampbell.dev` → **DNS**:
+
+| Type | Host | Answer | TTL |
+|---|---|---|---|
+| `A` | `api.corewar` | `<DROPLET_IPV4>` | 600 |
+| `AAAA` | `api.corewar` | `<DROPLET_IPV6>` (optional) | 600 |
+
+Verify propagation from your laptop (give it 1–5 minutes):
+
+```bash
+dig +short api.corewar.coltcampbell.dev
+dig +short AAAA api.corewar.coltcampbell.dev
+```
+
+Both should return the droplet's addresses before you proceed — Caddy can't
+issue a Let's Encrypt cert until the hostname resolves to this box.
+
+## 7. First deploy from your laptop
+
+From the repo root on your laptop:
+
+```bash
+./deploy/deploy.sh colt@<DROPLET_IP>
+```
+
+That rsyncs the project tree to `~/corewar/` on the droplet. The first run
+will fail loudly because `.env.production` doesn't exist on the droplet
+yet — that's expected. SSH in and create it:
+
+```bash
+ssh colt@<DROPLET_IP>
+cd ~/corewar
+cp .env.production.example .env.production
+nano .env.production    # or vim, whatever
+```
+
+Fill in real values:
+
+```ini
+BACKEND_DOMAIN=api.corewar.coltcampbell.dev
+ACME_EMAIL=colt@coltcampbell.dev
+FRONTEND_URL=https://corewar.coltcampbell.dev
+JWT_SECRET=<openssl rand -base64 48>
+POSTGRES_USER=corewar
+POSTGRES_PASSWORD=<openssl rand -base64 24>
+POSTGRES_DB=corewar
+DATABASE_URL=postgresql://corewar:<same password>@postgres:5432/corewar
+REDIS_URL=redis://redis:6379
+TRUSTED_PROXIES=
+```
+
+Then re-run the deploy from your laptop:
+
+```bash
+./deploy/deploy.sh colt@<DROPLET_IP>
+```
+
+This time it'll build the backend image on the droplet (~2–3 min on a $6
+droplet — the build is CPU-bound on cargo) and bring the stack up.
+
+## 8. Verify TLS
+
+```bash
+curl -i https://api.corewar.coltcampbell.dev/health
+```
+
+The first request can take **30+ seconds** while Caddy negotiates the
+Let's Encrypt cert. Expected response:
+
+```
+HTTP/2 200
+content-type: application/json
+{"status":"ok"}
+```
+
+If the cert handshake fails:
+
+- `dig +short api.corewar.coltcampbell.dev` must return the droplet IP.
+- Port 80 must be reachable from the public internet (Let's Encrypt's
+  HTTP-01 challenge uses it). `sudo ufw status` should show 80/tcp ALLOW.
+- Inspect Caddy's logs: `docker compose -f docker-compose.prod.yml logs caddy`.
+
+## 9. Operations cheat sheet
+
+All commands run from `~/corewar/` on the droplet.
+
+```bash
+# Tail logs
+docker compose -f docker-compose.prod.yml --env-file .env.production logs -f backend
+
+# Restart just the backend (after a config change)
+docker compose -f docker-compose.prod.yml --env-file .env.production restart backend
+
+# Stop everything (volumes survive)
+docker compose -f docker-compose.prod.yml --env-file .env.production down
+
+# Nuke the database (only if you mean it — volumes go too)
+docker compose -f docker-compose.prod.yml --env-file .env.production down -v
+```
+
+Steady-state redeploy from your laptop after pushing code:
+
+```bash
+./deploy/deploy.sh colt@<DROPLET_IP>
+```
+
+The script rsyncs (skipping `.env.production` and other excluded paths),
+then runs `docker compose up -d --build` over SSH so only changed layers
+rebuild.
+
+## What's NOT here (yet)
+
+- **Database backups.** Volumes survive `down`, but the droplet does not.
+  PR 5 or later will add either DO managed snapshots ($1.20/mo) or a
+  `pg_dump`-to-S3 cron.
+- **Migration step in CI.** Currently the backend runs `sqlx::migrate!()`
+  on startup. PR 5 makes that an explicit deploy step so failures surface
+  before the container starts accepting traffic.
+- **Automated deploy on merge.** PR 4 wires up GitHub Actions.
+- **Uptime monitoring.** PR 5 adds a free external pinger against `/health`.

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+#
+# Manual deploy script for the prod-mirror Docker Compose stack.
+#
+# Usage:
+#     ./deploy/deploy.sh user@host
+#
+# What it does:
+#   1. Rsyncs the project tree to ~/corewar/ on the target host,
+#      excluding build artifacts and any local .env* files.
+#   2. SSHes in and runs `docker compose up -d --build` on
+#      docker-compose.prod.yml using the .env.production file that
+#      already exists on the droplet (NOT rsynced from your laptop).
+#
+# Prerequisites on the target:
+#   - SSH key auth working (no password prompts).
+#   - Docker Engine + compose plugin installed (see deploy/README.md).
+#   - ~/corewar/.env.production created and filled in.
+#
+# Exits non-zero on any failure so it's safe to chain in a script.
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+    echo "Usage: $0 <user@host>" >&2
+    exit 1
+fi
+
+TARGET="$1"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REMOTE_PATH="corewar"  # relative to the remote user's $HOME
+
+echo "==> Syncing $REPO_ROOT -> $TARGET:~/$REMOTE_PATH/"
+
+# Rsync filter rules are evaluated in order; first match wins.
+# We include .env.production.example explicitly so the runbook's
+# `cp .env.production.example .env.production` step has something to
+# copy on the droplet. Real .env files are excluded so secrets never
+# leave the laptop — and excluded files are not deleted by --delete
+# either, so the droplet's .env.production survives redeploys.
+rsync -azh --delete \
+    --include '.env.production.example' \
+    --exclude '.env' \
+    --exclude '.env.*' \
+    --exclude '.git' \
+    --exclude '.github' \
+    --exclude 'target' \
+    --exclude 'node_modules' \
+    --exclude 'frontend/dist' \
+    --exclude 'engine/pkg' \
+    --exclude '.playwright-mcp' \
+    --exclude '.mcp.json' \
+    --exclude '.vscode' \
+    --exclude '.idea' \
+    --exclude '.DS_Store' \
+    "$REPO_ROOT/" "$TARGET:$REMOTE_PATH/"
+
+echo "==> Rebuilding and restarting prod stack on $TARGET"
+
+# Run a single remote bash session so we can keep -euo pipefail
+# behavior on the droplet side.
+ssh "$TARGET" 'bash -s' <<'REMOTE'
+set -euo pipefail
+cd ~/corewar
+
+if [[ ! -f .env.production ]]; then
+    echo "ERROR: ~/corewar/.env.production not found." >&2
+    echo "Create it from .env.production.example and fill in secrets:" >&2
+    echo "    cp .env.production.example .env.production" >&2
+    echo "    \$EDITOR .env.production" >&2
+    exit 1
+fi
+
+docker compose -f docker-compose.prod.yml --env-file .env.production up -d --build
+docker compose -f docker-compose.prod.yml --env-file .env.production ps
+REMOTE
+
+echo "==> Done. Smoke-test with: curl -i https://<your-api-host>/health"


### PR DESCRIPTION
## Summary

Second PR of the deployment epic (#39). Carves out the human-driven half of getting a real deploy up on a fresh DigitalOcean droplet. PR 4 will automate it later via GitHub Actions; this PR is what we'll walk through the first time.

- **`deploy/README.md`** — 9-step runbook covering droplet provisioning, SSH key + non-root user setup, root-login + password-auth lockdown, ufw + fail2ban, Docker Engine install from the official apt repo, Porkbun DNS records for `api.corewar.coltcampbell.dev`, first deploy with `.env.production` creation on the droplet, TLS verification, and a steady-state operations cheat sheet.
- **`deploy/deploy.sh`** — rsync + SSH deploy script. Includes `.env.production.example` so the runbook's `cp` step has something to copy on the droplet, but explicitly excludes real `.env*` files so secrets never leave the laptop. Uses rsync's "don't delete excluded files" default so the droplet's `.env.production` survives every redeploy.
- **`README.md`** — small Deployment section pointing at `deploy/README.md` so the runbook is discoverable from the project root.

## Cross-PR note

The runbook references `docker-compose.prod.yml` and `.env.production.example` which land in #62 (the prod-mirror compose stack). Both PRs are independently mergeable; the runbook becomes fully executable once both are on master.

## Test plan

- [x] `bash -n deploy/deploy.sh` — shell syntax parses clean.
- [x] `rsync --dry-run` of the actual filter rules from this repo — 154 files / ~911 KB would transfer, none of `target/`, `node_modules/`, `engine/pkg`, `.env*` (sans `.example`), or `.git/` slip through.
- [x] **End-to-end against a real droplet** — deferred until rollout. The runbook is the testable artifact; we'll catch any gaps the first time we walk through it. Will follow up here with corrections if the steps are wrong.

## What's intentionally NOT in this PR

- **Database backups.** Mentioned at the end of the runbook as a follow-up.
- **Migration step in the deploy.** Backend currently runs `sqlx::migrate!()` on startup; PR 5 splits that out into an explicit pre-start step.
- **Uptime monitoring.** PR 5.
- **GitHub Actions automation.** PR 4.

Refs epic #39.