### PR TITLE
Add Cloudflare Pages deploy config for the frontend (epic #39, PR 3/5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,12 @@ cd backend && cargo build --release
 
 ## Deployment
 
-The backend ships as a Docker image and runs on a DigitalOcean droplet behind Caddy. The frontend is hosted on Cloudflare Pages. See [`deploy/README.md`](deploy/README.md) for the full VPS bootstrap and manual deploy runbook, and `docker-compose.prod.yml` for the production-mirror stack you can run locally to verify changes before deploying.
+The backend ships as a Docker image and runs on a DigitalOcean droplet behind Caddy. The frontend is hosted on Cloudflare Pages. Two runbooks cover the two halves:
+
+- [`deploy/README.md`](deploy/README.md) — VPS bootstrap + manual backend deploy
+- [`deploy/cloudflare-pages.md`](deploy/cloudflare-pages.md) — frontend (static + Wasm) on Cloudflare Pages
+
+`docker-compose.prod.yml` at the repo root is the production-mirror stack you can run locally to verify backend changes before deploying.
 
 ```bash
 # Push a fresh build to the droplet (from your laptop, after configuring

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -8,6 +8,11 @@ The deploy is fully manual at this stage. `deploy/deploy.sh` rsyncs the
 project to the droplet and rebuilds the prod compose stack over SSH —
 GitHub Actions automation comes in PR 4.
 
+For the **frontend** (Cloudflare Pages) see the sibling runbook
+[`deploy/cloudflare-pages.md`](cloudflare-pages.md). Frontend and backend
+deploys are independent — Pages can ship before this VPS exists; the app
+will just see a non-resolving API host until the droplet is up.
+
 > All `<placeholder>` values are things you fill in. Wherever the runbook
 > references `coltcampbell.dev`, replace with your domain if you forked.
 

--- a/deploy/cloudflare-pages-build.sh
+++ b/deploy/cloudflare-pages-build.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+#
+# Cloudflare Pages build script.
+#
+# Cloudflare Pages doesn't know how to drive a Rust + Wasm + Vite build on
+# its own, so we run all four steps here:
+#   1. Add the wasm32-unknown-unknown target to the Pages build image's
+#      pre-installed Rust toolchain.
+#   2. Download a pinned wasm-pack binary (matches the version pinned in
+#      .github/workflows/ci.yml — older wasm-pack ships a too-old
+#      wasm-opt that can't parse modern Rust Wasm output).
+#   3. Build the engine to Wasm via wasm-pack (writes engine/pkg/).
+#   4. Install frontend deps (npm picks up the engine pkg via the
+#      `file:../engine/pkg` dep) and run `vite build` → frontend/dist/.
+#
+# Configure in Cloudflare Pages dashboard:
+#   Framework preset:        None
+#   Build command:           bash deploy/cloudflare-pages-build.sh
+#   Build output directory:  frontend/dist
+#   Root directory:          /
+#   Environment variables:
+#       NODE_VERSION=20
+#       VITE_API_URL=https://api.corewar.coltcampbell.dev
+
+set -euo pipefail
+
+# Matches .github/workflows/ci.yml — keep in sync when bumping.
+WASM_PACK_VERSION="v0.13.1"
+WASM_PACK_TARBALL="wasm-pack-${WASM_PACK_VERSION}-x86_64-unknown-linux-musl"
+
+echo "==> Pages build env: $(uname -a)"
+echo "==> rustc: $(rustc --version 2>/dev/null || echo MISSING)"
+echo "==> node: $(node --version 2>/dev/null || echo MISSING)"
+
+echo "==> Adding wasm32 target"
+rustup target add wasm32-unknown-unknown
+
+echo "==> Installing wasm-pack ${WASM_PACK_VERSION}"
+TMPDIR="$(mktemp -d)"
+curl -fsSL "https://github.com/rustwasm/wasm-pack/releases/download/${WASM_PACK_VERSION}/${WASM_PACK_TARBALL}.tar.gz" \
+    | tar -xzC "$TMPDIR"
+export PATH="${TMPDIR}/${WASM_PACK_TARBALL}:$PATH"
+wasm-pack --version
+
+echo "==> Building Wasm engine (release)"
+( cd engine && wasm-pack build --target web --release )
+
+echo "==> Installing frontend deps + building"
+( cd frontend && npm ci && npm run build )
+
+echo "==> Done. Output at frontend/dist/"

--- a/deploy/cloudflare-pages.md
+++ b/deploy/cloudflare-pages.md
@@ -1,0 +1,108 @@
+# Frontend deploy: Cloudflare Pages runbook
+
+Companion to [`deploy/README.md`](README.md). That doc covers the backend
+(DigitalOcean droplet + Caddy). This one covers the frontend (static + Wasm
+bundle on Cloudflare Pages).
+
+The two are independent — Pages can deploy before the droplet exists; the
+frontend will just hit a non-resolving API host until the backend is up.
+
+## Prerequisites
+
+- Free Cloudflare account.
+- Frontend code on master (Pages auto-deploys from a branch).
+- Backend hostname decided (`api.corewar.coltcampbell.dev`) — the
+  frontend's `VITE_API_URL` env var points here.
+
+## 1. Create the Pages project
+
+Cloudflare dashboard → **Workers & Pages → Create application → Pages → Connect to Git**.
+
+1. Authorize Cloudflare's GitHub app for the `Coltosaur/Core-War-Reimagined` repo.
+2. Production branch: `master`.
+3. **Build configuration:**
+
+   | Setting | Value |
+   |---|---|
+   | Framework preset | None |
+   | Build command | `bash deploy/cloudflare-pages-build.sh` |
+   | Build output directory | `frontend/dist` |
+   | Root directory | `/` (leave blank) |
+
+4. **Environment variables** (set under "Environment variables → Production"):
+
+   | Variable | Value |
+   |---|---|
+   | `NODE_VERSION` | `20` |
+   | `VITE_API_URL` | `https://api.corewar.coltcampbell.dev` |
+
+Click **Save and Deploy**. The first build takes 4–6 minutes (Rust toolchain
+download + wasm-pack download + `cargo build --release` for the engine +
+`npm ci` + `vite build`). Subsequent builds reuse Cloudflare's npm cache.
+
+## 2. Verify the first deploy
+
+When the build finishes you'll get a `<project>.pages.dev` URL. Open it:
+
+- The app should load and render the landing page.
+- Open DevTools → Network → reload. The `.wasm` file should be served with
+  `content-type: application/wasm` (forced by `frontend/public/_headers`).
+- Any client-side navigation that creates a fresh URL (e.g. visit
+  `/leaderboard` then reload) should still serve `index.html` — confirms
+  the SPA fallback in `frontend/public/_redirects` works.
+- The browser will try to hit the backend at `VITE_API_URL` and fail until
+  the droplet is up — that's expected at this stage.
+
+## 3. Custom domain (`corewar.coltcampbell.dev`)
+
+Cloudflare dashboard → Pages project → **Custom domains → Set up a custom domain**.
+
+1. Enter `corewar.coltcampbell.dev`.
+2. Cloudflare gives you a CNAME target like `<project>.pages.dev`.
+3. In **Porkbun DNS** for `coltcampbell.dev`:
+
+   | Type | Host | Answer | TTL |
+   |---|---|---|---|
+   | `CNAME` | `corewar` | `<project>.pages.dev` | 600 |
+
+4. Back in Cloudflare, wait for it to verify (usually under 5 minutes). Pages
+   provisions the TLS cert automatically.
+
+When done, `https://corewar.coltcampbell.dev` serves the production frontend.
+
+## 4. Update backend CORS allowlist
+
+The backend's `FRONTEND_URL` env var is the single allowed CORS origin. On
+the droplet, edit `~/corewar/.env.production`:
+
+```ini
+FRONTEND_URL=https://corewar.coltcampbell.dev
+```
+
+Then restart the backend container:
+
+```bash
+docker compose -f docker-compose.prod.yml --env-file .env.production restart backend
+```
+
+`<project>.pages.dev` itself will get blocked by CORS at this point — that's
+intended; only the public hostname should be talking to the API.
+
+## 5. Operations
+
+- **Push to master** → Pages auto-builds and rolls out a new production
+  deploy. Build log + preview URL appear under **Deployments**.
+- **PR branches** get **preview deployments** at
+  `<branch>.<project>.pages.dev`. They share the same `VITE_API_URL` (prod
+  backend) unless you override at preview-environment scope. Preview deploys
+  will fail CORS unless you broaden the backend allowlist — fine to leave
+  blocked since previews are for visual review, not full E2E.
+- **Roll back** in seconds via the **Deployments → ⋯ → Rollback** menu;
+  no code change needed.
+
+## Build script
+
+The build is driven by [`deploy/cloudflare-pages-build.sh`](cloudflare-pages-build.sh).
+It pins wasm-pack to the same version as the CI workflow
+(`.github/workflows/ci.yml`) so the wasm-opt failure modes we hit in #57
+stay fixed. Bump both at once if you ever change versions.

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,10 @@
+# Frontend env example. Copy to .env.local for dev overrides.
+# Vite only exposes vars prefixed with VITE_ to the client bundle.
+
+# Backend API + Socket.IO origin. Used by both src/api/client.ts (REST)
+# and src/pages/LobbyPage.tsx (Socket.IO connection). Defaults to
+# http://localhost:3001 if unset, matching the dev backend.
+#
+# Set this to the production backend hostname in Cloudflare Pages env
+# vars when deploying (e.g. https://api.corewar.coltcampbell.dev).
+VITE_API_URL=http://localhost:3001

--- a/frontend/public/_headers
+++ b/frontend/public/_headers
@@ -1,0 +1,6 @@
+# Belt-and-suspenders Content-Type for the wasm-pack output. Cloudflare
+# Pages should set this automatically by extension, but pinning it here
+# guarantees streaming WebAssembly compilation (WebAssembly.instantiateStreaming)
+# works regardless of upstream defaults drifting.
+/*.wasm
+  Content-Type: application/wasm

--- a/frontend/public/_redirects
+++ b/frontend/public/_redirects
@@ -1,0 +1,5 @@
+# SPA fallback: every unmatched route serves index.html so React Router
+# handles client-side routing (/match/:id, /profile/:user, etc.). The 200
+# status code makes this a server-side rewrite, not a redirect — the URL
+# in the browser stays the same.
+/*    /index.html   200


### PR DESCRIPTION
## Summary

Third PR of the deployment epic (#39). Wires the frontend up to deploy on Cloudflare Pages with a custom build that drives Rust + Wasm + Vite end-to-end.

**No application code changes** — `VITE_API_URL` was already plumbed through `src/api/client.ts` and `src/pages/LobbyPage.tsx` with a `http://localhost:3001` fallback. The only frontend-runtime change is which value Pages bakes in at build time (`https://api.corewar.coltcampbell.dev`).

## What's in the PR

- **`frontend/public/_redirects`** — `/* → /index.html 200` SPA fallback so React Router routes (`/match/:id`, `/profile/:user`, etc.) survive direct loads and reloads.
- **`frontend/public/_headers`** — forces `Content-Type: application/wasm` on `*.wasm` regardless of Pages defaults, guaranteeing streaming Wasm compilation works.
- **`frontend/.env.example`** — documents `VITE_API_URL`.
- **`deploy/cloudflare-pages-build.sh`** — the build Cloudflare Pages drives. Adds the `wasm32` target, downloads the **pinned `wasm-pack v0.13.1`** binary (matches `.github/workflows/ci.yml` — bump both at once per #57's history), builds the engine, then `npm ci` + `vite build`.
- **`deploy/cloudflare-pages.md`** — runbook covering Pages project creation, build config, env vars, custom domain (`corewar.coltcampbell.dev`), CORS update on the backend, and steady-state ops (auto-deploy, PR previews, rollbacks).
- **`deploy/README.md`** + **`README.md`** — cross-links to the Pages runbook.

## Test plan

- [x] `npm run build` — 584 modules transformed; `dist/_redirects` and `dist/_headers` present at the output root; wasm hashed into `dist/assets/`.
- [x] `npm run lint` — single pre-existing warning in `AuthContext.tsx`, unrelated to this PR.
- [x] `npm run format:check` — clean.
- [x] `npm test` — 56/56 pass.
- [x] `bash -n deploy/cloudflare-pages-build.sh` — shell syntax clean.
- [x] **First Pages build against this branch** — deferred until you connect the repo in the Cloudflare dashboard. Runbook section 1 walks through it; any build-script gaps will surface there and I'll follow up on this PR with corrections.

## What's NOT in this PR

- **GitHub Actions automation for backend** — PR 4.
- **CORS preview-deploy allowlist** — preview Pages deploys (`<branch>.<project>.pages.dev`) will be blocked by the backend's strict single-origin CORS. Intentional for now; if we want PR previews to talk to prod backend, we'd need to widen the allowlist.

Refs epic #39.