### PR TITLE
Add GitHub Actions deploy-on-merge for the backend (epic #39, PR 4/5)

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -1,0 +1,150 @@
+name: Deploy backend
+
+# Triggers:
+#   - push to master: build + push image to ghcr.io, then (if DEPLOY_ENABLED)
+#     ssh into the droplet and roll out the new image.
+#   - pull_request: build only (no push, no deploy) so Dockerfile breakage
+#     gets caught before merge.
+#   - workflow_dispatch: manual trigger from the Actions tab — useful for
+#     re-deploying after a Caddyfile change or a manual config tweak on the
+#     droplet, without needing a code change to land on master.
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'backend/**'
+      - 'engine/**'
+      - 'Caddyfile'
+      - 'docker-compose.prod.yml'
+      - '.github/workflows/deploy-backend.yml'
+  pull_request:
+    branches: [master]
+    paths:
+      - 'backend/**'
+      - 'engine/**'
+      - 'Caddyfile'
+      - 'docker-compose.prod.yml'
+      - '.github/workflows/deploy-backend.yml'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  build:
+    name: Build (and push on master) backend image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      image: ${{ steps.image.outputs.ref }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Compute lowercase image ref
+        id: image
+        run: |
+          OWNER_LC=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          echo "ref=${REGISTRY}/${OWNER_LC}/core-war-backend" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ steps.image.outputs.ref }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,prefix=master-,enable={{is_default_branch}}
+            type=ref,event=pr
+
+      - name: Build and (on master) push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: backend/Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  deploy:
+    name: Deploy to droplet
+    needs: build
+    # Gated by a repo variable so we don't try to ssh into a droplet that
+    # doesn't exist yet. Flip vars.DEPLOY_ENABLED to 'true' once you've
+    # provisioned the droplet and added the secrets below.
+    if: github.event_name != 'pull_request' && vars.DEPLOY_ENABLED == 'true'
+    runs-on: ubuntu-latest
+    concurrency:
+      group: deploy-backend
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up SSH agent
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.DROPLET_SSH_KEY }}
+
+      - name: Trust droplet host key
+        run: |
+          mkdir -p ~/.ssh
+          ssh-keyscan -H "${{ secrets.DROPLET_HOST }}" >> ~/.ssh/known_hosts
+
+      - name: Sync compose + Caddyfile to droplet
+        # No --delete: we don't want to nuke .env.production on the
+        # destination, and the only files we push are listed explicitly
+        # anyway.
+        run: |
+          rsync -azh \
+            docker-compose.prod.yml Caddyfile \
+            "${{ secrets.DROPLET_USER }}@${{ secrets.DROPLET_HOST }}:~/corewar/"
+
+      - name: Pull image + restart stack + verify health
+        run: |
+          ssh "${{ secrets.DROPLET_USER }}@${{ secrets.DROPLET_HOST }}" bash -s <<'REMOTE'
+          set -euo pipefail
+          cd ~/corewar
+
+          if [[ ! -f .env.production ]]; then
+              echo "ERROR: ~/corewar/.env.production not found. Run the manual" >&2
+              echo "       bootstrap first (deploy/README.md section 7)." >&2
+              exit 1
+          fi
+
+          echo "==> Pulling backend image"
+          docker compose -f docker-compose.prod.yml --env-file .env.production pull backend
+
+          echo "==> Restarting stack"
+          docker compose -f docker-compose.prod.yml --env-file .env.production up -d --remove-orphans
+
+          echo "==> Waiting up to 60s for backend to be healthy"
+          end=$((SECONDS + 60))
+          while [[ $SECONDS -lt $end ]]; do
+              state=$(docker inspect -f '{{.State.Health.Status}}' corewar-prod-backend-1 2>/dev/null || echo "starting")
+              if [[ "$state" == "healthy" ]]; then
+                  echo "==> Backend healthy"
+                  docker compose -f docker-compose.prod.yml --env-file .env.production ps
+                  docker image prune -f
+                  exit 0
+              fi
+              echo "    backend state: $state"
+              sleep 3
+          done
+
+          echo "ERROR: backend did not become healthy within 60s" >&2
+          docker compose -f docker-compose.prod.yml --env-file .env.production logs --tail 80 backend >&2
+          exit 1
+          REMOTE

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -245,7 +245,9 @@ docker compose -f docker-compose.prod.yml --env-file .env.production down
 docker compose -f docker-compose.prod.yml --env-file .env.production down -v
 ```
 
-Steady-state redeploy from your laptop after pushing code:
+Steady-state redeploy from your laptop after pushing code (escape hatch
+when CI is unavailable — normal redeploys happen automatically via
+GitHub Actions, see section 10):
 
 ```bash
 ./deploy/deploy.sh colt@<DROPLET_IP>
@@ -255,6 +257,67 @@ The script rsyncs (skipping `.env.production` and other excluded paths),
 then runs `docker compose up -d --build` over SSH so only changed layers
 rebuild.
 
+## 10. Enable CI deploys (deploy-on-merge)
+
+Once the droplet is up and the manual deploy from section 7 worked, wire
+up `.github/workflows/deploy-backend.yml` to take over steady-state
+deploys. The workflow builds the backend image on every push to master,
+pushes it to GitHub Container Registry (ghcr.io), then SSHes into the
+droplet and rolls out the new image.
+
+### One-time: make the backend image public
+
+The first time the workflow runs, it creates a private package under
+`ghcr.io/coltosaur/core-war-backend`. The droplet can't pull it without
+auth setup, so flip it to public:
+
+1. GitHub → your profile → **Packages** → `core-war-backend`.
+2. **Package settings → Change visibility → Public**.
+
+(Source is already public; the compiled binary doesn't expose anything
+new.)
+
+### Required GitHub Actions secrets
+
+Repo → **Settings → Secrets and variables → Actions → Secrets → New
+repository secret**:
+
+| Secret | Value |
+|---|---|
+| `DROPLET_HOST` | Droplet IPv4 (or `api.corewar.coltcampbell.dev` once DNS is in) |
+| `DROPLET_USER` | The non-root user from section 2 (e.g. `colt`) |
+| `DROPLET_SSH_KEY` | **Private** half of an SSH key whose public half is in the droplet's `~/.ssh/authorized_keys`. Generate a fresh one for CI — don't reuse your personal key: `ssh-keygen -t ed25519 -f ~/.ssh/corewar_deploy -C corewar-deploy`. Copy `~/.ssh/corewar_deploy.pub` to the droplet's `~/.ssh/authorized_keys`, paste the contents of `~/.ssh/corewar_deploy` (the private file) here. |
+
+### Required GitHub Actions variable
+
+Same page → **Variables → New repository variable**:
+
+| Variable | Value |
+|---|---|
+| `DEPLOY_ENABLED` | `true` |
+
+The workflow's `deploy` job is gated by `vars.DEPLOY_ENABLED == 'true'`,
+so until you set this it'll only build + push the image without
+attempting to ssh anywhere. Useful for the gap between provisioning the
+droplet and being ready to roll out.
+
+### Trigger the first CI deploy
+
+After the secrets and variable are in place:
+
+```
+GitHub repo → Actions → "Deploy backend" → Run workflow → master → Run
+```
+
+The job log will show the image push, the rsync, and the docker compose
+restart. Health check waits up to 60s for the container to report
+`healthy` before declaring success.
+
+From then on, every push to master that touches `backend/`, `engine/`,
+`Caddyfile`, or `docker-compose.prod.yml` triggers a deploy. PRs build
+the image without pushing (so Dockerfile breakage gets caught before
+merge).
+
 ## What's NOT here (yet)
 
 - **Database backups.** Volumes survive `down`, but the droplet does not.
@@ -263,5 +326,4 @@ rebuild.
 - **Migration step in CI.** Currently the backend runs `sqlx::migrate!()`
   on startup. PR 5 makes that an explicit deploy step so failures surface
   before the container starts accepting traffic.
-- **Automated deploy on merge.** PR 4 wires up GitHub Actions.
 - **Uptime monitoring.** PR 5 adds a free external pinger against `/health`.

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -15,6 +15,12 @@ name: corewar-prod
 
 services:
   backend:
+    # `image:` is what CI publishes and what the droplet pulls. `build:` is
+    # kept so the local prod-mirror smoke test still works with
+    # `docker compose up --build` — that build tags the local image with
+    # this same name, which is harmless. If you fork, update the owner
+    # segment to match your GitHub login (lowercase).
+    image: ghcr.io/coltosaur/core-war-backend:latest
     build:
       context: .
       dockerfile: backend/Dockerfile


### PR DESCRIPTION
## Summary

Fourth PR of the deployment epic (#39). Builds the backend image in CI, publishes it to GitHub Container Registry, and rolls it out to the droplet on every push to master. PR builds validate the Dockerfile without pushing.

## Files

- **`.github/workflows/deploy-backend.yml`** — two jobs:
  - **`build`**: docker buildx with GHA cache; pushes `ghcr.io/coltosaur/core-war-backend:{latest, master-<sha>}` on master, builds-only on PRs.
  - **`deploy`**: gated by repo variable `DEPLOY_ENABLED == 'true'` so it can't try to ssh into a droplet that doesn't exist yet. Sets up an ssh-agent from a secret key, rsyncs `docker-compose.prod.yml` + `Caddyfile` to the droplet, then SSHes in and runs `docker compose pull && up -d --remove-orphans`. A 60s health-check loop tails container logs and fails the job if the backend doesn't reach `healthy`.
  - Path filters scope the trigger to `backend/`, `engine/`, `Caddyfile`, `docker-compose.prod.yml`, and the workflow file itself.
- **`docker-compose.prod.yml`** — add `image: ghcr.io/coltosaur/core-war-backend:latest` to the backend service. The `build:` block stays so the local prod-mirror smoke test still works with `up --build` — that build tags the local image under the same name, harmlessly.
- **`deploy/README.md`** — new section 10 walking through:
  - the one-time GHCR-package-public toggle (first push creates a private package; droplet can't pull without auth setup),
  - the three required secrets (`DROPLET_HOST`, `DROPLET_USER`, `DROPLET_SSH_KEY` — recommended dedicated key, not personal),
  - the `DEPLOY_ENABLED` repo variable,
  - how to fire the first workflow run from the Actions tab.
- Section 9 now frames `deploy/deploy.sh` as the manual escape hatch rather than the steady-state path.

## Test plan

- [x] Workflow YAML parses cleanly; triggers + permissions inspected.
- [x] `docker-compose.prod.yml` parses cleanly with the new `image:` field; backend resolves to `ghcr.io/coltosaur/core-war-backend:latest` while `build:` still resolves.
- [x] `bash -n` clean for the inline heredoc that runs on the droplet.
- [x] **First PR build (no push)** — fires when this PR is opened. Will catch any Dockerfile gotchas.
- [x] **First master push build + image publish** — fires after merge.
- [x] **First gated deploy** — fires after droplet provisioning + secrets + `DEPLOY_ENABLED=true`. Until that flip, the deploy job is conditionally skipped, so the workflow won't fail.

## What's intentionally NOT in this PR

- Provisioning the droplet (PR 2's runbook + manual user action).
- Migrations as an explicit deploy step (PR 5 — currently runs at backend startup via `sqlx::migrate!()`).
- Uptime monitoring (PR 5).
- Database backups (deferred — listed under "What's NOT here").

Refs epic #39.