### PR TITLE
Upgrade /health + fold runbook touch-ups (epic #39, PR 5/5)

### DIFF
--- a/backend/src/health.rs
+++ b/backend/src/health.rs
@@ -1,0 +1,35 @@
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::Json;
+use serde_json::{json, Value};
+use std::time::Duration;
+
+use crate::AppState;
+
+const DB_CHECK_TIMEOUT: Duration = Duration::from_secs(2);
+
+pub async fn handler(State(state): State<AppState>) -> impl IntoResponse {
+    let db_ok = check_db(&state).await;
+
+    let (status_code, overall) = if db_ok {
+        (StatusCode::OK, "ok")
+    } else {
+        (StatusCode::SERVICE_UNAVAILABLE, "degraded")
+    };
+
+    let body: Json<Value> = Json(json!({
+        "status": overall,
+        "database": if db_ok { "ok" } else { "fail" }
+    }));
+
+    (status_code, body)
+}
+
+async fn check_db(state: &AppState) -> bool {
+    let query = sqlx::query_scalar::<_, i32>("SELECT 1").fetch_one(&state.db);
+    matches!(
+        tokio::time::timeout(DB_CHECK_TIMEOUT, query).await,
+        Ok(Ok(_))
+    )
+}

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -2,6 +2,7 @@ pub mod auth;
 pub mod config;
 pub mod db;
 pub mod errors;
+pub mod health;
 pub mod leaderboard;
 pub mod matches;
 pub mod matchmaking;

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,19 +1,14 @@
 use axum::http::{header, Method};
-use axum::{middleware, routing::get, routing::post, Json, Router};
+use axum::{middleware, routing::get, routing::post, Router};
 use core_war_backend::{
-    auth, config::Config, db, leaderboard, matches, matchmaking, profile, warriors, AppConfig,
-    AppState,
+    auth, config::Config, db, health, leaderboard, matches, matchmaking, profile, warriors,
+    AppConfig, AppState,
 };
-use serde_json::{json, Value};
 use socketioxide::{extract::SocketRef, SocketIo};
 use std::net::SocketAddr;
 use tower_http::cors::CorsLayer;
 use tracing::info;
 use tracing_subscriber::EnvFilter;
-
-async fn health() -> Json<Value> {
-    Json(json!({ "status": "ok" }))
-}
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -75,7 +70,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let refresh_limiter = auth::rate_limit::refresh_limiter(redis_conn, proxies);
 
     let app = Router::new()
-        .route("/health", get(health))
+        .route("/health", get(health::handler))
         .route(
             "/api/auth/register",
             post(auth::handlers::register).layer(middleware::from_fn_with_state(

--- a/backend/tests/health_integration.rs
+++ b/backend/tests/health_integration.rs
@@ -1,0 +1,64 @@
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use axum::routing::get;
+use axum::Router;
+use core_war_backend::{health, AppConfig, AppState};
+use http_body_util::BodyExt;
+use serde_json::Value;
+use sqlx::PgPool;
+use tower::ServiceExt;
+
+const JWT_SECRET: &[u8] = b"integration-test-secret-that-is-at-least-32-bytes!!";
+
+fn state(pool: PgPool) -> AppState {
+    AppState {
+        db: pool,
+        config: AppConfig {
+            frontend_url: "http://localhost:5173".into(),
+            jwt_secret: JWT_SECRET.to_vec(),
+            trusted_proxies: vec![],
+        },
+    }
+}
+
+fn app(pool: PgPool) -> Router {
+    Router::new()
+        .route("/health", get(health::handler))
+        .with_state(state(pool))
+}
+
+#[sqlx::test]
+async fn health_returns_ok_when_db_reachable(pool: PgPool) {
+    let response = app(pool)
+        .oneshot(Request::get("/health").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body: Value =
+        serde_json::from_slice(&response.into_body().collect().await.unwrap().to_bytes()).unwrap();
+
+    assert_eq!(body["status"], "ok");
+    assert_eq!(body["database"], "ok");
+}
+
+#[tokio::test]
+async fn health_returns_503_when_db_unreachable() {
+    // Lazy pool pointed at a port nothing's listening on. The 2s timeout in
+    // the health handler caps the test runtime.
+    let pool = PgPool::connect_lazy("postgresql://corewar:bogus@127.0.0.1:1/corewar").unwrap();
+
+    let response = app(pool)
+        .oneshot(Request::get("/health").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+
+    let body: Value =
+        serde_json::from_slice(&response.into_body().collect().await.unwrap().to_bytes()).unwrap();
+
+    assert_eq!(body["status"], "degraded");
+    assert_eq!(body["database"], "fail");
+}

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -22,10 +22,19 @@ Before starting:
 
 - DigitalOcean account with a payment method on file.
 - Domain `coltcampbell.dev` registered (Porkbun) with DNS management access.
-- Local SSH key pair (`~/.ssh/id_ed25519` + `.pub`). Generate one if needed:
+- A dedicated SSH key pair for the droplet — **separate from any key you already use** (e.g. your GitHub key at `~/.ssh/id_ed25519`). Generate one with an explicit filename so the default location isn't clobbered:
   ```bash
-  ssh-keygen -t ed25519 -C "colt@coltcampbell.dev"
+  ssh-keygen -t ed25519 -f ~/.ssh/droplet -C "colt@coltcampbell.dev"
   ```
+  Subsequent commands assume this key. To skip typing `-i ~/.ssh/droplet` every time, add a `~/.ssh/config` alias once the droplet's hostname resolves:
+  ```
+  Host droplet api.corewar.coltcampbell.dev
+      HostName api.corewar.coltcampbell.dev
+      User colt
+      IdentityFile ~/.ssh/droplet
+      IdentitiesOnly yes
+  ```
+  Until then (and for the initial `root@` login below), pass `-i ~/.ssh/droplet -o IdentitiesOnly=yes` explicitly.
 - Docker installed locally (PR 1's prod-mirror stack already requires this).
 
 ## 1. Provision the droplet
@@ -37,7 +46,8 @@ DigitalOcean control panel → **Create → Droplets**:
 | Region | NYC3 (or SFO3 — pick whichever is closest to your users) |
 | OS image | Ubuntu 24.04 (LTS) x64 |
 | Plan | Basic → Regular CPU → **$6/mo (1 GB / 1 CPU / 25 GB SSD / 1 TB transfer)** |
-| Authentication | SSH key — paste the contents of `~/.ssh/id_ed25519.pub`. Do **not** use a password. |
+| Authentication | SSH key — paste the contents of `~/.ssh/droplet.pub`. Do **not** use a password. |
+| IPv6 | Enable (free; you'll add an AAAA record alongside the A in section 6) |
 | Hostname | `corewar-prod` |
 | Backups | Skip for now ($1.20/mo, add later if you want) |
 | Monitoring | Enable (free) |
@@ -51,19 +61,34 @@ DigitalOcean drops the SSH key onto `root@<DROPLET_IP>` for the initial
 connection. The first thing we do is leave that login behind.
 
 ```bash
-ssh root@<DROPLET_IP>
+ssh -i ~/.ssh/droplet -o IdentitiesOnly=yes root@<DROPLET_IP>
 ```
+
+(The `-i` + `IdentitiesOnly=yes` belt-and-suspenders tells SSH not to try other
+keys in your agent first — handy if your default key isn't authorized on the
+droplet.)
 
 On the droplet:
 
 ```bash
-# Patch the base image
+# Patch the base image. If apt prompts about /etc/ssh/sshd_config during the
+# openssh-server upgrade, press D to view the diff, then prefer the package
+# maintainer's version — section 2 below sets the lockdown lines explicitly.
 apt update && apt upgrade -y
 apt install -y sudo
 
 # Create a non-root user (replace 'colt' with whatever you prefer)
 adduser --disabled-password --gecos "" colt
 usermod -aG sudo colt
+
+# Allow colt to sudo without typing a password. The user was created
+# --disabled-password so sudo would otherwise refuse. Cloud-init does this
+# same trick for default cloud-image users; safe here because SSH is
+# key-only and the blast radius if colt is compromised is "the whole
+# droplet" with or without a sudo password.
+echo 'colt ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/colt
+chmod 0440 /etc/sudoers.d/colt
+visudo -c    # syntax-check; should print "/etc/sudoers.d/colt: parsed OK"
 
 # Reuse your existing SSH key for the new user
 rsync --archive --chown=colt:colt ~/.ssh /home/colt
@@ -72,7 +97,7 @@ rsync --archive --chown=colt:colt ~/.ssh /home/colt
 Log out, then SSH back in as the new user from your laptop to confirm it works:
 
 ```bash
-ssh colt@<DROPLET_IP>
+ssh -i ~/.ssh/droplet -o IdentitiesOnly=yes colt@<DROPLET_IP>
 ```
 
 If that succeeds, lock down SSH on the droplet:
@@ -143,6 +168,51 @@ docker run --rm hello-world
 docker compose version
 ```
 
+### 5a. Allocate swap (2 GB)
+
+The $6 droplet has 1 GB RAM. Steady-state operations fit, but the
+`deploy/deploy.sh` escape hatch runs `cargo build --release` on-box, which
+can OOM during linking. A swap file gives the kernel a pressure-release
+valve without changing the plan:
+
+```bash
+sudo fallocate -l 2G /swapfile
+sudo chmod 600 /swapfile
+sudo mkswap /swapfile
+sudo swapon /swapfile
+echo '/swapfile none swap sw 0 0' | sudo tee -a /etc/fstab
+free -h    # verify "Swap:" row shows 2.0Gi
+```
+
+### 5b. Log into GitHub Container Registry
+
+The CI workflow publishes the backend image to `ghcr.io/coltosaur/core-war-backend`.
+By default, ghcr.io creates packages as **private**, which means the droplet
+needs to authenticate before it can pull. (If you'd rather make the package
+public, you can skip this whole step — but private is the more defensible
+default for portfolio infrastructure.)
+
+Create a Personal Access Token first, on your laptop:
+
+1. GitHub → **Settings → Developer settings → Personal access tokens (classic) → Generate new token**.
+2. Note: `corewar-droplet-pull`.
+3. Expiration: 1 year (set a calendar reminder to rotate).
+4. Scopes: tick **`read:packages`** only.
+5. Generate, copy the token (you can't see it again).
+
+Then on the droplet, log in as `colt` (no sudo — Docker reads credentials
+from `~/.docker/config.json` under the current user's home):
+
+```bash
+echo "<paste-PAT-here>" | docker login ghcr.io -u Coltosaur --password-stdin
+```
+
+You should see `Login Succeeded`. Verify the pull path works:
+
+```bash
+docker pull ghcr.io/coltosaur/core-war-backend:latest
+```
+
 ## 6. DNS records at Porkbun
 
 In the Porkbun control panel for `coltcampbell.dev` → **DNS**:
@@ -181,20 +251,28 @@ cp .env.production.example .env.production
 nano .env.production    # or vim, whatever
 ```
 
-Fill in real values:
+Fill in real values. **Use `openssl rand -hex` (not `-base64`) for anything
+that lands inside `DATABASE_URL`** — base64 output includes `/`, `+`, and `=`,
+all of which break URL parsing (sqlx will reject the URL with
+`Configuration(InvalidPort)`).
 
 ```ini
 BACKEND_DOMAIN=api.corewar.coltcampbell.dev
 ACME_EMAIL=colt@coltcampbell.dev
 FRONTEND_URL=https://corewar.coltcampbell.dev
-JWT_SECRET=<openssl rand -base64 48>
+JWT_SECRET=<openssl rand -hex 48>
 POSTGRES_USER=corewar
-POSTGRES_PASSWORD=<openssl rand -base64 24>
+POSTGRES_PASSWORD=<openssl rand -hex 24>
 POSTGRES_DB=corewar
-DATABASE_URL=postgresql://corewar:<same password>@postgres:5432/corewar
+DATABASE_URL=postgresql://corewar:<same hex password>@postgres:5432/corewar
 REDIS_URL=redis://redis:6379
 TRUSTED_PROXIES=
 ```
+
+`POSTGRES_PASSWORD` and the password portion of `DATABASE_URL` MUST match
+byte-for-byte. If you change one, change both — and `down -v` the postgres
+volume so the new credentials take effect (the volume bakes credentials in
+on first init and ignores env-var changes afterward).
 
 Then re-run the deploy from your laptop:
 
@@ -217,8 +295,12 @@ Let's Encrypt cert. Expected response:
 ```
 HTTP/2 200
 content-type: application/json
-{"status":"ok"}
+{"status":"ok","database":"ok"}
 ```
+
+(Older deploys returned just `{"status":"ok"}` — `/health` now also probes
+Postgres via a 2s-timeout `SELECT 1` and returns HTTP 503 if the DB is
+unreachable.)
 
 If the cert handshake fails:
 
@@ -226,6 +308,21 @@ If the cert handshake fails:
 - Port 80 must be reachable from the public internet (Let's Encrypt's
   HTTP-01 challenge uses it). `sudo ufw status` should show 80/tcp ALLOW.
 - Inspect Caddy's logs: `docker compose -f docker-compose.prod.yml logs caddy`.
+
+If `/health` returns 503 with `"database":"fail"`, the backend booted but
+can't talk to Postgres. Tail the backend logs to see the exact error:
+
+```bash
+docker compose -f docker-compose.prod.yml --env-file .env.production logs --tail 80 backend
+```
+
+Common causes:
+- **`Configuration(InvalidPort)`** — `DATABASE_URL` password contains URL-special
+  characters (`/`, `+`, `:`, `@`, `=`). Regenerate with `openssl rand -hex`.
+- **`password authentication failed for user "corewar"`** — `POSTGRES_PASSWORD`
+  and the password in `DATABASE_URL` disagree, OR a previous `up` initialized
+  the postgres volume with different credentials. Fix: nuke the volume with
+  `docker compose ... down -v` and re-up.
 
 ## 9. Operations cheat sheet
 
@@ -265,17 +362,14 @@ deploys. The workflow builds the backend image on every push to master,
 pushes it to GitHub Container Registry (ghcr.io), then SSHes into the
 droplet and rolls out the new image.
 
-### One-time: make the backend image public
+### Package visibility — already handled
 
-The first time the workflow runs, it creates a private package under
-`ghcr.io/coltosaur/core-war-backend`. The droplet can't pull it without
-auth setup, so flip it to public:
-
-1. GitHub → your profile → **Packages** → `core-war-backend`.
-2. **Package settings → Change visibility → Public**.
-
-(Source is already public; the compiled binary doesn't expose anything
-new.)
+Section 5b walked through logging the droplet into GHCR with a
+`read:packages` PAT, so a private package is the assumed default. If
+you'd rather make the package public (no droplet auth needed, anyone can
+pull the compiled image), GitHub → your profile → **Packages** →
+`core-war-backend` → **Package settings → Change visibility → Public**.
+Source is already public; the binary doesn't expose anything new.
 
 ### Required GitHub Actions secrets
 
@@ -318,12 +412,36 @@ From then on, every push to master that touches `backend/`, `engine/`,
 the image without pushing (so Dockerfile breakage gets caught before
 merge).
 
+## 11. Uptime monitoring
+
+External monitor pinging `/health` so you find out about an outage from
+a notification, not from a friend trying to use the site. **UptimeRobot**
+has the longest-running free tier and is what we'll wire up:
+
+1. Sign up at [uptimerobot.com](https://uptimerobot.com) — free, no card.
+2. **+ New Monitor**:
+   - Type: HTTPS
+   - Friendly name: `Core War backend`
+   - URL: `https://api.corewar.coltcampbell.dev/health`
+   - Monitoring interval: 5 minutes (free-tier minimum)
+3. **Alert contacts**: at least email. Optional: Slack, Telegram, webhooks.
+4. **Advanced** (optional but recommended):
+   - **Keyword monitoring**: also check the response body for the string
+     `"status":"ok"`. Catches the case where `/health` returns 503 with
+     `"status":"degraded"` (DB unreachable) but the TLS/proxy layer is fine.
+
+The same pattern will work for the frontend once Cloudflare Pages is up
+— add a second monitor for `https://corewar.coltcampbell.dev`.
+
 ## What's NOT here (yet)
 
 - **Database backups.** Volumes survive `down`, but the droplet does not.
-  PR 5 or later will add either DO managed snapshots ($1.20/mo) or a
-  `pg_dump`-to-S3 cron.
-- **Migration step in CI.** Currently the backend runs `sqlx::migrate!()`
-  on startup. PR 5 makes that an explicit deploy step so failures surface
-  before the container starts accepting traffic.
-- **Uptime monitoring.** PR 5 adds a free external pinger against `/health`.
+  A future PR will add either DO managed snapshots ($1.20/mo) or a
+  `pg_dump`-to-Backblaze-B2 cron job.
+- **Redis check in `/health`.** Currently only Postgres is probed. Adding
+  Redis means restructuring `AppState`; tracked as a follow-up.
+- **Migrations as an explicit deploy step.** The backend currently runs
+  `sqlx::migrate!()` at startup; migration failures surface as backend
+  startup errors in `docker compose logs backend` and the CI deploy job's
+  60s health-check loop catches them. Splitting into a separate
+  pre-startup step is a nice-to-have, not a blocker.


### PR DESCRIPTION
## Summary

Final PR of the deployment epic (#39). Two threads:

1. **`/health` actually probes Postgres now** and returns HTTP 503 when it can't reach the DB (with a 2-second timeout). Replaces the bare `{"status":"ok"}` constant that didn't catch a degraded database.
2. **Runbook touch-ups** — the gaps that surfaced while walking through the first real droplet provisioning yesterday.

## Backend changes — `/health` endpoint

- **`backend/src/health.rs`** (new) — handler extracted from `main.rs` so integration tests can import it. `check_db` runs `SELECT 1` with a `tokio::time::timeout(2s)` wrapper so a hung DB doesn't hang the healthcheck.
- **`backend/src/main.rs`** — uses `health::handler` instead of the local closure; unused JSON imports dropped.
- **`backend/tests/health_integration.rs`** (new) — happy-path test via `#[sqlx::test]` (uses CI's Postgres service); failure-path test via a lazy pool pointed at a closed port — exercises the 2s timeout and confirms the 503 + `"database":"fail"` response.

Response shape:
```json
{"status": "ok",       "database": "ok"  }   // HTTP 200
{"status": "degraded", "database": "fail"}   // HTTP 503
```

Shape is intentionally extensible for the eventual Redis check (tracked as a follow-up — would require restructuring `AppState`).

## Runbook touch-ups (`deploy/README.md`)

These came up while we walked through the first real provisioning and would have made the process smoother:

| Change | Why |
|---|---|
| Prerequisites: dedicated `~/.ssh/droplet` key, not `id_ed25519` | Stops the runbook from clobbering an existing GitHub key |
| Section 1: explicit "Enable IPv6" row | Free, matches what we decided in chat |
| Section 2: `NOPASSWD` sudoers drop-in for the non-root user | `--disabled-password` user can't sudo otherwise; matches cloud-init defaults |
| Section 2: callout about apt's `sshd_config` upgrade prompt | Hit this during the run; "keep maintainer's version" is the right answer |
| Section 5a: 2 GB swap allocation | Mitigates OOM if `deploy.sh` runs `cargo build` on the 1 GB droplet |
| Section 5b: GHCR PAT login (`docker login ghcr.io`) | Replaces the previous "make package public" approach; private+PAT is more defensible for portfolio infra |
| Section 7: `openssl rand -hex` (not `-base64`) for DB password | Base64 includes `/+=` which break `DATABASE_URL`; this is exactly the `Configuration(InvalidPort)` we hit |
| Section 8: documents new `/health` response shape + debug callouts for the two most common backend startup errors | Reduces "container is crash-looping, why" time |
| Section 10: package-visibility section reframed | Private+PAT is now the default; public is the alternative |
| Section 11 (new): uptime monitoring with UptimeRobot | Free, 5-min HTTPS check with keyword match against `"status":"ok"` |

## Test plan

- [x] `cargo build` — clean.
- [x] `cargo clippy --all-targets -- -D warnings` — clean.
- [x] `cargo fmt -- --check` — clean.
- [x] `cargo test --test health_integration health_returns_503_when_db_unreachable` — passes locally in 2s (the timeout firing as designed).
- [x] `cargo test --test health_integration health_returns_ok_when_db_reachable` — needs CI's Postgres service. Will validate via the PR's backend CI job.
- [x] **End-to-end check on the live droplet** post-merge: `curl -i https://api.corewar.coltcampbell.dev/health` should now return `{"status":"ok","database":"ok"}` after CI auto-deploys.

## Defers (explicitly NOT in this PR)

- **Redis check in `/health`** — small but requires `AppState` restructuring (Redis isn't there today). Clean follow-up.
- **Migrations as an explicit pre-startup step** — current behavior (sqlx::migrate! at backend startup + 60s CI health-check loop catching failures) is good enough. Splitting is a nice-to-have, not a blocker.
- **Database backups** — separate, larger piece of work; tracked under "What's NOT here" in the runbook.

Refs epic #39 — final PR.