### PR TITLE
Install rustup in Cloudflare Pages build script

### DIFF
--- a/deploy/cloudflare-pages-build.sh
+++ b/deploy/cloudflare-pages-build.sh
@@ -3,14 +3,15 @@
 # Cloudflare Pages build script.
 #
 # Cloudflare Pages doesn't know how to drive a Rust + Wasm + Vite build on
-# its own, so we run all four steps here:
-#   1. Add the wasm32-unknown-unknown target to the Pages build image's
-#      pre-installed Rust toolchain.
-#   2. Download a pinned wasm-pack binary (matches the version pinned in
+# its own, so we run all five steps here:
+#   1. Install rustup + a stable Rust toolchain (the Pages build image ships
+#      with Node but NOT Rust, so we bootstrap it ourselves).
+#   2. Add the wasm32-unknown-unknown target.
+#   3. Download a pinned wasm-pack binary (matches the version pinned in
 #      .github/workflows/ci.yml — older wasm-pack ships a too-old
 #      wasm-opt that can't parse modern Rust Wasm output).
-#   3. Build the engine to Wasm via wasm-pack (writes engine/pkg/).
-#   4. Install frontend deps (npm picks up the engine pkg via the
+#   4. Build the engine to Wasm via wasm-pack (writes engine/pkg/).
+#   5. Install frontend deps (npm picks up the engine pkg via the
 #      `file:../engine/pkg` dep) and run `vite build` → frontend/dist/.
 #
 # Configure in Cloudflare Pages dashboard:
@@ -29,8 +30,22 @@ WASM_PACK_VERSION="v0.13.1"
 WASM_PACK_TARBALL="wasm-pack-${WASM_PACK_VERSION}-x86_64-unknown-linux-musl"
 
 echo "==> Pages build env: $(uname -a)"
-echo "==> rustc: $(rustc --version 2>/dev/null || echo MISSING)"
 echo "==> node: $(node --version 2>/dev/null || echo MISSING)"
+
+# Install rustup + stable toolchain (minimal profile = rustc + cargo only,
+# no docs/rust-src, fastest install). The `-y` skips the interactive prompt.
+if ! command -v rustup >/dev/null 2>&1; then
+    echo "==> Installing rustup + stable Rust (minimal profile)"
+    curl --proto '=https' --tlsv1.2 -fsSL https://sh.rustup.rs \
+        | sh -s -- -y --default-toolchain stable --profile minimal --no-modify-path
+    # rustup installs to $HOME/.cargo by default. Source the env so cargo/rustc
+    # land on PATH for the rest of this script.
+    # shellcheck disable=SC1091
+    . "$HOME/.cargo/env"
+else
+    echo "==> rustup already present"
+fi
+echo "==> rustc: $(rustc --version)"
 
 echo "==> Adding wasm32 target"
 rustup target add wasm32-unknown-unknown


### PR DESCRIPTION
## Summary

Hotfix for a wrong assumption baked into PR #64's Pages build script: I assumed Cloudflare Pages' build image had Rust pre-installed. It doesn't — ships with Node but not Rust. First real Pages build failed at `rustup target add` with "command not found."

## Fix

Bootstrap rustup ourselves at the top of `deploy/cloudflare-pages-build.sh`:

- Use the official rustup-init via curl (`--proto '=https' --tlsv1.2`).
- Stable toolchain, **minimal profile** (rustc + cargo only — no docs/rust-src) for fastest install — adds ~30–60s on a cold build.
- Source `$HOME/.cargo/env` so cargo/rustc land on PATH for the rest of the script.
- Guard with `command -v rustup` so a re-run on a warm image is a no-op (in case Cloudflare ever does add Rust to the image).

Updated the leading comment to reflect 5 steps instead of 4 and to call out the missing-Rust reality so the next reader doesn't make the same assumption.

## Test plan

- [x] `bash -n deploy/cloudflare-pages-build.sh` — shell syntax clean.
- [x] **Cloudflare Pages re-run** (the actual test) — once this lands on master, retrigger the Pages build from the dashboard. Expected: rustup install line appears in the log around 30–60s, then the existing flow (wasm-pack download → cargo build --release → npm ci → vite build) runs to completion.

Refs epic #39 (frontend half).