### PR TITLE
Backend hardening: body limits, password policy, timing fix, security headers (#68)

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -12,6 +12,19 @@
 {$BACKEND_DOMAIN} {
 	encode gzip zstd
 
+	# Security headers applied to every response. HSTS is one-year with
+	# subdomain coverage; `preload` is intentionally omitted so we can
+	# revert without users being locked out by a browser's preload list.
+	# Submit to hstspreload.org separately when ready.
+	header {
+		Strict-Transport-Security "max-age=31536000; includeSubDomains"
+		X-Content-Type-Options "nosniff"
+		X-Frame-Options "DENY"
+		Referrer-Policy "strict-origin-when-cross-origin"
+		Permissions-Policy "geolocation=(), microphone=(), camera=()"
+		-Server
+	}
+
 	# Reverse-proxy everything to the backend. Caddy upgrades WebSocket
 	# (Socket.IO) connections automatically and sets X-Forwarded-For /
 	# X-Forwarded-Proto by default.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -33,6 +33,6 @@ WORKDIR /home/app
 EXPOSE 3001
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
-    CMD curl -fsS http://localhost:3001/health || exit 1
+    CMD curl -fsS http://localhost:3001/health/deep || exit 1
 
 CMD ["core-war-backend"]

--- a/backend/src/auth/handlers.rs
+++ b/backend/src/auth/handlers.rs
@@ -1,5 +1,5 @@
 use crate::auth::jwt::{encode_access_token, generate_refresh_token, hash_refresh_token};
-use crate::auth::password::{hash_password, verify_password};
+use crate::auth::password::{hash_password, verify_password, verify_password_against_dummy};
 use crate::errors::AppError;
 use crate::AppState;
 use axum::extract::State;
@@ -63,14 +63,19 @@ fn validate_email(email: &str) -> Result<(), AppError> {
 }
 
 fn validate_password(password: &str) -> Result<(), AppError> {
-    if password.len() < 8 {
+    if password.len() < 12 {
         return Err(AppError::BadRequest(
-            "Password must be at least 8 characters".into(),
+            "Password must be at least 12 characters".into(),
         ));
     }
     if password.len() > 1000 {
         return Err(AppError::BadRequest(
             "Password must not exceed 1000 characters".into(),
+        ));
+    }
+    if password.chars().all(|c| c.is_ascii_digit()) {
+        return Err(AppError::BadRequest(
+            "Password must contain at least one non-digit character".into(),
         ));
     }
     Ok(())
@@ -196,10 +201,15 @@ pub async fn login(
     .bind(input)
     .bind(&email_input)
     .fetch_optional(&state.db)
-    .await?
-    .ok_or_else(|| AppError::Unauthorized("Invalid credentials".into()))?;
+    .await?;
 
-    let (user_id, username, password_hash) = user;
+    let (user_id, username, password_hash) = match user {
+        Some(row) => row,
+        None => {
+            verify_password_against_dummy(&body.password);
+            return Err(AppError::Unauthorized("Invalid credentials".into()));
+        }
+    };
 
     if !verify_password(&body.password, &password_hash)? {
         return Err(AppError::Unauthorized("Invalid credentials".into()));
@@ -380,13 +390,15 @@ mod tests {
 
     #[test]
     fn valid_password() {
-        assert!(validate_password("12345678").is_ok());
+        assert!(validate_password("hunter2hunter").is_ok());
         assert!(validate_password("a-very-long-password-indeed").is_ok());
     }
 
     #[test]
     fn password_too_short() {
-        assert!(validate_password("1234567").is_err());
+        assert!(validate_password("short").is_err());
+        assert!(validate_password("eleven-chars").is_ok());
+        assert!(validate_password("ten-chars1").is_err());
     }
 
     #[test]
@@ -399,6 +411,25 @@ mod tests {
     fn password_at_max_length() {
         let max = "a".repeat(1000);
         assert!(validate_password(&max).is_ok());
+    }
+
+    #[test]
+    fn password_exactly_min_length_passes() {
+        assert!(validate_password("abcdefghijkl").is_ok());
+        assert_eq!("abcdefghijkl".len(), 12);
+    }
+
+    #[test]
+    fn password_pure_numeric_rejected() {
+        assert!(validate_password("123456789012").is_err());
+        assert!(validate_password(&"1".repeat(20)).is_err());
+    }
+
+    #[test]
+    fn password_with_any_non_digit_accepted() {
+        assert!(validate_password("12345678901a").is_ok());
+        assert!(validate_password("a23456789012").is_ok());
+        assert!(validate_password("123456-78901").is_ok());
     }
 
     #[test]

--- a/backend/src/auth/jwt.rs
+++ b/backend/src/auth/jwt.rs
@@ -1,11 +1,12 @@
 use chrono::Utc;
-use jsonwebtoken::{decode, encode, DecodingKey, EncodingKey, Header, Validation};
+use jsonwebtoken::{decode, encode, Algorithm, DecodingKey, EncodingKey, Header, Validation};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::errors::AppError;
 
 const ACCESS_TOKEN_DURATION_SECS: i64 = 15 * 60;
+const JWT_ALGORITHM: Algorithm = Algorithm::HS256;
 
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub struct Claims {
@@ -39,7 +40,7 @@ pub fn decode_access_token(token: &str, secret: &[u8]) -> Result<Claims, AppErro
     decode::<Claims>(
         token,
         &DecodingKey::from_secret(secret),
-        &Validation::default(),
+        &Validation::new(JWT_ALGORITHM),
     )
     .map(|data| data.claims)
     .map_err(|e| AppError::Unauthorized(format!("Invalid token: {e}")))
@@ -109,6 +110,26 @@ mod tests {
         let tampered = format!("{token}x");
         let result = decode_access_token(&tampered, TEST_SECRET);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn token_signed_with_different_algorithm_rejected() {
+        let user_id = Uuid::new_v4();
+        let now = Utc::now().timestamp();
+        let claims = Claims {
+            sub: user_id.to_string(),
+            username: "testuser".into(),
+            exp: now + 60,
+            iat: now,
+        };
+        let mut header = Header::new(Algorithm::HS384);
+        header.typ = Some("JWT".into());
+        let token = encode(&header, &claims, &EncodingKey::from_secret(TEST_SECRET)).unwrap();
+        let result = decode_access_token(&token, TEST_SECRET);
+        assert!(
+            result.is_err(),
+            "decode_access_token must reject tokens signed with non-HS256 algorithms"
+        );
     }
 
     #[test]

--- a/backend/src/auth/password.rs
+++ b/backend/src/auth/password.rs
@@ -2,6 +2,7 @@ use argon2::{
     password_hash::{rand_core::OsRng, PasswordHash, PasswordHasher, PasswordVerifier, SaltString},
     Argon2,
 };
+use std::sync::OnceLock;
 
 use crate::errors::AppError;
 
@@ -20,6 +21,30 @@ pub fn verify_password(plain: &str, hash: &str) -> Result<bool, AppError> {
     Ok(Argon2::default()
         .verify_password(plain.as_bytes(), &parsed)
         .is_ok())
+}
+
+static DUMMY_HASH: OnceLock<String> = OnceLock::new();
+
+fn dummy_hash() -> &'static str {
+    DUMMY_HASH.get_or_init(|| {
+        hash_password("dummy-password-for-timing-equalization")
+            .expect("dummy password hashing must succeed at startup")
+    })
+}
+
+/// Run an Argon2 verification against a fixed dummy hash, discarding the
+/// result. Used in the login handler when the username/email doesn't exist —
+/// without this call, the "user-not-found" path returns in microseconds
+/// while the "user-found-wrong-password" path takes ~100 ms, letting an
+/// attacker enumerate valid accounts by timing.
+pub fn verify_password_against_dummy(plain: &str) {
+    let _ = verify_password(plain, dummy_hash());
+}
+
+/// Pre-compute the dummy hash at startup so the first cold login request
+/// doesn't leak the initialization cost.
+pub fn warm_dummy_hash() {
+    let _ = dummy_hash();
 }
 
 #[cfg(test)]
@@ -55,5 +80,27 @@ mod tests {
     fn invalid_hash_format_returns_error() {
         let result = verify_password("test", "not-a-valid-hash");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn dummy_hash_is_stable_across_calls() {
+        let a = dummy_hash();
+        let b = dummy_hash();
+        assert_eq!(a, b);
+        assert!(a.starts_with("$argon2id$"));
+    }
+
+    #[test]
+    fn verify_against_dummy_does_not_panic() {
+        verify_password_against_dummy("anything");
+        verify_password_against_dummy("");
+        verify_password_against_dummy("\0\0\0");
+    }
+
+    #[test]
+    fn warm_dummy_hash_initializes_lock() {
+        warm_dummy_hash();
+        let h = dummy_hash();
+        assert!(h.starts_with("$argon2id$"));
     }
 }

--- a/backend/src/health.rs
+++ b/backend/src/health.rs
@@ -9,7 +9,17 @@ use crate::AppState;
 
 const DB_CHECK_TIMEOUT: Duration = Duration::from_secs(2);
 
-pub async fn handler(State(state): State<AppState>) -> impl IntoResponse {
+/// Cheap liveness probe. Always 200 if the process can serve requests.
+/// Used by Cloudflare/UptimeRobot-style external probes — does no DB work,
+/// so a hostile flood here can't amplify into database load.
+pub async fn liveness() -> impl IntoResponse {
+    let body: Json<Value> = Json(json!({ "status": "ok" }));
+    (StatusCode::OK, body)
+}
+
+/// Deep readiness probe. Verifies the database is reachable. Used by the
+/// container HEALTHCHECK so Docker can react to a downstream outage.
+pub async fn readiness(State(state): State<AppState>) -> impl IntoResponse {
     let db_ok = check_db(&state).await;
 
     let (status_code, overall) = if db_ok {
@@ -32,4 +42,36 @@ async fn check_db(state: &AppState) -> bool {
         tokio::time::timeout(DB_CHECK_TIMEOUT, query).await,
         Ok(Ok(_))
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::response::IntoResponse;
+    use http_body_util::BodyExt;
+
+    #[tokio::test]
+    async fn liveness_returns_200_with_status_ok() {
+        let response = liveness().await.into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body: Value =
+            serde_json::from_slice(&response.into_body().collect().await.unwrap().to_bytes())
+                .unwrap();
+        assert_eq!(body["status"], "ok");
+    }
+
+    #[tokio::test]
+    async fn liveness_does_not_include_database_field() {
+        // Critical: liveness must not reveal anything about downstream
+        // state — otherwise it can't serve as a cheap probe.
+        let response = liveness().await.into_response();
+        let body: Value =
+            serde_json::from_slice(&response.into_body().collect().await.unwrap().to_bytes())
+                .unwrap();
+        assert!(
+            body.get("database").is_none(),
+            "liveness must not probe or expose database state"
+        );
+    }
 }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,9 +1,12 @@
+use axum::extract::DefaultBodyLimit;
 use axum::http::{header, Method};
 use axum::{middleware, routing::get, routing::post, Router};
 use core_war_backend::{
     auth, config::Config, db, health, leaderboard, matches, matchmaking, profile, warriors,
     AppConfig, AppState,
 };
+
+const MAX_REQUEST_BODY_BYTES: usize = 128 * 1024;
 use socketioxide::{extract::SocketRef, SocketIo};
 use std::net::SocketAddr;
 use tower_http::cors::CorsLayer;
@@ -23,6 +26,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let config = Config::from_env()?;
     let pool = db::init_pool(&config.database_url).await?;
+
+    auth::password::warm_dummy_hash();
 
     let redis_client = redis::Client::open(config.redis_url.as_str())?;
     let redis_conn = redis::aio::ConnectionManager::new(redis_client).await?;
@@ -70,7 +75,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let refresh_limiter = auth::rate_limit::refresh_limiter(redis_conn, proxies);
 
     let app = Router::new()
-        .route("/health", get(health::handler))
+        .route("/health", get(health::liveness))
+        .route("/health/deep", get(health::readiness))
         .route(
             "/api/auth/register",
             post(auth::handlers::register).layer(middleware::from_fn_with_state(
@@ -119,6 +125,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             state.clone(),
             auth::middleware::csrf_middleware,
         ))
+        .layer(DefaultBodyLimit::max(MAX_REQUEST_BODY_BYTES))
         .with_state(state)
         .layer(socket_layer)
         .layer(cors);

--- a/backend/tests/auth_integration.rs
+++ b/backend/tests/auth_integration.rs
@@ -143,7 +143,7 @@ async fn register_success(pool: PgPool) {
         app(pool),
         post_json(
             "/api/auth/register",
-            &register_body("alice", "alice@example.com", "password123"),
+            &register_body("alice", "alice@example.com", "password1234"),
         ),
     )
     .await;
@@ -162,7 +162,7 @@ async fn register_duplicate_username(pool: PgPool) {
         router.clone(),
         post_json(
             "/api/auth/register",
-            &register_body("alice", "alice1@example.com", "password123"),
+            &register_body("alice", "alice1@example.com", "password1234"),
         ),
     )
     .await;
@@ -172,7 +172,7 @@ async fn register_duplicate_username(pool: PgPool) {
         router,
         post_json(
             "/api/auth/register",
-            &register_body("alice", "alice2@example.com", "password123"),
+            &register_body("alice", "alice2@example.com", "password1234"),
         ),
     )
     .await;
@@ -188,7 +188,7 @@ async fn register_duplicate_email(pool: PgPool) {
         router.clone(),
         post_json(
             "/api/auth/register",
-            &register_body("user1", "same@example.com", "password123"),
+            &register_body("user1", "same@example.com", "password1234"),
         ),
     )
     .await;
@@ -198,7 +198,7 @@ async fn register_duplicate_email(pool: PgPool) {
         router,
         post_json(
             "/api/auth/register",
-            &register_body("user2", "same@example.com", "password123"),
+            &register_body("user2", "same@example.com", "password1234"),
         ),
     )
     .await;
@@ -215,7 +215,7 @@ async fn register_validation_errors(pool: PgPool) {
         router.clone(),
         post_json(
             "/api/auth/register",
-            &register_body("ab", "ab@example.com", "password123"),
+            &register_body("ab", "ab@example.com", "password1234"),
         ),
     )
     .await;
@@ -226,7 +226,7 @@ async fn register_validation_errors(pool: PgPool) {
         router.clone(),
         post_json(
             "/api/auth/register",
-            &register_body("user!name", "un@example.com", "password123"),
+            &register_body("user!name", "un@example.com", "password1234"),
         ),
     )
     .await;
@@ -237,7 +237,7 @@ async fn register_validation_errors(pool: PgPool) {
         router.clone(),
         post_json(
             "/api/auth/register",
-            &register_body("validuser", "not-an-email", "password123"),
+            &register_body("validuser", "not-an-email", "password1234"),
         ),
     )
     .await;
@@ -284,7 +284,7 @@ async fn register_email_normalized(pool: PgPool) {
         router.clone(),
         post_json(
             "/api/auth/register",
-            &register_body("alice", "  Alice@Example.COM  ", "password123"),
+            &register_body("alice", "  Alice@Example.COM  ", "password1234"),
         ),
     )
     .await;
@@ -295,7 +295,7 @@ async fn register_email_normalized(pool: PgPool) {
         router,
         post_json(
             "/api/auth/register",
-            &register_body("bob", "alice@example.com", "password123"),
+            &register_body("bob", "alice@example.com", "password1234"),
         ),
     )
     .await;
@@ -308,7 +308,7 @@ async fn register_username_trimmed(pool: PgPool) {
         app(pool),
         post_json(
             "/api/auth/register",
-            &register_body("  alice  ", "alice@example.com", "password123"),
+            &register_body("  alice  ", "alice@example.com", "password1234"),
         ),
     )
     .await;
@@ -327,14 +327,14 @@ async fn login_by_username(pool: PgPool) {
         router.clone(),
         post_json(
             "/api/auth/register",
-            &register_body("alice", "alice@example.com", "password123"),
+            &register_body("alice", "alice@example.com", "password1234"),
         ),
     )
     .await;
 
     let resp = send(
         router,
-        post_json("/api/auth/login", &login_body("alice", "password123")),
+        post_json("/api/auth/login", &login_body("alice", "password1234")),
     )
     .await;
     assert_eq!(resp.status, StatusCode::OK);
@@ -349,7 +349,7 @@ async fn login_by_email(pool: PgPool) {
         router.clone(),
         post_json(
             "/api/auth/register",
-            &register_body("alice", "alice@example.com", "password123"),
+            &register_body("alice", "alice@example.com", "password1234"),
         ),
     )
     .await;
@@ -358,7 +358,7 @@ async fn login_by_email(pool: PgPool) {
         router,
         post_json(
             "/api/auth/login",
-            &login_body("alice@example.com", "password123"),
+            &login_body("alice@example.com", "password1234"),
         ),
     )
     .await;
@@ -373,7 +373,7 @@ async fn login_email_case_insensitive(pool: PgPool) {
         router.clone(),
         post_json(
             "/api/auth/register",
-            &register_body("alice", "alice@example.com", "password123"),
+            &register_body("alice", "alice@example.com", "password1234"),
         ),
     )
     .await;
@@ -382,7 +382,7 @@ async fn login_email_case_insensitive(pool: PgPool) {
         router,
         post_json(
             "/api/auth/login",
-            &login_body("ALICE@EXAMPLE.COM", "password123"),
+            &login_body("ALICE@EXAMPLE.COM", "password1234"),
         ),
     )
     .await;
@@ -397,7 +397,7 @@ async fn login_wrong_password(pool: PgPool) {
         router.clone(),
         post_json(
             "/api/auth/register",
-            &register_body("alice", "alice@example.com", "password123"),
+            &register_body("alice", "alice@example.com", "password1234"),
         ),
     )
     .await;
@@ -415,7 +415,7 @@ async fn login_wrong_password(pool: PgPool) {
 async fn login_nonexistent_user(pool: PgPool) {
     let resp = send(
         app(pool),
-        post_json("/api/auth/login", &login_body("ghost", "password123")),
+        post_json("/api/auth/login", &login_body("ghost", "password1234")),
     )
     .await;
     assert_eq!(resp.status, StatusCode::UNAUTHORIZED);
@@ -429,14 +429,14 @@ async fn login_sets_both_cookies(pool: PgPool) {
         router.clone(),
         post_json(
             "/api/auth/register",
-            &register_body("alice", "alice@example.com", "password123"),
+            &register_body("alice", "alice@example.com", "password1234"),
         ),
     )
     .await;
 
     let resp = send(
         router,
-        post_json("/api/auth/login", &login_body("alice", "password123")),
+        post_json("/api/auth/login", &login_body("alice", "password1234")),
     )
     .await;
     assert_eq!(resp.status, StatusCode::OK);
@@ -453,14 +453,14 @@ async fn login_cookie_properties(pool: PgPool) {
         router.clone(),
         post_json(
             "/api/auth/register",
-            &register_body("alice", "alice@example.com", "password123"),
+            &register_body("alice", "alice@example.com", "password1234"),
         ),
     )
     .await;
 
     let resp = send(
         router,
-        post_json("/api/auth/login", &login_body("alice", "password123")),
+        post_json("/api/auth/login", &login_body("alice", "password1234")),
     )
     .await;
 
@@ -495,7 +495,7 @@ async fn login_cookie_properties(pool: PgPool) {
 #[sqlx::test]
 async fn refresh_rotates_token(pool: PgPool) {
     let router = app(pool);
-    let cookies = register_and_login(&router, "alice", "alice@example.com", "password123").await;
+    let cookies = register_and_login(&router, "alice", "alice@example.com", "password1234").await;
     let old_refresh = cookies["refresh_token"].clone();
 
     let resp = send(
@@ -513,7 +513,7 @@ async fn refresh_rotates_token(pool: PgPool) {
 #[sqlx::test]
 async fn refresh_old_token_rejected(pool: PgPool) {
     let router = app(pool);
-    let cookies = register_and_login(&router, "alice", "alice@example.com", "password123").await;
+    let cookies = register_and_login(&router, "alice", "alice@example.com", "password1234").await;
     let old_refresh = cookies["refresh_token"].clone();
 
     // Use the token once (rotates it)
@@ -558,7 +558,7 @@ async fn refresh_expired_token(pool: PgPool) {
         router.clone(),
         post_json(
             "/api/auth/register",
-            &register_body("alice", "alice@example.com", "password123"),
+            &register_body("alice", "alice@example.com", "password1234"),
         ),
     )
     .await;
@@ -593,7 +593,7 @@ async fn refresh_expired_token(pool: PgPool) {
 #[sqlx::test]
 async fn logout_clears_cookies(pool: PgPool) {
     let router = app(pool);
-    let cookies = register_and_login(&router, "alice", "alice@example.com", "password123").await;
+    let cookies = register_and_login(&router, "alice", "alice@example.com", "password1234").await;
     let refresh = &cookies["refresh_token"];
 
     let resp = send(
@@ -622,7 +622,7 @@ async fn logout_clears_cookies(pool: PgPool) {
 #[sqlx::test]
 async fn logout_token_not_reusable(pool: PgPool) {
     let router = app(pool);
-    let cookies = register_and_login(&router, "alice", "alice@example.com", "password123").await;
+    let cookies = register_and_login(&router, "alice", "alice@example.com", "password1234").await;
     let refresh = cookies["refresh_token"].clone();
 
     // Logout
@@ -668,7 +668,7 @@ async fn full_flow_register_login_refresh_logout(pool: PgPool) {
         router.clone(),
         post_json(
             "/api/auth/register",
-            &register_body("flowuser", "flow@example.com", "password123"),
+            &register_body("flowuser", "flow@example.com", "password1234"),
         ),
     )
     .await;
@@ -678,7 +678,7 @@ async fn full_flow_register_login_refresh_logout(pool: PgPool) {
     // 2. Login
     let resp = send(
         router.clone(),
-        post_json("/api/auth/login", &login_body("flowuser", "password123")),
+        post_json("/api/auth/login", &login_body("flowuser", "password1234")),
     )
     .await;
     assert_eq!(resp.status, StatusCode::OK);

--- a/backend/tests/health_integration.rs
+++ b/backend/tests/health_integration.rs
@@ -23,14 +23,34 @@ fn state(pool: PgPool) -> AppState {
 
 fn app(pool: PgPool) -> Router {
     Router::new()
-        .route("/health", get(health::handler))
+        .route("/health", get(health::liveness))
+        .route("/health/deep", get(health::readiness))
         .with_state(state(pool))
 }
 
 #[sqlx::test]
-async fn health_returns_ok_when_db_reachable(pool: PgPool) {
+async fn liveness_returns_ok_regardless_of_db(pool: PgPool) {
     let response = app(pool)
         .oneshot(Request::get("/health").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body: Value =
+        serde_json::from_slice(&response.into_body().collect().await.unwrap().to_bytes()).unwrap();
+
+    assert_eq!(body["status"], "ok");
+    assert!(
+        body.get("database").is_none(),
+        "liveness must not expose database state"
+    );
+}
+
+#[sqlx::test]
+async fn readiness_returns_ok_when_db_reachable(pool: PgPool) {
+    let response = app(pool)
+        .oneshot(Request::get("/health/deep").body(Body::empty()).unwrap())
         .await
         .unwrap();
 
@@ -44,13 +64,13 @@ async fn health_returns_ok_when_db_reachable(pool: PgPool) {
 }
 
 #[tokio::test]
-async fn health_returns_503_when_db_unreachable() {
+async fn readiness_returns_503_when_db_unreachable() {
     // Lazy pool pointed at a port nothing's listening on. The 2s timeout in
-    // the health handler caps the test runtime.
+    // the readiness handler caps the test runtime.
     let pool = PgPool::connect_lazy("postgresql://corewar:bogus@127.0.0.1:1/corewar").unwrap();
 
     let response = app(pool)
-        .oneshot(Request::get("/health").body(Body::empty()).unwrap())
+        .oneshot(Request::get("/health/deep").body(Body::empty()).unwrap())
         .await
         .unwrap();
 
@@ -61,4 +81,18 @@ async fn health_returns_503_when_db_unreachable() {
 
     assert_eq!(body["status"], "degraded");
     assert_eq!(body["database"], "fail");
+}
+
+#[tokio::test]
+async fn liveness_responds_when_db_unreachable() {
+    // Key invariant: even with a dead DB, /health returns 200 instantly —
+    // that's the whole point of splitting it from readiness.
+    let pool = PgPool::connect_lazy("postgresql://corewar:bogus@127.0.0.1:1/corewar").unwrap();
+
+    let response = app(pool)
+        .oneshot(Request::get("/health").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
 }

--- a/backend/tests/warriors_integration.rs
+++ b/backend/tests/warriors_integration.rs
@@ -136,7 +136,7 @@ async fn register_and_login(router: &Router) -> String {
         router.clone(),
         post_json(
             "/api/auth/register",
-            &json!({"username": "testuser", "email": "test@example.com", "password": "password123"}),
+            &json!({"username": "testuser", "email": "test@example.com", "password": "password1234"}),
         ),
     )
     .await;
@@ -145,7 +145,7 @@ async fn register_and_login(router: &Router) -> String {
         router.clone(),
         post_json(
             "/api/auth/login",
-            &json!({"username_or_email": "testuser", "password": "password123"}),
+            &json!({"username_or_email": "testuser", "password": "password1234"}),
         ),
     )
     .await;
@@ -158,7 +158,7 @@ async fn register_and_login_as(router: &Router, username: &str, email: &str) -> 
         router.clone(),
         post_json(
             "/api/auth/register",
-            &json!({"username": username, "email": email, "password": "password123"}),
+            &json!({"username": username, "email": email, "password": "password1234"}),
         ),
     )
     .await;
@@ -167,7 +167,7 @@ async fn register_and_login_as(router: &Router, username: &str, email: &str) -> 
         router.clone(),
         post_json(
             "/api/auth/login",
-            &json!({"username_or_email": username, "password": "password123"}),
+            &json!({"username_or_email": username, "password": "password1234"}),
         ),
     )
     .await;

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -286,11 +286,21 @@ droplet — the build is CPU-bound on cargo) and bring the stack up.
 ## 8. Verify TLS
 
 ```bash
+# Cheap liveness probe — public, no DB work.
 curl -i https://api.corewar.coltcampbell.dev/health
+
+# Deep readiness probe — DB-probing, used by the container HEALTHCHECK.
+curl -i https://api.corewar.coltcampbell.dev/health/deep
 ```
 
 The first request can take **30+ seconds** while Caddy negotiates the
-Let's Encrypt cert. Expected response:
+Let's Encrypt cert. Expected responses:
+
+```
+HTTP/2 200
+content-type: application/json
+{"status":"ok"}
+```
 
 ```
 HTTP/2 200
@@ -298,9 +308,11 @@ content-type: application/json
 {"status":"ok","database":"ok"}
 ```
 
-(Older deploys returned just `{"status":"ok"}` — `/health` now also probes
-Postgres via a 2s-timeout `SELECT 1` and returns HTTP 503 if the DB is
-unreachable.)
+`/health` always returns 200 if the process is listening; it does no DB
+work, so it can't be used to amplify load against Postgres. `/health/deep`
+runs a 2s-timeout `SELECT 1` and returns HTTP 503 if the DB is
+unreachable — Docker's HEALTHCHECK uses it so a downstream outage marks
+the container unhealthy.
 
 If the cert handshake fails:
 
@@ -309,7 +321,7 @@ If the cert handshake fails:
   HTTP-01 challenge uses it). `sudo ufw status` should show 80/tcp ALLOW.
 - Inspect Caddy's logs: `docker compose -f docker-compose.prod.yml logs caddy`.
 
-If `/health` returns 503 with `"database":"fail"`, the backend booted but
+If `/health/deep` returns 503 with `"database":"fail"`, the backend booted but
 can't talk to Postgres. Tail the backend logs to see the exact error:
 
 ```bash
@@ -414,21 +426,24 @@ merge).
 
 ## 11. Uptime monitoring
 
-External monitor pinging `/health` so you find out about an outage from
+External monitor pinging the backend so you find out about an outage from
 a notification, not from a friend trying to use the site. **UptimeRobot**
-has the longest-running free tier and is what we'll wire up:
+has the longest-running free tier and is what we'll wire up. Use
+`/health/deep` so the monitor catches DB outages, not just process
+liveness:
 
 1. Sign up at [uptimerobot.com](https://uptimerobot.com) — free, no card.
 2. **+ New Monitor**:
    - Type: HTTPS
    - Friendly name: `Core War backend`
-   - URL: `https://api.corewar.coltcampbell.dev/health`
+   - URL: `https://api.corewar.coltcampbell.dev/health/deep`
    - Monitoring interval: 5 minutes (free-tier minimum)
 3. **Alert contacts**: at least email. Optional: Slack, Telegram, webhooks.
 4. **Advanced** (optional but recommended):
    - **Keyword monitoring**: also check the response body for the string
-     `"status":"ok"`. Catches the case where `/health` returns 503 with
-     `"status":"degraded"` (DB unreachable) but the TLS/proxy layer is fine.
+     `"database":"ok"`. Catches the case where `/health/deep` returns 503
+     with `"status":"degraded"` (DB unreachable) but the TLS/proxy layer
+     is fine.
 
 The same pattern will work for the frontend once Cloudflare Pages is up
 — add a second monitor for `https://corewar.coltcampbell.dev`.
@@ -438,10 +453,12 @@ The same pattern will work for the frontend once Cloudflare Pages is up
 - **Database backups.** Volumes survive `down`, but the droplet does not.
   A future PR will add either DO managed snapshots ($1.20/mo) or a
   `pg_dump`-to-Backblaze-B2 cron job.
-- **Redis check in `/health`.** Currently only Postgres is probed. Adding
-  Redis means restructuring `AppState`; tracked as a follow-up.
+- **Redis check in `/health/deep`.** Currently only Postgres is probed.
+  Adding Redis means restructuring `AppState`; tracked as a follow-up.
 - **Migrations as an explicit deploy step.** The backend currently runs
   `sqlx::migrate!()` at startup; migration failures surface as backend
   startup errors in `docker compose logs backend` and the CI deploy job's
   60s health-check loop catches them. Splitting into a separate
   pre-startup step is a nice-to-have, not a blocker.
+
+We should probably have a way to back up the latest image and test and tag an image as "good" and keep at least the last good image without overwriting it. Ideally though, I think we should keep as many images we build as we can that go through successfully, may recquire versioning the images and keeping "latest" as a sort of duplicate or alias of the most recent version of image. 


### PR DESCRIPTION
## Summary

Closes #68. Post-Phase-1 hardening sweep — six low-cost backend/edge changes that close real gaps before public traffic ramps up on `corewar.coltcampbell.dev`.

- **JWT pinned to HS256.** `Validation::new(Algorithm::HS256)` replaces `Validation::default()` so a future dep update can't silently widen the accepted algorithm set. Test added: an HS384-signed token is rejected.
- **Password policy 8 → 12 chars + reject pure-numeric.** Updated `validate_password` and the unit + integration test fixtures.
- **Login timing equalized.** On user-not-found, login now verifies the submitted password against a stable Argon2 dummy hash so wall-clock matches the wrong-password path. The dummy hash is `OnceLock<String>`-backed and `warm_dummy_hash()` is called at startup so the first request doesn't pay cold-init.
- **128 KB request body cap** via `axum::extract::DefaultBodyLimit`. Default is 2 MB; legitimate JSON bodies top out around 64 KB (warrior source).
- **`/health` split into liveness + readiness.** Public `/health` is now a no-DB 200 OK; `/health/deep` keeps the existing DB-probe logic. Docker `HEALTHCHECK` and the UptimeRobot monitor (per `deploy/README.md`) now target `/health/deep` with a `"database":"ok"` keyword check.
- **Caddy security headers.** HSTS (1y + includeSubDomains, **no `preload`** — intentionally omitted so we can revert without users being locked out by a browser's preload list; comment in `Caddyfile` documents the decision), `X-Content-Type-Options nosniff`, `X-Frame-Options DENY`, `Referrer-Policy strict-origin-when-cross-origin`, `Permissions-Policy geolocation=(), microphone=(), camera=()`, and `-Server`.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` in `backend/` — 157 tests pass (with Postgres + Redis up via `docker compose`)
- [x] After deploy: `curl -I https://api.corewar.coltcampbell.dev/health` shows the new HSTS / XFO / XCTO / Referrer-Policy / Permissions-Policy headers and no `Server: ...`
- [x] After deploy: `/health` returns `{"status":"ok"}` instantly (no DB); `/health/deep` returns the existing payload with `"database":"ok"`
- [x] After deploy: POST with a 200 KB JSON body returns 413
- [ ] After deploy: login wall-clock for `valid-user + wrong-password` ≈ `nonexistent-user + any-password` (within ~10 ms)

Part of the Phase-1 hardening sweep (#68 / #69 / #70).

🤖 Generated with [Claude Code](https://claude.com/claude-code)