### PR TITLE
Deploy: force-recreate caddy so Caddyfile changes actually land

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -130,6 +130,15 @@ jobs:
           echo "==> Restarting stack"
           docker compose -f docker-compose.prod.yml --env-file .env.production up -d --remove-orphans
 
+          # Caddyfile is a single-file bind mount. rsync replaces the host
+          # file via write-new + rename, which leaves the running container
+          # pointed at the original inode and blind to config changes. Force
+          # caddy to be recreated so its bind mount re-resolves to the new
+          # file. ~1s bounce, no data loss (caddy_data + caddy_config are
+          # named volumes that survive container recreation).
+          echo "==> Recreating caddy to refresh single-file bind mount"
+          docker compose -f docker-compose.prod.yml --env-file .env.production up -d --force-recreate caddy
+
           echo "==> Waiting up to 60s for backend to be healthy"
           end=$((SECONDS + 60))
           while [[ $SECONDS -lt $end ]]; do


### PR DESCRIPTION
## Summary

Follow-up to #71. The security headers shipped in that PR didn't appear on the deployed site until we manually recreated the caddy container. Root cause: the deploy workflow's `up -d --remove-orphans` doesn't recreate caddy when only its bind-mounted `Caddyfile` has changed, and Docker single-file bind mounts pin to inodes — so rsync's write-new + rename pattern leaves the running container looking at the original (pre-merge) inode. `caddy reload` then no-ops because the in-container view of the file matches its in-memory config (`"config is unchanged"`).

Fix: add `docker compose ... up -d --force-recreate caddy` immediately after the regular stack up. ~1s of Caddy downtime per deploy, no data loss (caddy_data / caddy_config are named volumes so the Let's Encrypt cert survives).

## Why force-recreate every deploy instead of detecting Caddyfile changes

Detecting which files actually changed would mean parsing rsync's `--itemize-changes` output and conditionally branching the script. That's more surface area for a 1-second saving. The unconditional recreate is simpler and bulletproof.

## Test plan

- [x] Workflow runs to completion on this PR's no-op deploy (the workflow itself only triggers on changes to `.github/workflows/deploy-backend.yml`, which this PR is — so the workflow will redeploy and exercise the new step).
- [x] After merge, headers still present: `curl -sI https://api.corewar.coltcampbell.dev/health` shows HSTS / XCTO / XFO / Referrer-Policy / Permissions-Policy.
- [x] Caddy logs show a fresh container start at deploy time, not just a reload.

Closes the operational follow-up tracked from #71's debugging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)