### PR TITLE
Wire Elo ratings into matchmaking + stop the runaway step loop

### DIFF
--- a/backend/src/matches/handlers.rs
+++ b/backend/src/matches/handlers.rs
@@ -47,7 +47,13 @@ fn run_battle(red_source: &str, blue_source: &str) -> Result<(String, i32), AppE
     m.load_warrior(0, &red, 0);
     m.load_warrior(1, &blue, CORE_SIZE / 2);
 
-    while m.step() {}
+    // Issue #87: engine's step() keeps running the survivor after a Victory,
+    // so this loop would otherwise always pin steps_taken at MAX_STEPS.
+    while m.step() {
+        if !matches!(m.result(), MatchResult::Ongoing) {
+            break;
+        }
+    }
 
     let result_str = match m.result() {
         MatchResult::Victory { winner_id: 0 } => "red_win",
@@ -184,15 +190,21 @@ mod tests {
     }
 
     #[test]
-    fn run_battle_completes_with_valid_result() {
+    fn run_battle_decisive_match_stops_short_of_max_steps() {
+        // Issue #87: without the non-Ongoing short-circuit this test would
+        // silently pass at steps == MAX_STEPS because the engine keeps
+        // stepping the survivor. Use Dwarf-vs-mice-lite (rather than
+        // Dwarf-vs-Imp, which is deceptively a tie at 8000/80k) so the
+        // decision reliably lands well before MAX_STEPS and any regression
+        // that lets the loop continue past Victory fails loudly here.
         let dwarf = ";name Dwarf\n  ORG start\nstart ADD.AB #4, bomb\n  MOV.I bomb, @bomb\n  JMP start\nbomb DAT.F #0, #0";
-        let imp = "MOV.I $0, $1";
-        let (result, steps) = run_battle(dwarf, imp).unwrap();
+        let mice_lite = ";name Mice-Lite\n        ORG    loop\ncounter DAT.F  #0, #3\ndest    DAT.F  #0, #8\nimp     MOV.I  $0, $1\nloop    MOV.I  imp, <dest\n        DJN.B  loop, counter\nlanding DAT.F  #0, #0\n        END";
+        let (result, steps) = run_battle(dwarf, mice_lite).unwrap();
+        assert_eq!(result, "red_win");
         assert!(
-            ["red_win", "blue_win", "tie", "all_dead"].contains(&result.as_str()),
-            "unexpected result: {result}"
+            steps < 50,
+            "mice-lite self-terminates quickly; got {steps} steps"
         );
-        assert!(steps > 0);
     }
 
     #[test]

--- a/backend/src/matchmaking/events.rs
+++ b/backend/src/matchmaking/events.rs
@@ -1,8 +1,9 @@
 use crate::auth::socket::{get_auth, require_auth};
 use crate::matchmaking::queue::{QueueEntry, RedisQueue};
+use crate::matchmaking::runner::execute_and_persist_match;
 use crate::models::warrior::Warrior;
 use chrono::Utc;
-use core_war_engine::{parse_warrior, MatchResult, MatchState};
+use core_war_engine::parse_warrior;
 use serde::{Deserialize, Serialize};
 use socketioxide::extract::{Data, SocketRef};
 use socketioxide::{socket::Sid, SocketIo};
@@ -300,43 +301,28 @@ async fn run_matched_battle(io: SocketIo, db: PgPool, red: QueueEntry, blue: Que
 
     let _ = io.to(room.clone()).emit("match:found", &found_event);
 
-    let red_source_for_battle = red_source.clone();
-    let blue_source_for_battle = blue_source.clone();
-    let battle_result = tokio::task::spawn_blocking(move || {
-        let red_parsed =
-            parse_warrior(&red_source_for_battle).map_err(|e| format!("Red parse: {e}"))?;
-        let blue_parsed =
-            parse_warrior(&blue_source_for_battle).map_err(|e| format!("Blue parse: {e}"))?;
-
-        let mut m = MatchState::new(CORE_SIZE, MAX_STEPS);
-        m.load_warrior(0, &red_parsed, RED_START);
-        m.load_warrior(1, &blue_parsed, BLUE_START);
-
-        while m.step() {}
-
-        let result_str = match m.result() {
-            MatchResult::Victory { winner_id: 0 } => "red_win",
-            MatchResult::Victory { .. } => "blue_win",
-            MatchResult::Tie => "tie",
-            MatchResult::AllDead => "all_dead",
-            MatchResult::Ongoing => unreachable!(),
-        };
-
-        Ok::<_, String>((result_str.to_string(), m.steps()))
-    })
-    .await;
-
-    let (result_str, steps_taken) = match battle_result {
-        Ok(Ok(r)) => r,
-        Ok(Err(e)) => {
-            error!("Battle error: {e}");
-            return;
-        }
+    let outcome = match execute_and_persist_match(
+        &db,
+        red.user_id,
+        blue.user_id,
+        red.warrior_id,
+        blue.warrior_id,
+        &red_source,
+        &blue_source,
+        CORE_SIZE,
+        MAX_STEPS,
+    )
+    .await
+    {
+        Ok(o) => o,
         Err(e) => {
-            error!("Battle task panic: {e}");
+            error!("Failed to execute+persist match: {e}");
             return;
         }
     };
+
+    let result_str = outcome.result.clone();
+    let steps_taken = outcome.steps_taken as u64;
 
     // Emit the full replay payload. Clients use playback_start_time_ms to
     // pace the local wasm replay deterministically; match:result follows
@@ -372,25 +358,15 @@ async fn run_matched_battle(io: SocketIo, db: PgPool, red: QueueEntry, blue: Que
 
     let _ = io.to(room).emit("match:result", &result_event);
 
-    let _ = sqlx::query(
-        "INSERT INTO matches \
-           (red_warrior_id, blue_warrior_id, red_user_id, blue_user_id, \
-            core_size, max_steps, result, steps_taken) \
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
-    )
-    .bind(red.warrior_id)
-    .bind(blue.warrior_id)
-    .bind(red.user_id)
-    .bind(blue.user_id)
-    .bind(CORE_SIZE as i32)
-    .bind(MAX_STEPS as i32)
-    .bind(&result_str)
-    .bind(steps_taken as i32)
-    .execute(&db)
-    .await;
-
     info!(
-        "match complete: {} vs {} -> {} ({} steps)",
-        red.username, blue.username, result_str, steps_taken
+        "match complete: {} vs {} -> {} ({} steps) — rating: red {}->{}, blue {}->{}",
+        red.username,
+        blue.username,
+        result_str,
+        steps_taken,
+        outcome.red_rating_before,
+        outcome.red_rating_after,
+        outcome.blue_rating_before,
+        outcome.blue_rating_after,
     );
 }

--- a/backend/src/matchmaking/mod.rs
+++ b/backend/src/matchmaking/mod.rs
@@ -1,2 +1,3 @@
 pub mod events;
 pub mod queue;
+pub mod runner;

--- a/backend/src/matchmaking/runner.rs
+++ b/backend/src/matchmaking/runner.rs
@@ -1,0 +1,207 @@
+use crate::leaderboard::elo::{rating_change, tie_change};
+use core_war_engine::{parse_warrior, MatchResult, MatchState};
+use sqlx::PgPool;
+use std::fmt;
+use uuid::Uuid;
+
+/// Everything the caller needs to render the result screen: canonical outcome
+/// plus each side's rating before and after the match. Returned by
+/// [`execute_and_persist_match`] once the transaction has committed, so an `Ok`
+/// value implies both the match row and both rating updates are durable.
+#[derive(Debug, Clone)]
+pub struct MatchOutcome {
+    pub match_id: Uuid,
+    pub result: String,
+    pub steps_taken: i32,
+    pub red_rating_before: i32,
+    pub red_rating_after: i32,
+    pub blue_rating_before: i32,
+    pub blue_rating_after: i32,
+}
+
+#[derive(Debug)]
+pub enum MatchExecuteError {
+    ParseRed(String),
+    ParseBlue(String),
+    Db(sqlx::Error),
+    Panic(String),
+}
+
+impl fmt::Display for MatchExecuteError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ParseRed(e) => write!(f, "Red warrior parse error: {e}"),
+            Self::ParseBlue(e) => write!(f, "Blue warrior parse error: {e}"),
+            Self::Db(e) => write!(f, "DB error: {e}"),
+            Self::Panic(e) => write!(f, "Battle task panic: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for MatchExecuteError {}
+
+impl From<sqlx::Error> for MatchExecuteError {
+    fn from(err: sqlx::Error) -> Self {
+        Self::Db(err)
+    }
+}
+
+/// Runs a battle to completion and persists the outcome plus rating changes.
+///
+/// The match row insert and both `users.rating` updates happen inside a single
+/// Postgres transaction — either all three land or none do, so a caller that
+/// sees `Ok(_)` knows the leaderboard and the match history agree.
+///
+/// `all_dead` (mutual destruction) is treated the same as `tie` for rating
+/// purposes — neither warrior outplayed the other, so the shift is toward the
+/// lower-rated player rather than either being credited with a win.
+#[allow(clippy::too_many_arguments)]
+pub async fn execute_and_persist_match(
+    db: &PgPool,
+    red_user_id: Uuid,
+    blue_user_id: Uuid,
+    red_warrior_id: Uuid,
+    blue_warrior_id: Uuid,
+    red_source: &str,
+    blue_source: &str,
+    core_size: usize,
+    max_steps: u64,
+) -> Result<MatchOutcome, MatchExecuteError> {
+    let red_src = red_source.to_owned();
+    let blue_src = blue_source.to_owned();
+    let (result_str, steps_taken) =
+        tokio::task::spawn_blocking(move || run_battle(&red_src, &blue_src, core_size, max_steps))
+            .await
+            .map_err(|e| MatchExecuteError::Panic(e.to_string()))??;
+
+    let mut tx = db.begin().await?;
+
+    let red_rating_before: i32 = sqlx::query_scalar("SELECT rating FROM users WHERE id = $1")
+        .bind(red_user_id)
+        .fetch_one(&mut *tx)
+        .await?;
+    let blue_rating_before: i32 = sqlx::query_scalar("SELECT rating FROM users WHERE id = $1")
+        .bind(blue_user_id)
+        .fetch_one(&mut *tx)
+        .await?;
+
+    let (red_rating_after, blue_rating_after) = match result_str.as_str() {
+        "red_win" => rating_change(red_rating_before, blue_rating_before),
+        "blue_win" => {
+            // rating_change returns (winner, loser); remap so the tuple stays (red, blue).
+            let (new_blue, new_red) = rating_change(blue_rating_before, red_rating_before);
+            (new_red, new_blue)
+        }
+        "tie" | "all_dead" => tie_change(red_rating_before, blue_rating_before),
+        other => unreachable!("battle produced unexpected result string: {other}"),
+    };
+
+    let match_id: Uuid = sqlx::query_scalar(
+        "INSERT INTO matches \
+           (red_warrior_id, blue_warrior_id, red_user_id, blue_user_id, \
+            core_size, max_steps, result, steps_taken) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8) \
+         RETURNING id",
+    )
+    .bind(red_warrior_id)
+    .bind(blue_warrior_id)
+    .bind(red_user_id)
+    .bind(blue_user_id)
+    .bind(core_size as i32)
+    .bind(max_steps as i32)
+    .bind(&result_str)
+    .bind(steps_taken)
+    .fetch_one(&mut *tx)
+    .await?;
+
+    sqlx::query("UPDATE users SET rating = $1 WHERE id = $2")
+        .bind(red_rating_after)
+        .bind(red_user_id)
+        .execute(&mut *tx)
+        .await?;
+    sqlx::query("UPDATE users SET rating = $1 WHERE id = $2")
+        .bind(blue_rating_after)
+        .bind(blue_user_id)
+        .execute(&mut *tx)
+        .await?;
+
+    tx.commit().await?;
+
+    Ok(MatchOutcome {
+        match_id,
+        result: result_str,
+        steps_taken,
+        red_rating_before,
+        red_rating_after,
+        blue_rating_before,
+        blue_rating_after,
+    })
+}
+
+fn run_battle(
+    red_source: &str,
+    blue_source: &str,
+    core_size: usize,
+    max_steps: u64,
+) -> Result<(String, i32), MatchExecuteError> {
+    let red = parse_warrior(red_source).map_err(|e| MatchExecuteError::ParseRed(e.to_string()))?;
+    let blue =
+        parse_warrior(blue_source).map_err(|e| MatchExecuteError::ParseBlue(e.to_string()))?;
+
+    let mut m = MatchState::new(core_size, max_steps);
+    m.load_warrior(0, &red, 0);
+    m.load_warrior(1, &blue, core_size / 2);
+
+    // Issue #87: the engine's `step()` keeps executing the surviving warrior
+    // after a Victory is decided, so left uncapped this loop always runs to
+    // max_steps and pins `steps_taken` at MAX_STEPS. Stop as soon as the
+    // result is no longer Ongoing — a genuine tie still runs to the step
+    // limit because Imp-vs-Imp stays Ongoing until then.
+    while m.step() {
+        if !matches!(m.result(), MatchResult::Ongoing) {
+            break;
+        }
+    }
+
+    let result_str = match m.result() {
+        MatchResult::Victory { winner_id: 0 } => "red_win",
+        MatchResult::Victory { .. } => "blue_win",
+        MatchResult::Tie => "tie",
+        MatchResult::AllDead => "all_dead",
+        MatchResult::Ongoing => unreachable!("engine step returned false while Ongoing"),
+    };
+
+    Ok((result_str.to_string(), m.steps() as i32))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decisive_match_stops_short_of_max_steps() {
+        // Dwarf-vs-mice-lite (rather than Dwarf-vs-Imp) because Imp is fast
+        // enough at CORE_SIZE=8000 to dodge Dwarf's ~13k bombs across an
+        // 80k-step budget — the "canonical" pairing is deceptively a tie.
+        // Mice-Lite replicates for a few iterations, then falls through to
+        // its own DAT landing pad and dies — a reliably decisive match.
+        // Kept inline (rather than include_str! from engine/) so the runner
+        // unit tests stay self-contained inside this crate.
+        let dwarf = ";name Dwarf\n  ORG start\nstart ADD.AB #4, bomb\n  MOV.I bomb, @bomb\n  JMP start\nbomb DAT.F #0, #0";
+        let mice_lite = ";name Mice-Lite\n        ORG    loop\ncounter DAT.F  #0, #3\ndest    DAT.F  #0, #8\nimp     MOV.I  $0, $1\nloop    MOV.I  imp, <dest\n        DJN.B  loop, counter\nlanding DAT.F  #0, #0\n        END";
+        let (result, steps) = run_battle(dwarf, mice_lite, 8000, 80_000).unwrap();
+        assert_eq!(result, "red_win");
+        assert!(
+            steps < 50,
+            "mice-lite self-terminates quickly; got {steps} steps"
+        );
+    }
+
+    #[test]
+    fn imp_vs_imp_still_ties_at_max_steps() {
+        let imp = "MOV.I $0, $1";
+        let (result, steps) = run_battle(imp, imp, 8000, 80_000).unwrap();
+        assert_eq!(result, "tie");
+        assert_eq!(steps, 80_000);
+    }
+}

--- a/backend/tests/matchmaking_integration.rs
+++ b/backend/tests/matchmaking_integration.rs
@@ -1,0 +1,360 @@
+//! Integration tests for the matchmaking pipeline: covers the "battle runs,
+//! match row inserts, both users' ratings update — all atomically" contract
+//! that regressed as #87 (loop overrun) and #89 (rating updates never called).
+//!
+//! Each scenario walks the full flow through the extracted
+//! [`execute_and_persist_match`] against a real Postgres via `sqlx::test`.
+//! Fixtures (users + warriors) are seeded with plain SQL to keep the tests
+//! focused on the pipeline itself — the HTTP + Socket.IO layers already have
+//! their own coverage.
+
+use core_war_backend::matchmaking::runner::{
+    execute_and_persist_match, MatchExecuteError, MatchOutcome,
+};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+const IMP: &str = "MOV.I $0, $1";
+const DWARF: &str = include_str!("../../engine/tests/warriors/dwarf.red");
+// Mice-Lite is the shortest self-terminating curated warrior in the
+// preset library — it copies an imp template a few times, then dies in its
+// own landing DAT. Paired with Dwarf it produces a reliably decisive match
+// (Blue is dead after ~14 alternating steps → Victory{Red}) without
+// depending on any particular attacker beating any particular defender
+// within MAX_STEPS. Dwarf-vs-Imp at 8000/80k is actually a tie, so it can't
+// stand in for a decisive matchup.
+const MICE_LITE: &str = include_str!("../../engine/tests/warriors/mice_lite.red");
+
+const CORE_SIZE: usize = 8000;
+const MAX_STEPS: u64 = 80_000;
+
+// K_FACTOR is duplicated here (from backend/src/leaderboard/elo.rs) as a
+// deliberate test-side re-declaration: the expected-delta helper below is our
+// oracle for what the Elo math should produce, and mirroring the K factor
+// keeps the oracle self-contained. If the K factor changes, this test module
+// must be updated too — that's the intended coupling.
+const K_FACTOR: f64 = 32.0;
+
+fn expected_win_delta(winner: i32, loser: i32) -> i32 {
+    let expected = 1.0 / (1.0 + 10.0_f64.powf((loser - winner) as f64 / 400.0));
+    (K_FACTOR * (1.0 - expected)).round() as i32
+}
+
+fn expected_tie_delta_a(rating_a: i32, rating_b: i32) -> i32 {
+    let expected = 1.0 / (1.0 + 10.0_f64.powf((rating_b - rating_a) as f64 / 400.0));
+    (K_FACTOR * (0.5 - expected)).round() as i32
+}
+
+struct Seeded {
+    red_user: Uuid,
+    blue_user: Uuid,
+    red_warrior: Uuid,
+    blue_warrior: Uuid,
+}
+
+async fn seed_users_and_warriors(pool: &PgPool, red_source: &str, blue_source: &str) -> Seeded {
+    let red_user: Uuid = sqlx::query_scalar(
+        "INSERT INTO users (username, email, password_hash) \
+         VALUES ($1, $2, $3) RETURNING id",
+    )
+    .bind("red_player")
+    .bind("red@example.com")
+    .bind("$argon2id$v=19$m=19456,t=2,p=1$fake$fake")
+    .fetch_one(pool)
+    .await
+    .expect("insert red user");
+
+    let blue_user: Uuid = sqlx::query_scalar(
+        "INSERT INTO users (username, email, password_hash) \
+         VALUES ($1, $2, $3) RETURNING id",
+    )
+    .bind("blue_player")
+    .bind("blue@example.com")
+    .bind("$argon2id$v=19$m=19456,t=2,p=1$fake$fake")
+    .fetch_one(pool)
+    .await
+    .expect("insert blue user");
+
+    let red_warrior: Uuid = sqlx::query_scalar(
+        "INSERT INTO warriors (user_id, name, source) VALUES ($1, $2, $3) RETURNING id",
+    )
+    .bind(red_user)
+    .bind("Red Warrior")
+    .bind(red_source)
+    .fetch_one(pool)
+    .await
+    .expect("insert red warrior");
+
+    let blue_warrior: Uuid = sqlx::query_scalar(
+        "INSERT INTO warriors (user_id, name, source) VALUES ($1, $2, $3) RETURNING id",
+    )
+    .bind(blue_user)
+    .bind("Blue Warrior")
+    .bind(blue_source)
+    .fetch_one(pool)
+    .await
+    .expect("insert blue warrior");
+
+    Seeded {
+        red_user,
+        blue_user,
+        red_warrior,
+        blue_warrior,
+    }
+}
+
+async fn set_rating(pool: &PgPool, user_id: Uuid, rating: i32) {
+    sqlx::query("UPDATE users SET rating = $1 WHERE id = $2")
+        .bind(rating)
+        .bind(user_id)
+        .execute(pool)
+        .await
+        .expect("seed rating");
+}
+
+async fn current_rating(pool: &PgPool, user_id: Uuid) -> i32 {
+    sqlx::query_scalar("SELECT rating FROM users WHERE id = $1")
+        .bind(user_id)
+        .fetch_one(pool)
+        .await
+        .expect("read rating")
+}
+
+async fn match_row_count(pool: &PgPool) -> i64 {
+    sqlx::query_scalar("SELECT COUNT(*) FROM matches")
+        .fetch_one(pool)
+        .await
+        .expect("count matches")
+}
+
+async fn run(pool: &PgPool, s: &Seeded, red_src: &str, blue_src: &str) -> MatchOutcome {
+    execute_and_persist_match(
+        pool,
+        s.red_user,
+        s.blue_user,
+        s.red_warrior,
+        s.blue_warrior,
+        red_src,
+        blue_src,
+        CORE_SIZE,
+        MAX_STEPS,
+    )
+    .await
+    .expect("execute_and_persist_match")
+}
+
+// =============================================================================
+// Scenario 1 — decisive match, red wins early
+// =============================================================================
+
+#[sqlx::test]
+async fn decisive_match_red_win_updates_ratings(pool: PgPool) {
+    // Dwarf-vs-mice-lite (rather than Dwarf-vs-Imp) because Dwarf-vs-Imp at the
+    // production 8000/80k parameters is actually a tie — Imp is fast enough
+    // that Dwarf's ~13k bombs across an 80k-step match can miss it entirely.
+    // Mice-Lite replicates for a handful of iterations, then falls through
+    // to its own DAT landing pad and dies — a reliably decisive match.
+    let s = seed_users_and_warriors(&pool, DWARF, MICE_LITE).await;
+    let outcome = run(&pool, &s, DWARF, MICE_LITE).await;
+
+    assert_eq!(outcome.result, "red_win");
+    // Issue #87: loop must stop the moment the decision is made, not pin
+    // steps_taken at MAX_STEPS. Mice-Lite self-terminates in a handful of
+    // its own turns; with round-robin alternation that's well under 50 total
+    // steps — far below MAX_STEPS.
+    assert!(
+        outcome.steps_taken < 50,
+        "mice-lite self-terminates quickly; got {}",
+        outcome.steps_taken
+    );
+
+    // Both players started at the 1200 default.
+    assert_eq!(outcome.red_rating_before, 1200);
+    assert_eq!(outcome.blue_rating_before, 1200);
+
+    // Zero-sum against equal ratings.
+    let delta = expected_win_delta(1200, 1200);
+    assert_eq!(outcome.red_rating_after, 1200 + delta);
+    assert_eq!(outcome.blue_rating_after, 1200 - delta);
+    assert_eq!(
+        outcome.red_rating_after + outcome.blue_rating_after,
+        1200 + 1200,
+        "zero-sum invariant"
+    );
+
+    // The persisted state agrees with the returned outcome.
+    assert_eq!(
+        current_rating(&pool, s.red_user).await,
+        outcome.red_rating_after
+    );
+    assert_eq!(
+        current_rating(&pool, s.blue_user).await,
+        outcome.blue_rating_after
+    );
+    assert_eq!(match_row_count(&pool).await, 1);
+}
+
+// =============================================================================
+// Scenario 2 — decisive match, blue wins early (side-mapping regression guard)
+// =============================================================================
+
+#[sqlx::test]
+async fn decisive_match_blue_win_updates_ratings(pool: PgPool) {
+    // Same warriors, swapped sides. This is the case a broken winner/loser
+    // remap tuple would silently botch — the winner gets rating-lowering
+    // updates and the loser gets a boost. Assert the direction explicitly.
+    let s = seed_users_and_warriors(&pool, MICE_LITE, DWARF).await;
+    let outcome = run(&pool, &s, MICE_LITE, DWARF).await;
+
+    assert_eq!(outcome.result, "blue_win");
+    assert!(
+        outcome.steps_taken < 50,
+        "mice-lite self-terminates quickly; got {}",
+        outcome.steps_taken
+    );
+
+    let delta = expected_win_delta(1200, 1200);
+    assert_eq!(outcome.blue_rating_after, 1200 + delta);
+    assert_eq!(outcome.red_rating_after, 1200 - delta);
+    assert!(outcome.blue_rating_after > outcome.red_rating_after);
+
+    assert_eq!(
+        current_rating(&pool, s.red_user).await,
+        outcome.red_rating_after
+    );
+    assert_eq!(
+        current_rating(&pool, s.blue_user).await,
+        outcome.blue_rating_after
+    );
+}
+
+// =============================================================================
+// Scenario 3 — genuine tie at equal ratings
+// =============================================================================
+
+#[sqlx::test]
+async fn tie_at_equal_ratings_no_change(pool: PgPool) {
+    // Imp-vs-Imp is the canonical "runs to MAX_STEPS and ties" match — the
+    // case that distinguishes #87 ("stops too early") from the correct behavior
+    // ("only stops early when a Victory is decided").
+    let s = seed_users_and_warriors(&pool, IMP, IMP).await;
+    let outcome = run(&pool, &s, IMP, IMP).await;
+
+    assert_eq!(outcome.result, "tie");
+    assert_eq!(
+        outcome.steps_taken as u64, MAX_STEPS,
+        "a genuine tie should still run to MAX_STEPS"
+    );
+
+    // tie_change of equal ratings is a no-op.
+    assert_eq!(outcome.red_rating_after, 1200);
+    assert_eq!(outcome.blue_rating_after, 1200);
+    assert_eq!(current_rating(&pool, s.red_user).await, 1200);
+    assert_eq!(current_rating(&pool, s.blue_user).await, 1200);
+}
+
+// =============================================================================
+// Scenario 4 — tie at unequal ratings shifts toward the lower-rated player
+// =============================================================================
+
+#[sqlx::test]
+async fn tie_at_unequal_ratings_shifts_toward_lower(pool: PgPool) {
+    let s = seed_users_and_warriors(&pool, IMP, IMP).await;
+    set_rating(&pool, s.red_user, 1600).await;
+    set_rating(&pool, s.blue_user, 1200).await;
+
+    let outcome = run(&pool, &s, IMP, IMP).await;
+
+    assert_eq!(outcome.result, "tie");
+    assert_eq!(outcome.red_rating_before, 1600);
+    assert_eq!(outcome.blue_rating_before, 1200);
+
+    let delta_red = expected_tie_delta_a(1600, 1200);
+    assert!(
+        delta_red < 0,
+        "higher-rated player should lose points on a tie"
+    );
+    assert_eq!(outcome.red_rating_after, 1600 + delta_red);
+    assert_eq!(outcome.blue_rating_after, 1200 - delta_red);
+    assert!(outcome.red_rating_after < 1600);
+    assert!(outcome.blue_rating_after > 1200);
+    assert_eq!(
+        outcome.red_rating_after + outcome.blue_rating_after,
+        1600 + 1200,
+        "zero-sum invariant"
+    );
+}
+
+// =============================================================================
+// Scenario 5 — errored match (parse failure) leaves ratings and matches table alone
+// =============================================================================
+
+#[sqlx::test]
+async fn parse_error_no_side_effects(pool: PgPool) {
+    let s = seed_users_and_warriors(&pool, "TOTAL NONSENSE 1234", IMP).await;
+
+    let result = execute_and_persist_match(
+        &pool,
+        s.red_user,
+        s.blue_user,
+        s.red_warrior,
+        s.blue_warrior,
+        "TOTAL NONSENSE 1234",
+        IMP,
+        CORE_SIZE,
+        MAX_STEPS,
+    )
+    .await;
+
+    match result {
+        Err(MatchExecuteError::ParseRed(_)) => {}
+        Err(e) => panic!("expected ParseRed, got {e:?}"),
+        Ok(o) => panic!("expected parse error, got Ok({o:?})"),
+    }
+
+    assert_eq!(
+        match_row_count(&pool).await,
+        0,
+        "no match row on parse error"
+    );
+    assert_eq!(current_rating(&pool, s.red_user).await, 1200);
+    assert_eq!(current_rating(&pool, s.blue_user).await, 1200);
+}
+
+// =============================================================================
+// Atomicity invariant — either both (match row inserted, ratings updated) or
+// neither. Cross-checks against every scenario above: after a successful call
+// the ratings AND the match count MUST agree, and after a failure BOTH must
+// be untouched. This is what a broken `execute_and_persist_match` that
+// commits the match row before updating ratings would fail.
+// =============================================================================
+
+#[sqlx::test]
+async fn atomicity_on_success(pool: PgPool) {
+    let s = seed_users_and_warriors(&pool, DWARF, MICE_LITE).await;
+    let outcome = run(&pool, &s, DWARF, MICE_LITE).await;
+
+    // Both writes present.
+    assert_eq!(match_row_count(&pool).await, 1);
+    assert_ne!(current_rating(&pool, s.red_user).await, 1200);
+    assert_ne!(current_rating(&pool, s.blue_user).await, 1200);
+
+    // And they agree.
+    assert_eq!(
+        current_rating(&pool, s.red_user).await,
+        outcome.red_rating_after
+    );
+    assert_eq!(
+        current_rating(&pool, s.blue_user).await,
+        outcome.blue_rating_after
+    );
+}
+
+// Note on the `all_dead` outcome: with the #87 short-circuit fix in place,
+// AllDead is effectively unreachable in a two-warrior match. `step()` is
+// round-robin per warrior, so if warrior A dies on turn N the runner breaks
+// at that step (result() reports Victory{B}) before B could also die on
+// turn N+1. The MatchExecuteError code path still maps AllDead → tie_change
+// as a correctness safety net (documented in runner.rs), and if the engine
+// ever grows a simultaneous-death primitive this file should grow a scenario
+// asserting the tie-rating semantics for it.

--- a/engine/tests/canonical_warriors.rs
+++ b/engine/tests/canonical_warriors.rs
@@ -163,32 +163,35 @@ fn parsed_scanner_finds_and_bombs_planted_marker() {
 }
 
 #[test]
-fn parsed_dwarf_outlasts_passive_dat_warrior_in_two_warrior_match() {
+fn parsed_dwarf_outlasts_mice_lite_in_two_warrior_match() {
     // This test exercises multi-warrior loading via the public API: two
     // separate parsed warriors loaded into different regions of the same
     // core, executing in round-robin alternation, with the dead-warrior
     // skip path kicking in after warrior 1 dies.
     let dwarf = parse_warrior(DWARF).expect("dwarf.red should parse");
 
-    // A deliberately suicidal warrior: a single DAT cell. The first time
-    // its process executes, it dies. (Parsed via the same public API, just
-    // from an inline source string instead of an .red file.)
-    let suicide = parse_warrior("DAT.F #0, #0").expect("suicide warrior should parse");
+    // Mice-Lite self-terminates after replicating three copies of the imp
+    // template — it walks its DJN counter down to zero and then falls
+    // through to its own DAT landing pad. Under round-robin alternation
+    // that death lands around total step 14 (7 blue turns × 2 for alternation),
+    // well within the step budget below.
+    let mice_lite = parse_warrior(MICE_LITE).expect("mice_lite.red should parse");
 
     let mut state = MatchState::new(64, 50);
     state.load_warrior(0, &dwarf, 0);
-    state.load_warrior(1, &suicide, 32);
+    state.load_warrior(1, &mice_lite, 32);
 
-    // Run several steps. The suicide warrior dies on its first turn
-    // (step 2); the dwarf is then the unique survivor and wins.
-    for _ in 0..10 {
+    // 20 steps is more than enough for mice-lite to hit its landing pad
+    // (~step 14) and for the dead-warrior skip path to leave the dwarf as
+    // the sole survivor.
+    for _ in 0..20 {
         state.step();
     }
 
     assert_eq!(
         state.result(),
         MatchResult::Victory { winner_id: 0 },
-        "dwarf should win against a passive DAT warrior",
+        "dwarf should win against a self-terminating mice-lite",
     );
 }
 


### PR DESCRIPTION
## Summary

Three tightly-linked defects in the matchmaking pipeline, bundled because they were all rooted in the same "built in pieces, tested in pieces, never asserted as a system" gap:

- **#89** — `leaderboard::elo` had six unit tests but zero callers in production. `users.rating` never moved after any match, and the only detector was a human eyeballing the leaderboard.
- **#87** — the battle loop (`while m.step() {}`) kept stepping the survivor after a Victory, pinning `steps_taken` at `MAX_STEPS` and dragging the client replay through ~80k empty steps past the decision.
- **#90** — no backend integration test walked the full matchmaking flow, so either defect would have been caught only by manual smoke testing.

## Changes

**New `backend/src/matchmaking/runner.rs`** — extracts `execute_and_persist_match` as a testable async fn that:
- Runs the battle with the #87 short-circuit (`if !matches!(m.result(), Ongoing) { break; }`).
- Does the match INSERT + both `users.rating` UPDATEs inside a single Postgres transaction (atomicity — either all three land or none).
- Maps `all_dead` → `tie_change` (documented; effectively unreachable in two-warrior matches under the #87 fix, kept as a correctness safety net).
- Returns a `MatchOutcome` struct with before/after ratings for both players so callers can render rating deltas without a second query.

**`backend/src/matchmaking/events.rs`** — `run_matched_battle` now delegates the battle + persist + rating step to the runner, and just handles Socket.IO emit + logging.

**`backend/src/matches/handlers.rs`** — same short-circuit applied to the HTTP `/api/matches` submit path. No rating updates on that path (#89 explicitly called it out as sandbox/dev-only and there's no frontend caller). Its unit test tightened from `assert!(steps > 0)` to a real upper bound (`< 50`) using Dwarf-vs-mice-lite so a #87 regression fails loudly instead of silently at 80,000.

**`engine/tests/canonical_warriors.rs`** — switched `parsed_dwarf_outlasts_passive_dat_warrior_in_two_warrior_match` to use the existing `MICE_LITE` fixture instead of an ad-hoc `"DAT.F #0, #0"` — consistent with how other engine tests source their warriors, and reused the same self-terminating pattern we settled on for the backend tests.

**New `backend/tests/matchmaking_integration.rs`** — six `#[sqlx::test]` scenarios against real Postgres:
1. Decisive `red_win` — rating deltas match `rating_change(1200, 1200)`, zero-sum, DB agrees with the returned outcome.
2. Decisive `blue_win` (same warriors, swapped sides) — regression guard for the winner/loser tuple remap.
3. Tie at equal ratings — Imp-vs-Imp still runs to MAX_STEPS, ratings unchanged.
4. Tie at unequal ratings — seed red=1600, blue=1200, verify the shift toward the lower-rated player.
5. Parse-error path — errored match leaves both `matches` table and `users.rating` untouched.
6. Atomicity invariant — after a successful call, both the match row and both rating updates are present and agree with the returned outcome.

## Note on Dwarf-vs-Imp

The issue #90 acceptance criteria assumed Dwarf-vs-Imp at 8000/80k is decisive. It's actually a tie — Imp is fast enough to dodge Dwarf's ~13k bombs across the step budget. Switched the decisive scenarios to Dwarf-vs-mice-lite (mice-lite self-terminates on its own landing DAT after replicating three copies), which is what the frontend preset library already uses for the same "runs briefly then dies" role. Documented in the tests so future readers don't spend an hour tracing the "why isn't Dwarf winning" thread.

## Test plan

- [x] `cargo fmt --check` — clean on backend + engine.
- [x] `cargo clippy --all-targets -- -D warnings` — clean on backend + engine.
- [x] `cargo test` — backend 65 tests pass (22 auth + 4 health + 6 new matchmaking + 20 warriors + 113 lib unit — the lib count includes the module unit tests). Engine 135 tests pass (124 unit + 11 integration).
- [x] End-to-end verified with Playwright + `bot-blue.mjs` against the running backend:
  - `steps_taken: 14` (was 80,000 pre-fix).
  - Match viewer shows **"Defeat / 14 steps"** to the losing side.
  - Leaderboard shows 🥇 _test_blue at **1216** and 🥈 _test_red at **1184** — exactly the K=32×(1-E)=16 delta at equal starting ratings, zero-sum invariant holds.
  - `SELECT rating FROM users` and `SELECT * FROM matches` agree with the on-screen values.

Closes #87
Closes #89
Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)