### PR TITLE
Bump undici 7.25.0 → 7.28.0 to close 7 high-severity CVEs

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5087,9 +5087,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Summary

`npm audit` on master has been failing CI on 7 high-severity advisories against undici 7.25.0 (vulnerable range 7.0.0 – 7.27.2), pulled in transitively as `jsdom → undici` for the Vitest test environment.

| Advisory | Impact |
|---|---|
| GHSA-vmh5-mc38-953g | TLS cert validation bypass in SOCKS5 ProxyAgent |
| GHSA-p88m-4jfj-68fv | HTTP header injection via Set-Cookie percent-decoding |
| GHSA-vxpw-j846-p89q | WebSocket DoS via fragment count bypass |
| GHSA-hm92-r4w5-c3mj | Cross-origin request routing via SOCKS5 proxy pool reuse |
| GHSA-35p6-xmwp-9g52 | HTTP response queue poisoning via keep-alive socket reuse |
| GHSA-g8m3-5g58-fq7m | Set-Cookie SameSite downgrade via permissive substring match |
| GHSA-pr7r-676h-xcf6 | Cross-user info disclosure via shared cache whitespace bypass |

jsdom 29.0.2 declares `undici: ^7.24.5`, so 7.28.0 (the first patched release) is a lockfile-only bump — no `package.json` change, no other packages moved. 3 lines in `package-lock.json`.

## Blast radius

`jsdom` in this repo is used only by Vitest for the DOM environment — undici doesn't reach production bundles. Fixing anyway so:

1. CI's `Supply-chain audit (cargo + npm)` step stops failing every PR.
2. `npm ci` in dev environments doesn't ship a known-vulnerable transitive.

Both currently-open PRs (#91, #92) are blocked by this on master; both will pass audit after they rebase against this fix.

## Test plan

- [x] `cargo audit` in `engine/` — pass.
- [x] `cargo audit --ignore RUSTSEC-2023-0071` in `backend/` — pass (same ignore CI uses, unchanged by this PR).
- [x] `npm audit --audit-level=high` in `frontend/` — pass (0 vulnerabilities after fix).
- [x] `npm run lint` — clean (1 pre-existing `react-refresh/only-export-components` warning in `AuthContext.tsx`, unrelated to this change).
- [x] `npm test` — 56 tests pass in 1.12s.
- [x] `npm run build` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)