### PR TITLE
Backend image versioning + race-immune concurrent deploys + retention (#78)

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -34,11 +34,24 @@ jobs:
   build:
     name: Build (and push on master) backend image
     runs-on: ubuntu-latest
+    # Only one build can be in flight per ref. On a burst of master
+    # merges, older builds are canceled and only the tip actually gets
+    # built + pushed — no `:latest` race between concurrent finish
+    # times, and only one deploy queues downstream. Same-branch PR
+    # pushes get the same treatment (older CI is canceled when a new
+    # commit lands). See issue #78.
+    concurrency:
+      group: deploy-backend-build-${{ github.ref }}
+      cancel-in-progress: true
     permissions:
       contents: read
       packages: write
     outputs:
       image: ${{ steps.image.outputs.ref }}
+      # The exact SHA-pinned tag this build pushed, consumed by the
+      # deploy job so it's bound to THIS run's commit rather than
+      # racing for whatever `:latest` happens to point at.
+      tag: ${{ steps.image_tag.outputs.tag }}
     steps:
       - uses: actions/checkout@v4
 
@@ -47,6 +60,16 @@ jobs:
         run: |
           OWNER_LC=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
           echo "ref=${REGISTRY}/${OWNER_LC}/core-war-backend" >> "$GITHUB_OUTPUT"
+
+      - name: Compute immutable image tag
+        id: image_tag
+        # Matches the SHA tag docker/metadata-action produces below
+        # (`type=sha,prefix=master-` → default 7-char short SHA). Kept
+        # in sync manually — if either format changes, both need to
+        # move together.
+        run: |
+          SHORT=$(echo "${GITHUB_SHA}" | cut -c1-7)
+          echo "tag=master-${SHORT}" >> "$GITHUB_OUTPUT"
 
       - uses: docker/setup-buildx-action@v3
 
@@ -113,8 +136,21 @@ jobs:
             "${{ secrets.DROPLET_USER }}@${{ secrets.DROPLET_HOST }}:~/corewar/"
 
       - name: Pull image + restart stack + verify health
+        env:
+          # Deploy pins to the exact SHA this build produced. Race-immune
+          # against concurrent master merges — `:latest` may have been
+          # overwritten by a parallel build that finished later, but the
+          # tag we pass through here is bound to THIS run's commit and
+          # was pushed to GHCR before this job started (build → deploy
+          # is a `needs:` edge). See issue #78.
+          IMAGE_TAG: ${{ needs.build.outputs.tag }}
         run: |
-          ssh "${{ secrets.DROPLET_USER }}@${{ secrets.DROPLET_HOST }}" bash -s <<'REMOTE'
+          # Pass BACKEND_IMAGE_TAG through to the remote via the ssh
+          # command prefix — the outer shell expands $IMAGE_TAG (local
+          # runner env), the remote bash sees the literal assignment.
+          # This works even when the heredoc is quoted (which we want
+          # so remote-only variables like $SECONDS don't leak upward).
+          ssh "${{ secrets.DROPLET_USER }}@${{ secrets.DROPLET_HOST }}" "BACKEND_IMAGE_TAG=$IMAGE_TAG bash -s" <<'REMOTE'
           set -euo pipefail
           cd ~/corewar
 
@@ -123,6 +159,15 @@ jobs:
               echo "       bootstrap first (deploy/README.md section 7)." >&2
               exit 1
           fi
+
+          echo "==> Deploying backend at tag ${BACKEND_IMAGE_TAG}"
+          # Export so `docker compose` sees BACKEND_IMAGE_TAG via the
+          # compose file's `${BACKEND_IMAGE_TAG:-latest}` interpolation.
+          # (`--env-file` supplies the app's runtime secrets, but
+          # variable interpolation in the compose file itself uses the
+          # calling shell's env — those are two separate resolution
+          # paths, both required.)
+          export BACKEND_IMAGE_TAG
 
           echo "==> Pulling backend image"
           docker compose -f docker-compose.prod.yml --env-file .env.production pull backend

--- a/.github/workflows/prune-ghcr.yml
+++ b/.github/workflows/prune-ghcr.yml
@@ -1,0 +1,43 @@
+name: Prune old GHCR backend image versions
+
+# Keeps GHCR from growing without bound: every push to master publishes
+# a new `master-<sha>` tag alongside `:latest`, so at ~2 pushes/day the
+# registry would accumulate hundreds of images per year with no way for
+# a human to find "the last known-good one".
+#
+# Policy: keep the last 20 image versions (roughly ~2 months of pushes
+# at current cadence) and prune the rest. `:latest` is always the most
+# recent version by construction, so it's inherently within the kept
+# set. Rollback path documented in deploy/README.md.
+#
+# Runs on a weekly schedule and on manual dispatch. Not tied to deploys
+# because retention should decouple from the hot deploy path — a bad
+# prune should never block a rollout.
+
+on:
+  schedule:
+    # Weekly, Mondays 08:00 UTC — off-hours for any US/EU dev, but
+    # early enough in the week that a broken prune has business days
+    # to be noticed and fixed.
+    - cron: '0 8 * * 1'
+  workflow_dispatch:
+
+jobs:
+  prune:
+    name: Prune old backend image versions
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Delete old container package versions
+        uses: actions/delete-package-versions@v5
+        with:
+          package-name: core-war-backend
+          package-type: container
+          # Keep the most recent N image versions regardless of tag.
+          # `:latest` is re-pushed on every master build and therefore
+          # is always among the most recent versions — no explicit
+          # protection needed. Kept generous (20) to preserve enough
+          # rollback headroom for at least two months at current push
+          # cadence.
+          min-versions-to-keep: 20

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -397,6 +397,55 @@ The script rsyncs (skipping `.env.production` and other excluded paths),
 then runs `docker compose up -d --build` over SSH so only changed layers
 rebuild.
 
+### 9a. Rollback to an earlier backend image
+
+Every push to master publishes an immutable `master-<sha>` tag alongside
+`:latest` (see the `Compute image tags` step in
+`.github/workflows/deploy-backend.yml`). The `docker-compose.prod.yml`
+backend service resolves `${BACKEND_IMAGE_TAG:-latest}`, so pinning to
+an older SHA is one env var away — no code change, no CI run.
+
+1. Pick a target SHA from **GitHub → your profile → Packages →
+   `core-war-backend` → Tags**. Anything of the form `master-abcdef1`
+   is a candidate. The list is bounded by the retention policy in
+   `.github/workflows/prune-ghcr.yml` (currently: last 20 versions,
+   ~2 months at present cadence).
+
+2. SSH into the droplet and pin the tag:
+
+   ```bash
+   ssh colt@<DROPLET_IP>
+   cd ~/corewar
+   # Add or update the line — no other secrets change.
+   echo 'BACKEND_IMAGE_TAG=master-abcdef1' >> .env.production
+   # (Or edit .env.production directly if BACKEND_IMAGE_TAG is already set.)
+   ```
+
+3. Pull the pinned image and restart just the backend:
+
+   ```bash
+   docker compose -f docker-compose.prod.yml --env-file .env.production pull backend
+   docker compose -f docker-compose.prod.yml --env-file .env.production up -d --remove-orphans
+   ```
+
+4. Verify the container came up healthy:
+
+   ```bash
+   docker compose -f docker-compose.prod.yml --env-file .env.production ps
+   curl -f http://localhost:3001/health/deep
+   ```
+
+To return to normal (deploy-managed) operation: the next `Deploy
+backend` workflow run exports `BACKEND_IMAGE_TAG=master-<tip-sha>` in
+the SSH session before the compose commands, and docker compose's
+shell-env-wins-over-`--env-file` rule means the workflow's value
+overrides anything in `.env.production` during the automated deploy.
+However, any *manual* `docker compose up -d` on the droplet (without
+`BACKEND_IMAGE_TAG` in the current shell) would still pick up whatever
+you left in `.env.production` — so once the incident is resolved,
+remove the `BACKEND_IMAGE_TAG=` line to avoid a surprise on the next
+manual restart.
+
 ## 10. Enable CI deploys (deploy-on-merge)
 
 Once the droplet is up and the manual deploy from section 7 worked, wire
@@ -580,9 +629,6 @@ If `npm audit` flags a new high/critical advisory:
   startup errors in `docker compose logs backend` and the CI deploy job's
   60s health-check loop catches them. Splitting into a separate
   pre-startup step is a nice-to-have, not a blocker. Tracked in #77.
-- **Backend image versioning + retention.** CI currently pushes only
-  `:latest` to GHCR, so each successful build overwrites the previous
-  image — rollback to a known-good image isn't possible. Tracked in #78.
 - **Zero-downtime deploys** (blue/green or rolling). Current `docker
   compose up -d` produces a ~5–15s window where `/health` returns
   connection refused. Fine at single-digit users; revisit if the user

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -20,7 +20,15 @@ services:
     # `docker compose up --build` — that build tags the local image with
     # this same name, which is harmless. If you fork, update the owner
     # segment to match your GitHub login (lowercase).
-    image: ghcr.io/coltosaur/core-war-backend:latest
+    #
+    # `BACKEND_IMAGE_TAG` is deliberately overridable: the deploy workflow
+    # sets it to the exact `master-<sha>` tag it just pushed, which makes
+    # each deploy race-immune (no dependence on the mutable `:latest`
+    # tag). For manual `docker pull` / local prod-mirror / doc examples,
+    # it falls back to `:latest`. For rollback, set BACKEND_IMAGE_TAG in
+    # `.env.production` on the droplet to any older `master-<sha>` tag
+    # from GHCR and `docker compose pull backend && up -d`.
+    image: ghcr.io/coltosaur/core-war-backend:${BACKEND_IMAGE_TAG:-latest}
     build:
       context: .
       dockerfile: backend/Dockerfile


### PR DESCRIPTION
## Summary

Three coupled changes that together make concurrent-merge deploys deterministic and give us a rollback path:

### 1. Deploy pins by SHA, not by `:latest`
The build job already emits both `:latest` and `:master-<sha>` tags via `docker/metadata-action`. The deploy step now:

- Adds a `Compute immutable image tag` step that emits `master-<short-sha>` as a job output.
- Exports `BACKEND_IMAGE_TAG=$IMAGE_TAG` into the SSH env before the compose commands.
- `docker-compose.prod.yml`'s backend service resolves `${BACKEND_IMAGE_TAG:-latest}`, so each deploy is bound to THIS run's commit rather than racing whichever build happened to push `:latest` last.

**Race scenario this closes:** two backend-touching PRs merge back-to-back. Build A (older merge) takes longer than Build B (newer merge). B pushes `:latest = SHA_B` at t=90s; A pushes `:latest = SHA_A` at t=120s, overwriting. Both deploy jobs pull `:latest` → both deploys land the older code. **After this PR:** deploy A pulls `master-SHA_A`, deploy B pulls `master-SHA_B` — both deterministic, and the FIFO concurrency on `deploy` ensures they run in merge order.

### 2. Build job has `cancel-in-progress` concurrency
```yaml
concurrency:
  group: deploy-backend-build-${{ github.ref }}
  cancel-in-progress: true
```
Bursts of master merges skip intermediate builds and only the tip actually builds + deploys. The `deploy` job keeps `cancel-in-progress: false` so a running deploy is never interrupted mid-way (which would leave prod half-updated). Net: N rapid merges → one final deploy of the tip, not N racing deploys of arbitrary intermediates.

### 3. Weekly GHCR retention
New `.github/workflows/prune-ghcr.yml` runs `actions/delete-package-versions@v5` on a Monday 08:00 UTC cron (plus `workflow_dispatch`), keeping the last 20 backend image versions. `:latest` is always among the most recent versions by construction, so no explicit protection needed. Retention keeps ~2 months of rollback headroom at current push cadence.

### 4. Rollback recipe (README section 9a)
`docker-compose.prod.yml`'s `${BACKEND_IMAGE_TAG:-latest}` makes manual rollback a one-line env change on the droplet: pin an older SHA in `.env.production`, `docker compose pull backend && up -d`. Full recipe added.

## Motivation

We just merged PRs #91 + #92 back-to-back and got lucky that #92 was agents-only (didn't touch any path in the deploy workflow's `paths:` filter), so only #91 actually deployed. With the senior-engineer subagents (Nova, Vale, Orion) about to be dispatched on parallel backend issues, the race scenario would fire on the next dual-merge where both PRs touch backend paths — Deploy A pulls whatever `:latest` points at, which could be either A or B's image depending on which build finished last. This PR closes that race.

## Test plan

- [x] YAML parses cleanly (`python3 -c "import yaml; yaml.safe_load(...)"`).
- [x] `actions/delete-package-versions@v5` release exists on the marketplace.
- [x] `docker-compose.prod.yml` still resolves `${BACKEND_IMAGE_TAG:-latest}` to `:latest` when the var is unset (local prod-mirror `docker compose up -d --build` unchanged).
- [ ] After merge, first deploy run confirms:
  - Build step logs the `Compute immutable image tag` step producing `master-<sha>`.
  - Deploy step logs `==> Deploying backend at tag master-<sha>` (from the new echo line).
  - Container comes up healthy within the existing 60s window.
- [ ] After merge, verify the two tags coexist in GHCR (`:latest` + `:master-<sha>` pointing at the same manifest).
- [ ] After merge, trigger the prune workflow manually via `workflow_dispatch` and confirm it keeps the most recent 20 versions.

## What's out of scope for #78

- Zero-downtime deploys (blue/green or rolling) — tracked in #79. This PR still has the ~5-15s restart window; race immunity is orthogonal to zero-downtime.
- Post-deploy validation ("is this image good?") — tracked in #79.
- Migrations as an explicit deploy step — tracked in #77.

Closes #78.

🤖 Generated with [Claude Code](https://claude.com/claude-code)