### PR TITLE
Builder: sync React source state with Monaco on mount (#85)

### DIFF
--- a/frontend/src/pages/builder/useBuilder.test.tsx
+++ b/frontend/src/pages/builder/useBuilder.test.tsx
@@ -1,0 +1,132 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { parseWarrior } from 'core-war-engine';
+import { useBuilder } from './useBuilder';
+
+// useBuilder pulls in useAuth, which requires an AuthProvider. Stub it out —
+// the fresh-mount bug reproduces for both anonymous and authenticated users,
+// and the auth path is not the code under test.
+vi.mock('../../api/AuthContext', () => ({
+  useAuth: () => ({
+    user: null,
+    loading: false,
+    login: vi.fn(),
+    register: vi.fn(),
+    logout: vi.fn(),
+  }),
+}));
+
+function wrapper({ children }: { children: ReactNode }): ReactNode {
+  return <MemoryRouter>{children}</MemoryRouter>;
+}
+
+// The shared parseWarrior mock in src/test/__mocks__/core-war-engine.ts
+// always succeeds, which is exactly what let issue #85 slip through — the
+// real engine rejects empty input with EmptyWarrior, but the mock did not.
+// For these tests we substitute a behavior-faithful implementation.
+const EMPTY_MESSAGE = 'warrior source has no instructions';
+
+type ParsedWarriorLike = ReturnType<typeof parseWarrior>;
+
+function fakeParsed(name: string): ParsedWarriorLike {
+  return {
+    name: () => name,
+    author: () => null,
+    instructionCount: () => 1,
+    startOffset: () => 0,
+  } as unknown as ParsedWarriorLike;
+}
+
+describe('useBuilder', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.mocked(parseWarrior).mockReset();
+    vi.mocked(parseWarrior).mockImplementation((source: string) => {
+      if (!source.trim()) throw new Error(EMPTY_MESSAGE);
+      return fakeParsed('Fake Warrior');
+    });
+  });
+
+  it('lazy-initializes source and label from the first library warrior', () => {
+    const { result } = renderHook(() => useBuilder(), { wrapper });
+
+    // The first library entry is always a preset (see warriors/library.ts —
+    // computeSnapshot returns [...PRESETS, ...userWarriors]).
+    expect(result.current.selectedId).toMatch(/^preset:/);
+    expect(result.current.source).not.toBe('');
+    expect(result.current.source).toBe(result.current.presets[0].source);
+    expect(result.current.label).toBe(result.current.presets[0].label);
+  });
+
+  it('reports a successful parse once wasm loads on a fresh mount (issue #85)', async () => {
+    const { result } = renderHook(() => useBuilder(), { wrapper });
+
+    // Before wasm loads, no parse has been attempted.
+    expect(result.current.wasmReady).toBe(false);
+    expect(result.current.parseStatus).toBeNull();
+
+    // Wait for the async init() promise to resolve and the parse effect
+    // to run against the (non-empty) initial source.
+    await waitFor(() => {
+      expect(result.current.wasmReady).toBe(true);
+      expect(result.current.parseStatus).not.toBeNull();
+    });
+
+    // The core regression: on a fresh mount with a preset selected, the
+    // status bar must report a successful parse — NOT EmptyWarrior.
+    expect(result.current.parseStatus?.ok).toBe(true);
+
+    // And parseWarrior was called with the preset body, not with ''.
+    const calls = vi.mocked(parseWarrior).mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    for (const [arg] of calls) {
+      expect(arg.trim()).not.toBe('');
+    }
+  });
+
+  it('re-syncs source and label when the selection changes while not dirty', async () => {
+    const { result } = renderHook(() => useBuilder(), { wrapper });
+    await waitFor(() => expect(result.current.wasmReady).toBe(true));
+
+    const initialId = result.current.selectedId;
+    const initialSource = result.current.source;
+    const nextPreset = result.current.presets.find((p) => p.id !== initialId);
+    expect(nextPreset).toBeDefined();
+
+    act(() => {
+      result.current.handleSelect(nextPreset!.id);
+    });
+
+    expect(result.current.selectedId).toBe(nextPreset!.id);
+    expect(result.current.source).toBe(nextPreset!.source);
+    expect(result.current.label).toBe(nextPreset!.label);
+    expect(result.current.source).not.toBe(initialSource);
+    expect(result.current.dirty).toBe(false);
+  });
+
+  it('handleSourceChange marks the buffer dirty and does not get reverted by the sync effect', async () => {
+    const { result } = renderHook(() => useBuilder(), { wrapper });
+    await waitFor(() => expect(result.current.wasmReady).toBe(true));
+
+    const originalSource = result.current.source;
+    const edited = originalSource + '\n; edited by test';
+
+    act(() => {
+      result.current.handleSourceChange(edited);
+    });
+
+    expect(result.current.source).toBe(edited);
+    expect(result.current.dirty).toBe(true);
+
+    // A no-op re-render must not clobber the user's edits back to the
+    // library value — the sync effect is gated on `!dirty`.
+    // We can nudge a re-render by calling handleLabelChange (also dirty=true).
+    act(() => {
+      result.current.handleLabelChange(result.current.label);
+    });
+
+    expect(result.current.source).toBe(edited);
+  });
+});

--- a/frontend/src/pages/builder/useBuilder.ts
+++ b/frontend/src/pages/builder/useBuilder.ts
@@ -28,8 +28,8 @@ export function useBuilder() {
   const { user } = useAuth();
   const library = useWarriorLibrary();
   const [selectedId, setSelectedId] = useState<string>(() => library[0]?.id ?? '');
-  const [source, setSource] = useState<string>('');
-  const [label, setLabel] = useState<string>('');
+  const [source, setSource] = useState<string>(() => library[0]?.source ?? '');
+  const [label, setLabel] = useState<string>(() => library[0]?.label ?? '');
   const [dirty, setDirty] = useState(false);
   const [wasmReady, setWasmReady] = useState(false);
   const [parseStatus, setParseStatus] = useState<ParseStatus>(null);
@@ -64,6 +64,22 @@ export function useBuilder() {
     setLabel(warrior.label);
     setDirty(false);
   }, []);
+
+  // Mirror the selected warrior into local source/label state whenever the
+  // selection or the library snapshot changes and the user has no pending
+  // edits. Combined with the lazy-init of `source` and `label` above, this
+  // guarantees the React state matches what Monaco shows (via
+  // `defaultValue={selected?.source}`) from the very first render — so the
+  // parse-status effect below never sees an empty string and mis-reports
+  // EmptyWarrior on a fresh load. Gated on `!dirty` so in-flight edits are
+  // never clobbered by an async library update (e.g. syncFromServer).
+  useEffect(() => {
+    if (dirty) return;
+    const warrior = library.find((w) => w.id === selectedId);
+    if (!warrior) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    syncFromWarrior(warrior);
+  }, [selectedId, dirty, library, syncFromWarrior]);
 
   function runParse(text: string): void {
     const monaco = monacoRef.current;


### PR DESCRIPTION
## Summary

Fixes the cosmetic-but-wrong "warrior source has no instructions" status that appeared on a fresh Builder load with a preset selected. Monaco showed Imp via `defaultValue={selected?.source ?? ''}` while the React `source` state was still `''`, so the parse effect ran `runParse('')` once wasm loaded and hit `ParseError::EmptyWarrior`. Typing any character cleared it — cosmetic, but a bad first impression on the very warrior the preset library is meant to showcase.

Closes #85.

### Change

`frontend/src/pages/builder/useBuilder.ts`:

- Lazy-initialize `source` from `library[0]?.source ?? ''` and `label` from `library[0]?.label ?? ''` (alongside the existing lazy-init of `selectedId`). `useWarriorLibrary()` returns a synchronously-computed snapshot with presets first, so this always resolves to Imp on first render.
- Add a defensive `useEffect` gated on `!dirty` that re-mirrors the selected warrior into `source`/`label` on later `selectedId`/`library` changes. Belt-and-suspenders for async server-warrior arrivals after `syncFromServer` and any future path that sets `selectedId` outside the current handlers. Cannot clobber user edits because it returns early when `dirty` is true.

Path (a) from the issue. Path (b) (removing the `wasmReady` guard in `handleEditorDidMount`) fixes only the initial mount and leaves state drift in other scenarios (e.g. clicking a sidebar warrior before wasm is ready); (a) fixes the whole class of desyncs.

### Tests added

`frontend/src/pages/builder/useBuilder.test.tsx` — new file. The shared `parseWarrior` mock in `src/test/__mocks__/core-war-engine.ts` always succeeds, which is exactly why this bug slipped through — so per-test I override it with a behavior-faithful implementation that throws `warrior source has no instructions` on empty input, matching the real engine.

Cases:
1. Source/label are non-empty on initial mount and match `library[0]`.
2. Once `wasmReady` flips true, `parseStatus.ok === true` — and `parseWarrior` was never called with an empty string across the whole mount → ready transition. Directly asserts no transient `EmptyWarrior` reaches the UI.
3. `handleSelect` to a different preset switches source/label in sync.
4. `handleSourceChange` marks dirty and is not reverted by the sync effect on a subsequent re-render (dirty gate works).

### Acceptance criteria

- [x] Loading the Builder with the default preset (Imp) selected shows a successful parse in the status bar without any user input — verified in browser via Playwright MCP: status shows "✓ parsed — Imp" from t=0.
- [x] Loading while wasm is still loading does not produce a transient `EmptyWarrior` — covered by Vitest case 2 (the parse effect gates on `if (!wasmReady) return;` and lazy-init source is non-empty, so no code path can reach `runParse('')`).
- [x] Switching between presets keeps displayed source and parsed source in sync — verified in browser: clicking Dwarf in sidebar updated Monaco content and status flipped to "✓ parsed — Dwarf". Also covered by Vitest case 3.
- [x] Existing save/duplicate/delete/test-in-battle/edit flows unchanged — verified in browser: Duplicate created "Imp (copy)" and switched selection; editing label enabled Save and showed "● unsaved changes"; Save persisted to localStorage and cleared the badge; Delete removed the user warrior and fell back to Imp preset; Test in Battlefield navigated to `/battle?red=preset:imp&blue=preset:dwarf`.
- [x] Vitest covers "mount with non-empty preset → status is ok" — case 2.

### Test plan

- [x] `npm test` — 60/60 passing, including 4 new cases in useBuilder.test.tsx
- [x] `npm run lint` — 0 errors (1 preexisting warning in `AuthContext.tsx`, unrelated)
- [x] `npm run format` — no changes
- [x] `npm run build` — clean
- [x] Manual browser verification (Playwright MCP): fresh load, preset switching, duplicate → edit → save → delete, test-in-battle nav

🤖 Generated with [Claude Code](https://claude.com/claude-code)