### PR TITLE
Own-profile dashboard: superset of public view + account settings (#88)

### DIFF
--- a/backend/src/account/handlers.rs
+++ b/backend/src/account/handlers.rs
@@ -1,0 +1,30 @@
+use crate::auth::middleware::AuthUser;
+use crate::errors::AppError;
+use crate::AppState;
+use axum::extract::State;
+use axum::Json;
+use serde::Serialize;
+
+/// Response body for `GET /api/account`.
+///
+/// Deliberately minimal today (email only). Add fields here — verified status,
+/// last-password-change, connected identities — as the account-settings surface
+/// grows, rather than expanding the `/api/profile` contract, which is meant to
+/// remain the public/anonymous-facing view.
+#[derive(Serialize)]
+pub struct AccountResponse {
+    pub email: String,
+}
+
+pub async fn me(
+    State(state): State<AppState>,
+    user: AuthUser,
+) -> Result<Json<AccountResponse>, AppError> {
+    let email: String = sqlx::query_scalar("SELECT email FROM users WHERE id = $1")
+        .bind(user.user_id)
+        .fetch_optional(&state.db)
+        .await?
+        .ok_or_else(|| AppError::Unauthorized("User not found".into()))?;
+
+    Ok(Json(AccountResponse { email }))
+}

--- a/backend/src/account/mod.rs
+++ b/backend/src/account/mod.rs
@@ -1,0 +1,1 @@
+pub mod handlers;

--- a/backend/src/auth/handlers.rs
+++ b/backend/src/auth/handlers.rs
@@ -1,4 +1,5 @@
 use crate::auth::jwt::{encode_access_token, generate_refresh_token, hash_refresh_token};
+use crate::auth::middleware::AuthUser;
 use crate::auth::password::{hash_password, verify_password, verify_password_against_dummy};
 use crate::errors::AppError;
 use crate::AppState;
@@ -21,6 +22,12 @@ pub struct RegisterRequest {
 pub struct LoginRequest {
     pub username_or_email: String,
     pub password: String,
+}
+
+#[derive(Deserialize)]
+pub struct ChangePasswordRequest {
+    pub current_password: String,
+    pub new_password: String,
 }
 
 #[derive(Serialize)]
@@ -314,6 +321,77 @@ pub async fn logout(
     }
 
     let jar = jar.add(clear_access_cookie()).add(clear_refresh_cookie());
+
+    Ok((jar, StatusCode::NO_CONTENT))
+}
+
+pub async fn change_password(
+    State(state): State<AppState>,
+    user: AuthUser,
+    jar: CookieJar,
+    Json(body): Json<ChangePasswordRequest>,
+) -> Result<(CookieJar, StatusCode), AppError> {
+    // Enforce the same rules as registration on the new password so a user
+    // can't downgrade to a weak one via this path.
+    validate_password(&body.new_password)?;
+
+    // Rejecting no-op changes early prevents accidental refresh-token wipes
+    // and gives the frontend a clear "different password required" signal.
+    if body.current_password == body.new_password {
+        return Err(AppError::BadRequest(
+            "New password must be different from the current password".into(),
+        ));
+    }
+
+    let password_hash: String = sqlx::query_scalar("SELECT password_hash FROM users WHERE id = $1")
+        .bind(user.user_id)
+        .fetch_optional(&state.db)
+        .await?
+        .ok_or_else(|| AppError::Unauthorized("User not found".into()))?;
+
+    if !verify_password(&body.current_password, &password_hash)? {
+        return Err(AppError::Unauthorized(
+            "Current password is incorrect".into(),
+        ));
+    }
+
+    let new_hash = hash_password(&body.new_password)?;
+
+    // Update the stored hash and revoke all refresh tokens for this user in
+    // a single transaction. Revoking every refresh token (not just the one on
+    // this device) is deliberate: a password change is the standard trigger
+    // for "log the user out everywhere else", which is the whole point of
+    // rotating the credential.
+    let mut tx = state.db.begin().await?;
+    sqlx::query("UPDATE users SET password_hash = $1 WHERE id = $2")
+        .bind(&new_hash)
+        .bind(user.user_id)
+        .execute(&mut *tx)
+        .await?;
+    sqlx::query("DELETE FROM refresh_tokens WHERE user_id = $1")
+        .bind(user.user_id)
+        .execute(&mut *tx)
+        .await?;
+    tx.commit().await?;
+
+    // Issue a fresh access + refresh pair so the *current* session stays
+    // logged in — otherwise the user would have to log back in on the device
+    // that just changed the password, which is jarring UX.
+    let access_token = encode_access_token(user.user_id, &user.username, &state.config.jwt_secret)?;
+    let refresh_token = generate_refresh_token();
+    let token_hash = hash_refresh_token(&refresh_token);
+    let expires_at = Utc::now() + Duration::days(7);
+
+    sqlx::query("INSERT INTO refresh_tokens (user_id, token_hash, expires_at) VALUES ($1, $2, $3)")
+        .bind(user.user_id)
+        .bind(&token_hash)
+        .bind(expires_at)
+        .execute(&state.db)
+        .await?;
+
+    let jar = jar
+        .add(build_access_cookie(access_token))
+        .add(build_refresh_cookie(refresh_token));
 
     Ok((jar, StatusCode::NO_CONTENT))
 }

--- a/backend/src/auth/rate_limit.rs
+++ b/backend/src/auth/rate_limit.rs
@@ -131,6 +131,16 @@ pub fn refresh_limiter(conn: ConnectionManager, trusted_proxies: Vec<IpAddr>) ->
     RateLimiter::new(conn, "refresh", 10, 15 * 60, trusted_proxies)
 }
 
+/// Change-password: 5 attempts per 15 min, same shape as login. The endpoint
+/// verifies the current password so it's a plausible brute-force surface even
+/// with a valid session cookie — cap it accordingly.
+pub fn change_password_limiter(
+    conn: ConnectionManager,
+    trusted_proxies: Vec<IpAddr>,
+) -> RateLimiter {
+    RateLimiter::new(conn, "change_password", 5, 15 * 60, trusted_proxies)
+}
+
 pub async fn rate_limit_middleware(
     connect_info: Option<ConnectInfo<SocketAddr>>,
     axum::extract::State(limiter): axum::extract::State<RateLimiter>,

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod account;
 pub mod auth;
 pub mod config;
 pub mod db;

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -2,8 +2,8 @@ use axum::extract::DefaultBodyLimit;
 use axum::http::{header, Method};
 use axum::{middleware, routing::get, routing::post, Router};
 use core_war_backend::{
-    auth, config::Config, db, health, leaderboard, matches, matchmaking, profile, warriors,
-    AppConfig, AppState,
+    account, auth, config::Config, db, health, leaderboard, matches, matchmaking, profile,
+    warriors, AppConfig, AppState,
 };
 
 const MAX_REQUEST_BODY_BYTES: usize = 128 * 1024;
@@ -72,7 +72,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let proxies = state.config.trusted_proxies.clone();
     let login_limiter = auth::rate_limit::login_limiter(redis_conn.clone(), proxies.clone());
     let register_limiter = auth::rate_limit::register_limiter(redis_conn.clone(), proxies.clone());
-    let refresh_limiter = auth::rate_limit::refresh_limiter(redis_conn, proxies);
+    let refresh_limiter = auth::rate_limit::refresh_limiter(redis_conn.clone(), proxies.clone());
+    let change_password_limiter = auth::rate_limit::change_password_limiter(redis_conn, proxies);
 
     let app = Router::new()
         .route("/health", get(health::liveness))
@@ -100,6 +101,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .route("/api/auth/logout", post(auth::handlers::logout))
         .route("/api/auth/me", get(auth::handlers::me))
+        .route(
+            "/api/auth/change-password",
+            post(auth::handlers::change_password).layer(middleware::from_fn_with_state(
+                change_password_limiter,
+                auth::rate_limit::rate_limit_middleware,
+            )),
+        )
+        .route("/api/account", get(account::handlers::me))
         .route(
             "/api/warriors",
             get(warriors::handlers::list).post(warriors::handlers::create),

--- a/backend/tests/account_integration.rs
+++ b/backend/tests/account_integration.rs
@@ -1,0 +1,145 @@
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use axum::routing::{get, post};
+use axum::{middleware, Router};
+use core_war_backend::{account, auth, AppConfig, AppState};
+use http_body_util::BodyExt;
+use serde_json::{json, Value};
+use sqlx::PgPool;
+use std::collections::HashMap;
+use tower::ServiceExt;
+
+const FRONTEND_URL: &str = "http://localhost:5173";
+const JWT_SECRET: &[u8] = b"integration-test-secret-that-is-at-least-32-bytes!!";
+
+fn test_state(pool: PgPool) -> AppState {
+    AppState {
+        db: pool,
+        config: AppConfig {
+            frontend_url: FRONTEND_URL.into(),
+            jwt_secret: JWT_SECRET.to_vec(),
+            trusted_proxies: vec![],
+        },
+    }
+}
+
+fn app(pool: PgPool) -> Router {
+    let state = test_state(pool);
+    Router::new()
+        .route("/api/auth/register", post(auth::handlers::register))
+        .route("/api/auth/login", post(auth::handlers::login))
+        .route("/api/account", get(account::handlers::me))
+        .layer(middleware::from_fn_with_state(
+            state.clone(),
+            auth::middleware::csrf_middleware,
+        ))
+        .with_state(state)
+}
+
+fn post_json(path: &str, body: &Value) -> Request<Body> {
+    Request::post(path)
+        .header("content-type", "application/json")
+        .header("origin", FRONTEND_URL)
+        .body(Body::from(body.to_string()))
+        .unwrap()
+}
+
+fn get_with_cookies(path: &str, cookies: &str) -> Request<Body> {
+    Request::get(path)
+        .header("cookie", cookies)
+        .body(Body::empty())
+        .unwrap()
+}
+
+fn get_no_auth(path: &str) -> Request<Body> {
+    Request::get(path).body(Body::empty()).unwrap()
+}
+
+struct TestResponse {
+    status: StatusCode,
+    json: Value,
+    cookies: HashMap<String, String>,
+}
+
+fn extract_cookies(headers: &axum::http::HeaderMap) -> HashMap<String, String> {
+    let mut map = HashMap::new();
+    for header in headers.get_all("set-cookie") {
+        if let Ok(s) = header.to_str() {
+            if let Some(cookie_part) = s.split(';').next() {
+                if let Some((name, value)) = cookie_part.split_once('=') {
+                    map.insert(name.trim().to_string(), value.trim().to_string());
+                }
+            }
+        }
+    }
+    map
+}
+
+async fn send(router: Router, req: Request<Body>) -> TestResponse {
+    let resp = router.oneshot(req).await.unwrap();
+    let status = resp.status();
+    let cookies = extract_cookies(resp.headers());
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    let json = serde_json::from_slice(&body).unwrap_or(Value::Null);
+    TestResponse {
+        status,
+        json,
+        cookies,
+    }
+}
+
+async fn register_user(router: &Router, username: &str, email: &str) -> HashMap<String, String> {
+    let resp = send(
+        router.clone(),
+        post_json(
+            "/api/auth/register",
+            &json!({
+                "username": username,
+                "email": email,
+                "password": "password1234",
+            }),
+        ),
+    )
+    .await;
+    assert_eq!(resp.status, StatusCode::CREATED);
+    resp.cookies
+}
+
+#[sqlx::test]
+async fn account_returns_email_for_authed_user(pool: PgPool) {
+    let router = app(pool);
+    let cookies = register_user(&router, "acctuser", "acct@example.com").await;
+    let access = cookies["access_token"].clone();
+
+    let resp = send(
+        router,
+        get_with_cookies("/api/account", &format!("access_token={access}")),
+    )
+    .await;
+    assert_eq!(resp.status, StatusCode::OK);
+    assert_eq!(resp.json["email"], "acct@example.com");
+}
+
+#[sqlx::test]
+async fn account_normalizes_email_to_lowercase(pool: PgPool) {
+    // Registration lowercases the email — /api/account should reflect that
+    // stored form so the settings page can display it verbatim.
+    let router = app(pool);
+    let cookies = register_user(&router, "acctcase", "AcCt+Mixed@ExAmPlE.COM").await;
+    let access = cookies["access_token"].clone();
+
+    let resp = send(
+        router,
+        get_with_cookies("/api/account", &format!("access_token={access}")),
+    )
+    .await;
+    assert_eq!(resp.status, StatusCode::OK);
+    assert_eq!(resp.json["email"], "acct+mixed@example.com");
+}
+
+#[sqlx::test]
+async fn account_requires_authentication(pool: PgPool) {
+    let router = app(pool);
+    let resp = send(router, get_no_auth("/api/account")).await;
+    assert_eq!(resp.status, StatusCode::UNAUTHORIZED);
+}

--- a/backend/tests/auth_integration.rs
+++ b/backend/tests/auth_integration.rs
@@ -30,6 +30,10 @@ fn app(pool: PgPool) -> Router {
         .route("/api/auth/login", post(auth::handlers::login))
         .route("/api/auth/refresh", post(auth::handlers::refresh))
         .route("/api/auth/logout", post(auth::handlers::logout))
+        .route(
+            "/api/auth/change-password",
+            post(auth::handlers::change_password),
+        )
         .layer(middleware::from_fn_with_state(
             state.clone(),
             auth::middleware::csrf_middleware,
@@ -52,6 +56,15 @@ fn post_with_cookies(path: &str, cookies: &str) -> Request<Body> {
         .header("origin", FRONTEND_URL)
         .header("cookie", cookies)
         .body(Body::empty())
+        .unwrap()
+}
+
+fn post_json_with_cookies(path: &str, body: &Value, cookies: &str) -> Request<Body> {
+    Request::post(path)
+        .header("content-type", "application/json")
+        .header("origin", FRONTEND_URL)
+        .header("cookie", cookies)
+        .body(Body::from(body.to_string()))
         .unwrap()
 }
 
@@ -723,6 +736,205 @@ async fn full_flow_register_login_refresh_logout(pool: PgPool) {
         post_with_cookies(
             "/api/auth/refresh",
             &format!("refresh_token={refresh_token}"),
+        ),
+    )
+    .await;
+    assert_eq!(resp.status, StatusCode::UNAUTHORIZED);
+}
+
+// =============================================================================
+// Change-password tests
+// =============================================================================
+
+fn change_password_body(current: &str, new: &str) -> Value {
+    json!({"current_password": current, "new_password": new})
+}
+
+#[sqlx::test]
+async fn change_password_success_updates_hash_and_keeps_session(pool: PgPool) {
+    let router = app(pool);
+    let cookies = register_and_login(&router, "cpuser", "cp@example.com", "password1234").await;
+    let access = cookies["access_token"].clone();
+
+    // Change to a new password.
+    let resp = send(
+        router.clone(),
+        post_json_with_cookies(
+            "/api/auth/change-password",
+            &change_password_body("password1234", "brand-new-password"),
+            &format!("access_token={access}"),
+        ),
+    )
+    .await;
+    assert_eq!(resp.status, StatusCode::NO_CONTENT);
+
+    // The response must issue a fresh access + refresh pair so the caller's
+    // session survives the rotation.
+    assert!(
+        resp.cookies.contains_key("access_token"),
+        "expected fresh access_token cookie"
+    );
+    assert!(
+        resp.cookies.contains_key("refresh_token"),
+        "expected fresh refresh_token cookie"
+    );
+
+    // Old password no longer works.
+    let resp = send(
+        router.clone(),
+        post_json("/api/auth/login", &login_body("cpuser", "password1234")),
+    )
+    .await;
+    assert_eq!(resp.status, StatusCode::UNAUTHORIZED);
+
+    // New password works.
+    let resp = send(
+        router,
+        post_json(
+            "/api/auth/login",
+            &login_body("cpuser", "brand-new-password"),
+        ),
+    )
+    .await;
+    assert_eq!(resp.status, StatusCode::OK);
+}
+
+#[sqlx::test]
+async fn change_password_wrong_current_rejected(pool: PgPool) {
+    let router = app(pool);
+    let cookies = register_and_login(&router, "cpwrong", "cpw@example.com", "password1234").await;
+    let access = cookies["access_token"].clone();
+
+    let resp = send(
+        router.clone(),
+        post_json_with_cookies(
+            "/api/auth/change-password",
+            &change_password_body("wrong-current-password", "brand-new-password"),
+            &format!("access_token={access}"),
+        ),
+    )
+    .await;
+    assert_eq!(resp.status, StatusCode::UNAUTHORIZED);
+    assert_eq!(resp.json["error"], "Current password is incorrect");
+
+    // Old password still works — nothing was changed.
+    let resp = send(
+        router,
+        post_json("/api/auth/login", &login_body("cpwrong", "password1234")),
+    )
+    .await;
+    assert_eq!(resp.status, StatusCode::OK);
+}
+
+#[sqlx::test]
+async fn change_password_rejects_weak_new_password(pool: PgPool) {
+    let router = app(pool);
+    let cookies = register_and_login(&router, "cpweak", "cpwk@example.com", "password1234").await;
+    let access = cookies["access_token"].clone();
+
+    // Too short.
+    let resp = send(
+        router.clone(),
+        post_json_with_cookies(
+            "/api/auth/change-password",
+            &change_password_body("password1234", "short"),
+            &format!("access_token={access}"),
+        ),
+    )
+    .await;
+    assert_eq!(resp.status, StatusCode::BAD_REQUEST);
+
+    // All-numeric.
+    let resp = send(
+        router,
+        post_json_with_cookies(
+            "/api/auth/change-password",
+            &change_password_body("password1234", "123456789012345"),
+            &format!("access_token={access}"),
+        ),
+    )
+    .await;
+    assert_eq!(resp.status, StatusCode::BAD_REQUEST);
+}
+
+#[sqlx::test]
+async fn change_password_rejects_same_password(pool: PgPool) {
+    let router = app(pool);
+    let cookies = register_and_login(&router, "cpsame", "cps@example.com", "password1234").await;
+    let access = cookies["access_token"].clone();
+
+    let resp = send(
+        router,
+        post_json_with_cookies(
+            "/api/auth/change-password",
+            &change_password_body("password1234", "password1234"),
+            &format!("access_token={access}"),
+        ),
+    )
+    .await;
+    assert_eq!(resp.status, StatusCode::BAD_REQUEST);
+    let msg = resp.json["error"].as_str().unwrap();
+    assert!(msg.to_lowercase().contains("different"));
+}
+
+#[sqlx::test]
+async fn change_password_requires_auth(pool: PgPool) {
+    let router = app(pool);
+
+    let resp = send(
+        router,
+        post_json(
+            "/api/auth/change-password",
+            &change_password_body("anything", "brand-new-password"),
+        ),
+    )
+    .await;
+    assert_eq!(resp.status, StatusCode::UNAUTHORIZED);
+}
+
+#[sqlx::test]
+async fn change_password_revokes_all_refresh_tokens(pool: PgPool) {
+    let router = app(pool);
+    let cookies = register_and_login(&router, "cprevoke", "cpr@example.com", "password1234").await;
+    let access = cookies["access_token"].clone();
+    let old_refresh = cookies["refresh_token"].clone();
+
+    // Log in a *second* time to simulate a session on another device.
+    let resp = send(
+        router.clone(),
+        post_json("/api/auth/login", &login_body("cprevoke", "password1234")),
+    )
+    .await;
+    assert_eq!(resp.status, StatusCode::OK);
+    let other_refresh = resp.cookies["refresh_token"].clone();
+
+    // Change the password.
+    let resp = send(
+        router.clone(),
+        post_json_with_cookies(
+            "/api/auth/change-password",
+            &change_password_body("password1234", "brand-new-password"),
+            &format!("access_token={access}"),
+        ),
+    )
+    .await;
+    assert_eq!(resp.status, StatusCode::NO_CONTENT);
+
+    // The refresh token from the initial login is invalidated.
+    let resp = send(
+        router.clone(),
+        post_with_cookies("/api/auth/refresh", &format!("refresh_token={old_refresh}")),
+    )
+    .await;
+    assert_eq!(resp.status, StatusCode::UNAUTHORIZED);
+
+    // The refresh token from the "other device" is also invalidated — this is
+    // the security-critical bit: changing your password kicks out every session.
+    let resp = send(
+        router,
+        post_with_cookies(
+            "/api/auth/refresh",
+            &format!("refresh_token={other_refresh}"),
         ),
     )
     .await;

--- a/frontend/src/api/account.ts
+++ b/frontend/src/api/account.ts
@@ -1,0 +1,18 @@
+import { api } from './client';
+
+export type Account = {
+  email: string;
+};
+
+export type ChangePasswordInput = {
+  current_password: string;
+  new_password: string;
+};
+
+export async function getAccount(): Promise<Account> {
+  return api.get<Account>('/api/account');
+}
+
+export async function changePassword(input: ChangePasswordInput): Promise<void> {
+  return api.post('/api/auth/change-password', input);
+}

--- a/frontend/src/pages/profile/AccountSettings.test.tsx
+++ b/frontend/src/pages/profile/AccountSettings.test.tsx
@@ -1,0 +1,168 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { MockedFunction } from 'vitest';
+import { render, screen, waitFor, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import AccountSettings from './AccountSettings';
+import { checkPasswordRules, passwordMeetsRules } from './passwordRules';
+import * as accountApi from '../../api/account';
+import * as AuthContextModule from '../../api/AuthContext';
+import { ApiError } from '../../api/client';
+
+vi.mock('../../api/account');
+vi.mock('../../api/AuthContext');
+
+type UseAuthReturn = ReturnType<typeof AuthContextModule.useAuth>;
+
+const mockUseAuth = AuthContextModule.useAuth as MockedFunction<() => UseAuthReturn>;
+const mockGetAccount = accountApi.getAccount as MockedFunction<typeof accountApi.getAccount>;
+const mockChangePassword = accountApi.changePassword as MockedFunction<
+  typeof accountApi.changePassword
+>;
+
+const logoutSpy = vi.fn();
+
+beforeEach(() => {
+  mockUseAuth.mockReturnValue({
+    user: { user_id: 'u1', username: 'vale' },
+    loading: false,
+    login: vi.fn(),
+    register: vi.fn(),
+    logout: logoutSpy,
+  });
+  mockGetAccount.mockResolvedValue({ email: 'vale@example.com' });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe('checkPasswordRules', () => {
+  it('marks length as ok only at >= 12 chars', () => {
+    const short = checkPasswordRules('short').find((r) => r.id === 'length')!;
+    expect(short.ok).toBe(false);
+    const at12 = checkPasswordRules('a'.repeat(12)).find((r) => r.id === 'length')!;
+    expect(at12.ok).toBe(true);
+  });
+
+  it('marks non_digit as failing on pure-numeric passwords', () => {
+    const digits = checkPasswordRules('1'.repeat(20)).find((r) => r.id === 'non_digit')!;
+    expect(digits.ok).toBe(false);
+    const mixed = checkPasswordRules('abcdefghijkl').find((r) => r.id === 'non_digit')!;
+    expect(mixed.ok).toBe(true);
+  });
+
+  it('hides too_long rule until it is actually violated', () => {
+    const short = checkPasswordRules('a'.repeat(20)).find((r) => r.id === 'too_long')!;
+    expect(short.visible).toBe(false);
+    const long = checkPasswordRules('a'.repeat(1001)).find((r) => r.id === 'too_long')!;
+    expect(long.visible).toBe(true);
+    expect(long.ok).toBe(false);
+  });
+
+  it('passwordMeetsRules mirrors backend validate_password', () => {
+    expect(passwordMeetsRules('short')).toBe(false);
+    expect(passwordMeetsRules('123456789012')).toBe(false); // all digits
+    expect(passwordMeetsRules('abcdefghijkl')).toBe(true);
+    expect(passwordMeetsRules('brand-new-password')).toBe(true);
+  });
+});
+
+describe('<AccountSettings /> change-password form', () => {
+  it('disables submit while the new password fails the checklist', async () => {
+    const user = userEvent.setup();
+    render(<AccountSettings />);
+    await waitFor(() => {
+      expect(screen.getByTestId('account-email')).toHaveTextContent('vale@example.com');
+    });
+
+    await user.type(screen.getByLabelText(/current password/i), 'anything');
+    await user.type(screen.getByLabelText(/new password/i), 'short');
+
+    const submit = screen.getByRole('button', { name: /change password/i });
+    expect(submit).toBeDisabled();
+  });
+
+  it('sends the request and clears fields on success', async () => {
+    mockChangePassword.mockResolvedValue(undefined);
+    const user = userEvent.setup();
+    render(<AccountSettings />);
+    await waitFor(() =>
+      expect(screen.getByTestId('account-email')).toHaveTextContent('vale@example.com'),
+    );
+
+    const current = screen.getByLabelText(/current password/i) as HTMLInputElement;
+    const next = screen.getByLabelText(/new password/i) as HTMLInputElement;
+    await user.type(current, 'password1234');
+    await user.type(next, 'brand-new-password');
+
+    await user.click(screen.getByRole('button', { name: /change password/i }));
+
+    await waitFor(() => {
+      expect(mockChangePassword).toHaveBeenCalledWith({
+        current_password: 'password1234',
+        new_password: 'brand-new-password',
+      });
+    });
+    await waitFor(() => {
+      expect(screen.getByText(/password updated/i)).toBeInTheDocument();
+    });
+    expect(current.value).toBe('');
+    expect(next.value).toBe('');
+  });
+
+  it('surfaces a 401 as "current password is incorrect"', async () => {
+    mockChangePassword.mockRejectedValue(new ApiError(401, 'Current password is incorrect'));
+    const user = userEvent.setup();
+    render(<AccountSettings />);
+    await waitFor(() =>
+      expect(screen.getByTestId('account-email')).toHaveTextContent('vale@example.com'),
+    );
+
+    await user.type(screen.getByLabelText(/current password/i), 'wrong-one');
+    await user.type(screen.getByLabelText(/new password/i), 'brand-new-password');
+    await user.click(screen.getByRole('button', { name: /change password/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/current password is incorrect/i)).toBeInTheDocument();
+    });
+  });
+
+  it('surfaces a 429 with a friendly rate-limit message', async () => {
+    mockChangePassword.mockRejectedValue(new ApiError(429, 'Too Many Requests'));
+    const user = userEvent.setup();
+    render(<AccountSettings />);
+    await waitFor(() =>
+      expect(screen.getByTestId('account-email')).toHaveTextContent('vale@example.com'),
+    );
+
+    await user.type(screen.getByLabelText(/current password/i), 'password1234');
+    await user.type(screen.getByLabelText(/new password/i), 'brand-new-password');
+    await user.click(screen.getByRole('button', { name: /change password/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/too many attempts/i)).toBeInTheDocument();
+    });
+  });
+
+  it('renders coming-soon tiles for change-email and delete-account', async () => {
+    render(<AccountSettings />);
+    await waitFor(() =>
+      expect(screen.getByTestId('account-email')).toHaveTextContent('vale@example.com'),
+    );
+
+    expect(screen.getByText(/change email/i)).toBeInTheDocument();
+    expect(screen.getByText(/delete account/i)).toBeInTheDocument();
+  });
+
+  it('logout button calls the auth context logout', async () => {
+    const user = userEvent.setup();
+    render(<AccountSettings />);
+    await waitFor(() =>
+      expect(screen.getByTestId('account-email')).toHaveTextContent('vale@example.com'),
+    );
+
+    await user.click(screen.getByRole('button', { name: /log out/i }));
+    expect(logoutSpy).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/pages/profile/AccountSettings.tsx
+++ b/frontend/src/pages/profile/AccountSettings.tsx
@@ -1,0 +1,337 @@
+import { useEffect, useState } from 'react';
+import { useAuth } from '../../api/AuthContext';
+import { ApiError } from '../../api/client';
+import { getAccount, changePassword } from '../../api/account';
+import { SECTION_HEADER } from './profileStyles';
+import {
+  PASSWORD_MIN_LEN,
+  checkPasswordRules,
+  passwordMeetsRules,
+  type PasswordRule,
+} from './passwordRules';
+
+/**
+ * Own-profile-only account settings panel. Renders email, change-password
+ * form, logout button, and "coming soon" affordances for change-email and
+ * delete-account. Deliberately absent from the public `/users/:username`
+ * view — presence of this panel on the wrong route is a bug.
+ */
+
+// --- styles ---
+
+const PANEL_STYLE: React.CSSProperties = {
+  marginTop: '2rem',
+};
+
+const ROW_STYLE: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'baseline',
+  justifyContent: 'space-between',
+  padding: '0.5rem 0',
+  borderBottom: '1px solid #1a1a1a',
+};
+
+const LABEL_STYLE: React.CSSProperties = {
+  fontSize: '0.7rem',
+  color: '#888',
+  textTransform: 'uppercase',
+  letterSpacing: '0.08em',
+};
+
+const VALUE_STYLE: React.CSSProperties = {
+  color: '#e0e0e0',
+  fontSize: '0.85rem',
+};
+
+const FORM_STYLE: React.CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.75rem',
+  padding: '1rem 0',
+};
+
+const FIELD_LABEL: React.CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.25rem',
+  fontSize: '0.75rem',
+  color: '#aaa',
+};
+
+// Split into borderWidth/Style/Color instead of the `border` shorthand so
+// per-instance overrides of borderColor don't collide with the shorthand
+// (React logs a warning on that pattern during rerender).
+const INPUT_BASE: React.CSSProperties = {
+  backgroundColor: '#111',
+  borderWidth: '1px',
+  borderStyle: 'solid',
+  borderColor: '#333',
+  borderRadius: '4px',
+  padding: '0.5rem',
+  color: '#e0e0e0',
+  fontSize: '0.85rem',
+  fontFamily: 'inherit',
+  outline: 'none',
+};
+
+const CHECKLIST_STYLE: React.CSSProperties = {
+  listStyle: 'none',
+  padding: 0,
+  margin: '0.25rem 0 0 0',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.15rem',
+  fontSize: '0.7rem',
+};
+
+const SUBMIT_BTN: React.CSSProperties = {
+  backgroundColor: '#e94560',
+  color: '#fff',
+  border: 'none',
+  borderRadius: '4px',
+  padding: '0.6rem',
+  fontSize: '0.85rem',
+  fontFamily: 'inherit',
+  cursor: 'pointer',
+  marginTop: '0.25rem',
+};
+
+const SUBMIT_DISABLED: React.CSSProperties = {
+  ...SUBMIT_BTN,
+  backgroundColor: '#333',
+  color: '#666',
+  cursor: 'not-allowed',
+};
+
+const ERROR_STYLE: React.CSSProperties = {
+  color: '#e94560',
+  fontSize: '0.75rem',
+};
+
+const SUCCESS_STYLE: React.CSSProperties = {
+  color: '#4caf50',
+  fontSize: '0.75rem',
+};
+
+const LOGOUT_BTN: React.CSSProperties = {
+  backgroundColor: 'transparent',
+  color: '#e94560',
+  border: '1px solid #e9456066',
+  borderRadius: '4px',
+  padding: '0.5rem 1rem',
+  fontSize: '0.8rem',
+  fontFamily: 'inherit',
+  cursor: 'pointer',
+  marginTop: '0.5rem',
+};
+
+const COMING_SOON_GRID: React.CSSProperties = {
+  display: 'flex',
+  gap: '0.75rem',
+  padding: '0.75rem 0',
+  flexWrap: 'wrap',
+};
+
+const COMING_SOON_TILE: React.CSSProperties = {
+  flex: '1 1 200px',
+  padding: '0.75rem',
+  border: '1px dashed #333',
+  borderRadius: '6px',
+  backgroundColor: '#0d0d0d',
+  color: '#555',
+};
+
+const COMING_SOON_TITLE: React.CSSProperties = {
+  fontSize: '0.85rem',
+  color: '#888',
+  marginBottom: '0.15rem',
+};
+
+const COMING_SOON_TAG: React.CSSProperties = {
+  fontSize: '0.6rem',
+  letterSpacing: '0.1em',
+  textTransform: 'uppercase',
+  color: '#e9456099',
+};
+
+function inputStyle(showValid: boolean | null): React.CSSProperties {
+  if (showValid === true) return { ...INPUT_BASE, borderColor: '#4caf5066' };
+  if (showValid === false) return { ...INPUT_BASE, borderColor: '#e9456099' };
+  return INPUT_BASE;
+}
+
+function RuleItem({ rule }: { rule: PasswordRule }) {
+  const color = rule.ok ? '#4caf50' : '#e94560';
+  return (
+    <li style={{ color, display: 'flex', gap: '0.35rem', alignItems: 'baseline' }}>
+      <span aria-hidden style={{ fontFamily: 'monospace' }}>
+        {rule.ok ? '[x]' : '[ ]'}
+      </span>
+      <span>{rule.label}</span>
+      <span
+        style={{
+          position: 'absolute',
+          width: 1,
+          height: 1,
+          overflow: 'hidden',
+          clip: 'rect(0 0 0 0)',
+        }}
+      >
+        {rule.ok ? '(satisfied)' : '(not satisfied)'}
+      </span>
+    </li>
+  );
+}
+
+export default function AccountSettings() {
+  const { logout } = useAuth();
+  const [email, setEmail] = useState<string | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [currentPassword, setCurrentPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [formSuccess, setFormSuccess] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    getAccount()
+      .then((a) => {
+        if (!cancelled) setEmail(a.email);
+      })
+      .catch((e) => {
+        if (!cancelled) setLoadError(e instanceof Error ? e.message : 'Failed to load account');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const rules = checkPasswordRules(newPassword);
+  const newPasswordValid = passwordMeetsRules(newPassword);
+  const canSubmit =
+    !submitting &&
+    currentPassword.length > 0 &&
+    newPassword.length > 0 &&
+    newPasswordValid &&
+    currentPassword !== newPassword;
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setFormError(null);
+    setFormSuccess(false);
+    if (!canSubmit) return;
+    setSubmitting(true);
+    try {
+      await changePassword({
+        current_password: currentPassword,
+        new_password: newPassword,
+      });
+      setCurrentPassword('');
+      setNewPassword('');
+      setFormSuccess(true);
+    } catch (err) {
+      if (err instanceof ApiError) {
+        if (err.status === 429) {
+          setFormError('Too many attempts. Try again in a few minutes.');
+        } else {
+          setFormError(err.message);
+        }
+      } else {
+        setFormError('Something went wrong');
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <section style={PANEL_STYLE} aria-label="Account settings">
+      <div style={SECTION_HEADER}>Account Settings</div>
+
+      <div style={ROW_STYLE}>
+        <span style={LABEL_STYLE}>Email</span>
+        <span style={VALUE_STYLE} data-testid="account-email">
+          {loadError ? (
+            <span style={ERROR_STYLE}>{loadError}</span>
+          ) : email === null ? (
+            <span style={{ color: '#666' }}>Loading...</span>
+          ) : (
+            email
+          )}
+        </span>
+      </div>
+
+      <form onSubmit={handleSubmit} style={FORM_STYLE} aria-label="Change password">
+        <label style={FIELD_LABEL}>
+          Current password
+          <input
+            style={INPUT_BASE}
+            type="password"
+            autoComplete="current-password"
+            value={currentPassword}
+            onChange={(e) => {
+              setCurrentPassword(e.target.value);
+              setFormError(null);
+              setFormSuccess(false);
+            }}
+          />
+        </label>
+
+        <label style={FIELD_LABEL}>
+          New password
+          <input
+            style={inputStyle(newPassword.length === 0 ? null : newPasswordValid)}
+            type="password"
+            autoComplete="new-password"
+            value={newPassword}
+            onChange={(e) => {
+              setNewPassword(e.target.value);
+              setFormError(null);
+              setFormSuccess(false);
+            }}
+            minLength={PASSWORD_MIN_LEN}
+            aria-describedby="password-rules"
+          />
+          <ul id="password-rules" style={CHECKLIST_STYLE} aria-live="polite">
+            {rules
+              .filter((r) => r.visible)
+              .map((r) => (
+                <RuleItem key={r.id} rule={r} />
+              ))}
+          </ul>
+        </label>
+
+        {formError && <div style={ERROR_STYLE}>{formError}</div>}
+        {formSuccess && (
+          <div style={SUCCESS_STYLE}>Password updated. Other sessions have been signed out.</div>
+        )}
+
+        <button
+          type="submit"
+          disabled={!canSubmit}
+          style={canSubmit ? SUBMIT_BTN : SUBMIT_DISABLED}
+        >
+          {submitting ? '...' : 'Change password'}
+        </button>
+      </form>
+
+      <div style={SECTION_HEADER}>Session</div>
+      <button style={LOGOUT_BTN} onClick={() => void logout()}>
+        Log out
+      </button>
+
+      <div style={SECTION_HEADER}>Coming soon</div>
+      <div style={COMING_SOON_GRID}>
+        <div style={COMING_SOON_TILE} aria-disabled>
+          <div style={COMING_SOON_TITLE}>Change email</div>
+          <span style={COMING_SOON_TAG}>Coming soon</span>
+        </div>
+        <div style={COMING_SOON_TILE} aria-disabled>
+          <div style={COMING_SOON_TITLE}>Delete account</div>
+          <span style={COMING_SOON_TAG}>Coming soon</span>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/pages/profile/ProfileContent.tsx
+++ b/frontend/src/pages/profile/ProfileContent.tsx
@@ -1,0 +1,195 @@
+import { Link } from 'react-router-dom';
+import type { ProfileStats } from '../../api/profile';
+import { SECTION_HEADER, actionLink, formatDate, type ProfileWarrior } from './profileStyles';
+
+/**
+ * Everything both the own-dashboard and the public-view render in common:
+ * header (username + join date), stats cards, and warriors list. Kept as one
+ * component so the two entry points can't drift — before this refactor the
+ * own dashboard had lost the warriors list entirely (see #88).
+ *
+ * The parent (own or public) decides what to render *around* the shared body
+ * (quick actions, account settings, etc.) via the `aboveWarriors` and
+ * `belowWarriors` slots.
+ */
+
+const PAGE_STYLE: React.CSSProperties = {
+  minHeight: '100vh',
+  padding: '2rem',
+  maxWidth: '720px',
+  margin: '0 auto',
+};
+
+const HEADER_STYLE: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'baseline',
+  gap: '1rem',
+  marginBottom: '1.5rem',
+};
+
+const USERNAME_STYLE: React.CSSProperties = {
+  margin: 0,
+  fontSize: '1.8rem',
+  color: '#e94560',
+  letterSpacing: '0.08em',
+};
+
+const JOINED_STYLE: React.CSSProperties = {
+  fontSize: '0.75rem',
+  color: '#666',
+};
+
+const STATS_ROW: React.CSSProperties = {
+  display: 'flex',
+  gap: '1.5rem',
+  marginBottom: '2rem',
+  flexWrap: 'wrap',
+};
+
+const STAT_BOX: React.CSSProperties = {
+  flex: '1 1 100px',
+  padding: '0.75rem 1rem',
+  backgroundColor: '#111',
+  border: '1px solid #222',
+  borderRadius: '6px',
+  textAlign: 'center',
+};
+
+const STAT_VALUE: React.CSSProperties = {
+  fontSize: '1.5rem',
+  fontWeight: 700,
+};
+
+const STAT_LABEL: React.CSSProperties = {
+  fontSize: '0.65rem',
+  color: '#888',
+  textTransform: 'uppercase',
+  letterSpacing: '0.1em',
+  marginTop: '0.25rem',
+};
+
+const WARRIOR_ROW: React.CSSProperties = {
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  padding: '0.5rem 0',
+  borderBottom: '1px solid #1a1a1a',
+};
+
+const WARRIOR_NAME: React.CSSProperties = {
+  color: '#4fc3f7',
+  fontWeight: 600,
+};
+
+const WARRIOR_DATE: React.CSSProperties = {
+  fontSize: '0.7rem',
+  color: '#555',
+};
+
+const EMPTY_STYLE: React.CSSProperties = {
+  color: '#555',
+  fontStyle: 'italic',
+  padding: '1rem 0',
+};
+
+function StatsCards({ stats }: { stats: ProfileStats }) {
+  return (
+    <div style={STATS_ROW}>
+      <div style={STAT_BOX}>
+        <div style={{ ...STAT_VALUE, color: '#4fc3f7' }}>{stats.warrior_count}</div>
+        <div style={STAT_LABEL}>Warriors</div>
+      </div>
+      <div style={STAT_BOX}>
+        <div style={{ ...STAT_VALUE, color: '#4caf50' }}>{stats.wins}</div>
+        <div style={STAT_LABEL}>Wins</div>
+      </div>
+      <div style={STAT_BOX}>
+        <div style={{ ...STAT_VALUE, color: '#e94560' }}>{stats.losses}</div>
+        <div style={STAT_LABEL}>Losses</div>
+      </div>
+      <div style={STAT_BOX}>
+        <div style={{ ...STAT_VALUE, color: '#f0c040' }}>{stats.ties}</div>
+        <div style={STAT_LABEL}>Ties</div>
+      </div>
+      <div style={STAT_BOX}>
+        <div style={{ ...STAT_VALUE, color: '#e0e0e0' }}>{stats.match_count}</div>
+        <div style={STAT_LABEL}>Matches</div>
+      </div>
+    </div>
+  );
+}
+
+function WarriorsList({ warriors, own }: { warriors: ProfileWarrior[]; own: boolean }) {
+  return (
+    <>
+      <div style={SECTION_HEADER}>Warriors ({warriors.length})</div>
+      {warriors.length === 0 ? (
+        <p style={EMPTY_STYLE}>
+          {own ? 'No warriors yet — head to the Builder to write your first.' : 'No warriors yet.'}
+        </p>
+      ) : (
+        warriors.map((w) => (
+          <div key={w.id} style={WARRIOR_ROW} data-testid="warrior-row">
+            <span style={WARRIOR_NAME}>{w.name}</span>
+            <span style={WARRIOR_DATE}>{formatDate(w.updated_at)}</span>
+          </div>
+        ))
+      )}
+    </>
+  );
+}
+
+export type ProfileContentProps = {
+  username: string;
+  createdAt: string;
+  stats: ProfileStats;
+  warriors: ProfileWarrior[];
+  /** Rendered above the warriors list, own-view only (quick actions, etc.). */
+  aboveWarriors?: React.ReactNode;
+  /** Rendered below the warriors list, own-view only (account settings). */
+  belowWarriors?: React.ReactNode;
+  /** Extends the outermost wrapper for callers that need extra bottom padding. */
+  extraStyle?: React.CSSProperties;
+  /** Used by tests + empty-state copy to distinguish own vs. public paths. */
+  own?: boolean;
+};
+
+export default function ProfileContent({
+  username,
+  createdAt,
+  stats,
+  warriors,
+  aboveWarriors,
+  belowWarriors,
+  extraStyle,
+  own = false,
+}: ProfileContentProps) {
+  return (
+    <div style={{ ...PAGE_STYLE, ...extraStyle }}>
+      <div style={HEADER_STYLE}>
+        <h1 style={USERNAME_STYLE}>{username}</h1>
+        <span style={JOINED_STYLE}>Joined {formatDate(createdAt)}</span>
+      </div>
+      <StatsCards stats={stats} />
+      {aboveWarriors}
+      <WarriorsList warriors={warriors} own={own} />
+      {belowWarriors}
+    </div>
+  );
+}
+
+export function QuickActions() {
+  return (
+    <>
+      <div style={SECTION_HEADER}>Quick Actions</div>
+      <div style={{ display: 'flex', gap: '0.75rem', padding: '0.75rem 0' }}>
+        <Link to="/builder" style={actionLink('#4fc3f7')}>
+          New Warrior
+        </Link>
+        <Link to="/lobby" style={actionLink('#e94560')}>
+          Start Battle
+        </Link>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/pages/profile/ProfilePage.test.tsx
+++ b/frontend/src/pages/profile/ProfilePage.test.tsx
@@ -1,0 +1,207 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { MockedFunction } from 'vitest';
+import { render, screen, waitFor, cleanup } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import ProfilePage from './ProfilePage';
+import * as profileApi from '../../api/profile';
+import * as warriorsApi from '../../api/warriors';
+import * as accountApi from '../../api/account';
+import * as AuthContextModule from '../../api/AuthContext';
+
+vi.mock('../../api/profile');
+vi.mock('../../api/warriors');
+vi.mock('../../api/account');
+vi.mock('../../api/AuthContext');
+
+type UseAuthReturn = ReturnType<typeof AuthContextModule.useAuth>;
+
+const mockUseAuth = AuthContextModule.useAuth as MockedFunction<() => UseAuthReturn>;
+const mockGetMyProfile = profileApi.getMyProfile as MockedFunction<typeof profileApi.getMyProfile>;
+const mockGetPublicProfile = profileApi.getPublicProfile as MockedFunction<
+  typeof profileApi.getPublicProfile
+>;
+const mockListWarriors = warriorsApi.listWarriors as MockedFunction<
+  typeof warriorsApi.listWarriors
+>;
+const mockGetAccount = accountApi.getAccount as MockedFunction<typeof accountApi.getAccount>;
+
+const myStats: profileApi.ProfileStats = {
+  user_id: 'u1',
+  username: 'vale',
+  created_at: '2025-01-01T00:00:00Z',
+  warrior_count: 2,
+  match_count: 10,
+  wins: 5,
+  losses: 4,
+  ties: 1,
+};
+
+const myServerWarriors: warriorsApi.ServerWarrior[] = [
+  {
+    id: 'w1',
+    user_id: 'u1',
+    name: 'Imp Redux',
+    source: 'MOV.I $0, $1',
+    created_at: '2025-01-02T00:00:00Z',
+    updated_at: '2025-01-03T00:00:00Z',
+  },
+  {
+    id: 'w2',
+    user_id: 'u1',
+    name: 'Bomber',
+    source: 'DAT #0, #0',
+    created_at: '2025-01-04T00:00:00Z',
+    updated_at: '2025-01-05T00:00:00Z',
+  },
+];
+
+const authedUser: UseAuthReturn = {
+  user: { user_id: 'u1', username: 'vale' },
+  loading: false,
+  login: vi.fn(),
+  register: vi.fn(),
+  logout: vi.fn(),
+};
+
+const anonymous: UseAuthReturn = {
+  user: null,
+  loading: false,
+  login: vi.fn(),
+  register: vi.fn(),
+  logout: vi.fn(),
+};
+
+beforeEach(() => {
+  mockUseAuth.mockReturnValue(authedUser);
+  mockGetMyProfile.mockResolvedValue(myStats);
+  mockListWarriors.mockResolvedValue({
+    warriors: myServerWarriors,
+    total: myServerWarriors.length,
+    page: 1,
+    per_page: 100,
+  });
+  mockGetAccount.mockResolvedValue({ email: 'vale@example.com' });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/profile" element={<ProfilePage />} />
+        <Route path="/users/:username" element={<ProfilePage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('/profile — own dashboard', () => {
+  it('renders the warriors list (the exact bug in #88)', async () => {
+    renderAt('/profile');
+
+    // Wait for warriors to appear.
+    await waitFor(() => {
+      expect(screen.getByText('Imp Redux')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Bomber')).toBeInTheDocument();
+    // Warriors list section header includes the count.
+    expect(screen.getByText(/Warriors \(2\)/)).toBeInTheDocument();
+  });
+
+  it('renders the Account Settings panel', async () => {
+    renderAt('/profile');
+
+    await waitFor(() => {
+      expect(screen.getByRole('region', { name: /account settings/i })).toBeInTheDocument();
+    });
+    expect(screen.getByRole('form', { name: /change password/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /log out/i })).toBeInTheDocument();
+  });
+
+  it('Start Battle Quick Action points to /lobby (not /battle)', async () => {
+    renderAt('/profile');
+
+    const startBattle = await screen.findByRole('link', { name: /start battle/i });
+    expect(startBattle).toHaveAttribute('href', '/lobby');
+  });
+
+  it('displays the email in the Account Settings panel', async () => {
+    renderAt('/profile');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('account-email')).toHaveTextContent('vale@example.com');
+    });
+  });
+});
+
+describe('/users/:username — public profile', () => {
+  const otherWarriors: profileApi.PublicWarrior[] = [
+    {
+      id: 'ow1',
+      name: 'Public Warrior',
+      created_at: '2025-02-01T00:00:00Z',
+      updated_at: '2025-02-02T00:00:00Z',
+    },
+  ];
+
+  const publicProfile: profileApi.PublicProfile = {
+    user_id: 'u2',
+    username: 'orion',
+    created_at: '2024-06-01T00:00:00Z',
+    warrior_count: 1,
+    match_count: 3,
+    wins: 2,
+    losses: 1,
+    ties: 0,
+    warriors: otherWarriors,
+  };
+
+  beforeEach(() => {
+    mockGetPublicProfile.mockResolvedValue(publicProfile);
+  });
+
+  it('renders warriors list from the public endpoint', async () => {
+    renderAt('/users/orion');
+
+    await waitFor(() => {
+      expect(screen.getByText('Public Warrior')).toBeInTheDocument();
+    });
+    // Public endpoint drives the fetch; the /api/warriors endpoint must not
+    // be called (it would 401 for a stranger looking at your profile).
+    expect(mockListWarriors).not.toHaveBeenCalled();
+  });
+
+  it('does NOT render the Account Settings panel', async () => {
+    renderAt('/users/orion');
+
+    await waitFor(() => {
+      expect(screen.getByText('Public Warrior')).toBeInTheDocument();
+    });
+    expect(screen.queryByRole('region', { name: /account settings/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('form', { name: /change password/i })).not.toBeInTheDocument();
+  });
+
+  it('does NOT render Quick Actions (no Start Battle link)', async () => {
+    renderAt('/users/orion');
+
+    await waitFor(() => {
+      expect(screen.getByText('Public Warrior')).toBeInTheDocument();
+    });
+    expect(screen.queryByRole('link', { name: /start battle/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /new warrior/i })).not.toBeInTheDocument();
+  });
+});
+
+describe('/profile — not logged in', () => {
+  it('renders a login prompt', () => {
+    mockUseAuth.mockReturnValue(anonymous);
+    renderAt('/profile');
+
+    expect(screen.getByText(/log in to view your dashboard/i)).toBeInTheDocument();
+    expect(mockGetMyProfile).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/pages/profile/ProfilePage.tsx
+++ b/frontend/src/pages/profile/ProfilePage.tsx
@@ -1,100 +1,28 @@
 import { useEffect, useState } from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { useAuth } from '../../api/AuthContext';
-import {
-  getMyProfile,
-  getPublicProfile,
-  type ProfileStats,
-  type PublicProfile,
-} from '../../api/profile';
+import { getMyProfile, getPublicProfile, type PublicProfile } from '../../api/profile';
+import { listWarriors } from '../../api/warriors';
+import ProfileContent, { QuickActions } from './ProfileContent';
+import type { ProfileWarrior } from './profileStyles';
+import AccountSettings from './AccountSettings';
+
+/**
+ * Two entry paths, one shared render (see ProfileContent):
+ * - `/profile` (own dashboard): stats + warriors + Quick Actions + Account Settings.
+ * - `/users/:username` (public view): stats + warriors only.
+ *
+ * The own dashboard fetches warriors from the existing `/api/warriors`
+ * endpoint rather than extending `/api/profile` — the public endpoint
+ * already returns warrior rows on its own, so the two paths converge on
+ * the same visual list without a backend contract change.
+ */
 
 const PAGE_STYLE: React.CSSProperties = {
   minHeight: '100vh',
   padding: '2rem',
   maxWidth: '720px',
   margin: '0 auto',
-};
-
-const HEADER_STYLE: React.CSSProperties = {
-  display: 'flex',
-  alignItems: 'baseline',
-  gap: '1rem',
-  marginBottom: '1.5rem',
-};
-
-const USERNAME_STYLE: React.CSSProperties = {
-  margin: 0,
-  fontSize: '1.8rem',
-  color: '#e94560',
-  letterSpacing: '0.08em',
-};
-
-const JOINED_STYLE: React.CSSProperties = {
-  fontSize: '0.75rem',
-  color: '#666',
-};
-
-const STATS_ROW: React.CSSProperties = {
-  display: 'flex',
-  gap: '1.5rem',
-  marginBottom: '2rem',
-  flexWrap: 'wrap',
-};
-
-const STAT_BOX: React.CSSProperties = {
-  flex: '1 1 100px',
-  padding: '0.75rem 1rem',
-  backgroundColor: '#111',
-  border: '1px solid #222',
-  borderRadius: '6px',
-  textAlign: 'center',
-};
-
-const STAT_VALUE: React.CSSProperties = {
-  fontSize: '1.5rem',
-  fontWeight: 700,
-};
-
-const STAT_LABEL: React.CSSProperties = {
-  fontSize: '0.65rem',
-  color: '#888',
-  textTransform: 'uppercase',
-  letterSpacing: '0.1em',
-  marginTop: '0.25rem',
-};
-
-const SECTION_HEADER: React.CSSProperties = {
-  fontSize: '0.7rem',
-  letterSpacing: '0.1em',
-  color: '#666',
-  textTransform: 'uppercase',
-  padding: '0.5rem 0',
-  borderBottom: '1px solid #222',
-  marginBottom: '0.5rem',
-};
-
-const WARRIOR_ROW: React.CSSProperties = {
-  display: 'flex',
-  justifyContent: 'space-between',
-  alignItems: 'center',
-  padding: '0.5rem 0',
-  borderBottom: '1px solid #1a1a1a',
-};
-
-const WARRIOR_NAME: React.CSSProperties = {
-  color: '#4fc3f7',
-  fontWeight: 600,
-};
-
-const WARRIOR_DATE: React.CSSProperties = {
-  fontSize: '0.7rem',
-  color: '#555',
-};
-
-const EMPTY_STYLE: React.CSSProperties = {
-  color: '#555',
-  fontStyle: 'italic',
-  padding: '1rem 0',
 };
 
 const LOGIN_PROMPT: React.CSSProperties = {
@@ -107,43 +35,28 @@ const LOGIN_PROMPT: React.CSSProperties = {
   color: '#888',
 };
 
-function formatDate(iso: string): string {
-  return new Date(iso).toLocaleDateString(undefined, {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-  });
+function LoadingPage() {
+  return (
+    <div style={PAGE_STYLE}>
+      <p style={{ color: '#888' }}>Loading...</p>
+    </div>
+  );
 }
 
-function StatsCards({ stats }: { stats: ProfileStats }) {
+function ErrorPage({ message }: { message: string }) {
   return (
-    <div style={STATS_ROW}>
-      <div style={STAT_BOX}>
-        <div style={{ ...STAT_VALUE, color: '#4fc3f7' }}>{stats.warrior_count}</div>
-        <div style={STAT_LABEL}>Warriors</div>
-      </div>
-      <div style={STAT_BOX}>
-        <div style={{ ...STAT_VALUE, color: '#4caf50' }}>{stats.wins}</div>
-        <div style={STAT_LABEL}>Wins</div>
-      </div>
-      <div style={STAT_BOX}>
-        <div style={{ ...STAT_VALUE, color: '#e94560' }}>{stats.losses}</div>
-        <div style={STAT_LABEL}>Losses</div>
-      </div>
-      <div style={STAT_BOX}>
-        <div style={{ ...STAT_VALUE, color: '#f0c040' }}>{stats.ties}</div>
-        <div style={STAT_LABEL}>Ties</div>
-      </div>
-      <div style={STAT_BOX}>
-        <div style={{ ...STAT_VALUE, color: '#e0e0e0' }}>{stats.match_count}</div>
-        <div style={STAT_LABEL}>Matches</div>
-      </div>
+    <div style={PAGE_STYLE}>
+      <p style={{ color: '#e94560' }}>{message}</p>
     </div>
   );
 }
 
 function MyDashboard() {
-  const [profile, setProfile] = useState<ProfileStats | null>(null);
+  // Two independent fetches — profile stats and warriors — because we
+  // deliberately don't extend /api/profile with a warriors array. If either
+  // fails, we render an error, but the two are otherwise decoupled.
+  const [profile, setProfile] = useState<Awaited<ReturnType<typeof getMyProfile>> | null>(null);
+  const [warriors, setWarriors] = useState<ProfileWarrior[] | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -160,36 +73,44 @@ function MyDashboard() {
     };
   }, []);
 
-  if (error)
-    return (
-      <div style={PAGE_STYLE}>
-        <p style={{ color: '#e94560' }}>{error}</p>
-      </div>
-    );
-  if (!profile)
-    return (
-      <div style={PAGE_STYLE}>
-        <p style={{ color: '#888' }}>Loading...</p>
-      </div>
-    );
+  useEffect(() => {
+    let cancelled = false;
+    // Grab up to 100 warriors — matches the Builder's page size cap. If a
+    // user ever exceeds that we'll add pagination to the profile too; today
+    // it's a non-issue.
+    listWarriors(1, 100)
+      .then((resp) => {
+        if (!cancelled) {
+          setWarriors(
+            resp.warriors.map((w) => ({
+              id: w.id,
+              name: w.name,
+              updated_at: w.updated_at,
+            })),
+          );
+        }
+      })
+      .catch((e) => {
+        if (!cancelled) setError(e instanceof Error ? e.message : 'Failed to load warriors');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (error) return <ErrorPage message={error} />;
+  if (!profile || warriors === null) return <LoadingPage />;
 
   return (
-    <div style={PAGE_STYLE}>
-      <div style={HEADER_STYLE}>
-        <h1 style={USERNAME_STYLE}>{profile.username}</h1>
-        <span style={JOINED_STYLE}>Joined {formatDate(profile.created_at)}</span>
-      </div>
-      <StatsCards stats={profile} />
-      <div style={SECTION_HEADER}>Quick Actions</div>
-      <div style={{ display: 'flex', gap: '0.75rem', padding: '0.75rem 0' }}>
-        <Link to="/builder" style={actionLink('#4fc3f7')}>
-          New Warrior
-        </Link>
-        <Link to="/battle" style={actionLink('#e94560')}>
-          Start Battle
-        </Link>
-      </div>
-    </div>
+    <ProfileContent
+      username={profile.username}
+      createdAt={profile.created_at}
+      stats={profile}
+      warriors={warriors}
+      own
+      aboveWarriors={<QuickActions />}
+      belowWarriors={<AccountSettings />}
+    />
   );
 }
 
@@ -198,66 +119,41 @@ function PublicProfileView({ username }: { username: string }) {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
+    let cancelled = false;
     getPublicProfile(username)
-      .then(setProfile)
-      .catch((e) => setError(e instanceof Error ? e.message : 'Failed to load profile'));
+      .then((p) => {
+        if (!cancelled) setProfile(p);
+      })
+      .catch((e) => {
+        if (!cancelled) setError(e instanceof Error ? e.message : 'Failed to load profile');
+      });
+    return () => {
+      cancelled = true;
+    };
   }, [username]);
 
-  if (error)
-    return (
-      <div style={PAGE_STYLE}>
-        <p style={{ color: '#e94560' }}>{error}</p>
-      </div>
-    );
-  if (!profile)
-    return (
-      <div style={PAGE_STYLE}>
-        <p style={{ color: '#888' }}>Loading...</p>
-      </div>
-    );
+  if (error) return <ErrorPage message={error} />;
+  if (!profile) return <LoadingPage />;
 
   return (
-    <div style={PAGE_STYLE}>
-      <div style={HEADER_STYLE}>
-        <h1 style={USERNAME_STYLE}>{profile.username}</h1>
-        <span style={JOINED_STYLE}>Joined {formatDate(profile.created_at)}</span>
-      </div>
-      <StatsCards stats={profile} />
-      <div style={SECTION_HEADER}>Warriors ({profile.warriors.length})</div>
-      {profile.warriors.length === 0 ? (
-        <p style={EMPTY_STYLE}>No warriors yet.</p>
-      ) : (
-        profile.warriors.map((w) => (
-          <div key={w.id} style={WARRIOR_ROW}>
-            <span style={WARRIOR_NAME}>{w.name}</span>
-            <span style={WARRIOR_DATE}>{formatDate(w.updated_at)}</span>
-          </div>
-        ))
-      )}
-    </div>
+    <ProfileContent
+      username={profile.username}
+      createdAt={profile.created_at}
+      stats={profile}
+      warriors={profile.warriors.map((w) => ({
+        id: w.id,
+        name: w.name,
+        updated_at: w.updated_at,
+      }))}
+    />
   );
 }
-
-const actionLink = (color: string): React.CSSProperties => ({
-  padding: '0.5rem 1rem',
-  fontSize: '0.8rem',
-  color,
-  textDecoration: 'none',
-  border: `1px solid ${color}66`,
-  borderRadius: '4px',
-  backgroundColor: `${color}11`,
-});
 
 export default function ProfilePage() {
   const { username } = useParams<{ username: string }>();
   const { user, loading } = useAuth();
 
-  if (loading)
-    return (
-      <div style={PAGE_STYLE}>
-        <p style={{ color: '#888' }}>Loading...</p>
-      </div>
-    );
+  if (loading) return <LoadingPage />;
 
   if (username) {
     return <PublicProfileView username={username} />;

--- a/frontend/src/pages/profile/passwordRules.ts
+++ b/frontend/src/pages/profile/passwordRules.ts
@@ -1,0 +1,47 @@
+// Password rules mirror backend `validate_password` in auth/handlers.rs.
+// Keep the numbers in sync: bumping the backend minimum without updating
+// the checklist here means users see a green checkmark then get rejected
+// on submit — the exact confusion the checklist was added to avoid.
+export const PASSWORD_MIN_LEN = 12;
+export const PASSWORD_MAX_LEN = 1000;
+
+export type PasswordRuleId = 'length' | 'non_digit' | 'too_long';
+
+export type PasswordRule = {
+  id: PasswordRuleId;
+  label: string;
+  ok: boolean;
+  /**
+   * Some rules only matter when violated (e.g. "≤ 1000 chars"). We hide
+   * those in the happy path to keep the checklist short and readable.
+   */
+  visible: boolean;
+};
+
+export function checkPasswordRules(pw: string): PasswordRule[] {
+  const hasNonDigit = /[^0-9]/.test(pw);
+  return [
+    {
+      id: 'length',
+      label: `At least ${PASSWORD_MIN_LEN} characters`,
+      ok: pw.length >= PASSWORD_MIN_LEN,
+      visible: true,
+    },
+    {
+      id: 'non_digit',
+      label: 'Contains at least one non-digit character',
+      ok: hasNonDigit,
+      visible: true,
+    },
+    {
+      id: 'too_long',
+      label: `At most ${PASSWORD_MAX_LEN} characters`,
+      ok: pw.length <= PASSWORD_MAX_LEN,
+      visible: pw.length > PASSWORD_MAX_LEN,
+    },
+  ];
+}
+
+export function passwordMeetsRules(pw: string): boolean {
+  return checkPasswordRules(pw).every((r) => r.ok);
+}

--- a/frontend/src/pages/profile/profileStyles.ts
+++ b/frontend/src/pages/profile/profileStyles.ts
@@ -1,0 +1,42 @@
+// Shared style tokens and small formatters for the profile pages. Kept
+// separate from ProfileContent.tsx so a component file exports only
+// components (react-refresh happy path).
+
+export const SECTION_HEADER: React.CSSProperties = {
+  fontSize: '0.7rem',
+  letterSpacing: '0.1em',
+  color: '#666',
+  textTransform: 'uppercase',
+  padding: '0.5rem 0',
+  borderBottom: '1px solid #222',
+  marginBottom: '0.5rem',
+};
+
+export const actionLink = (color: string): React.CSSProperties => ({
+  padding: '0.5rem 1rem',
+  fontSize: '0.8rem',
+  color,
+  textDecoration: 'none',
+  border: `1px solid ${color}66`,
+  borderRadius: '4px',
+  backgroundColor: `${color}11`,
+});
+
+export function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+/**
+ * A single item in the warriors list. Only the fields the row actually
+ * renders are required — callers can pass either the public-profile shape
+ * (with `updated_at`) or the raw warriors-list shape.
+ */
+export type ProfileWarrior = {
+  id: string;
+  name: string;
+  updated_at: string;
+};


### PR DESCRIPTION
Closes #88.

## Summary

Fixes the surprising asymmetry where `/users/<username>` (public) shows more about a user than `/profile` (own dashboard) shows about themselves. Own dashboard is now a strict superset of the public view:

- Renders everything the public view does — username, join date, stats, warriors list — via a single shared `ProfileContent` component so the two entry paths can't drift.
- Adds an Account Settings panel: email display, change-password form with a live requirements checklist, logout, and clearly labeled coming-soon tiles for change-email and delete-account.
- Fix small target bug: Start Battle Quick Action now navigates to `/lobby` instead of `/battle` (the local sandbox is still one nav click away, but the profile CTA is "find a match").

Design decisions worth calling out:

- **Warriors list on own view sources from `GET /api/warriors`**, not from an extended `/api/profile`. Keeps the profile endpoint as an anonymous-safe view of a user without hand-rolling per-endpoint auth branching. The issue's own recommendation was "reuse the Builder's `useWarriorLibrary` hook", which is close but the hook filters out timestamps and mixes in presets — calling the endpoint directly matches the row layout of the public view without a backend contract change, in the same spirit.
- **New `POST /api/auth/change-password`** deliberately revokes *all* refresh tokens for the user (not just the current one) inside the transaction with the hash update, and then issues a fresh access+refresh pair so the current session survives. Standard "log out everywhere else on password change" hygiene.
- **New `GET /api/account`** for the account-settings surface, keeping `/api/profile` untouched. Room to grow the settings surface without leaking private state through the anonymous route.
- Rate-limited change-password at 5 attempts/15min (same shape as login) since it verifies the current password and is a plausible brute-force surface even with a valid session cookie.

## Acceptance checklist (from #88)

- [x] `/profile` shows everything `/users/<self>` shows, plus the account settings panel — verified in the browser: own dashboard renders `Warriors (2)` list and Account Settings section; public view renders warriors only.
- [x] Warriors list rendered on own dashboard with the same row layout as the public view — same `ProfileContent`/`WarriorsList` render path for both.
- [x] Account settings panel includes email, change-password form, logout, and change-email + delete-account coming-soon tiles.
- [x] Start Battle Quick Action → `/lobby` (`ProfilePage.tsx` change; a Vitest asserts the `href`).
- [x] Two render paths share a single component — `MyDashboard` and `PublicProfileView` both delegate to `ProfileContent` for username, stats, and warriors list.
- [x] Vitest covers own view rendering warriors, public view not rendering account settings, Start Battle → `/lobby`, plus change-password happy/error paths.

Out of scope (matches the issue): avatars, public/private warrior visibility.

## Test plan

- [x] `cargo fmt` — clean.
- [x] `cargo clippy --all-targets -- -D warnings` — clean.
- [x] `cargo test` (backend, integration + unit) — 113 unit + 61 integration tests, all pass. New tests:
    - `change_password_success_updates_hash_and_keeps_session`
    - `change_password_wrong_current_rejected`
    - `change_password_rejects_weak_new_password`
    - `change_password_rejects_same_password`
    - `change_password_requires_auth`
    - `change_password_revokes_all_refresh_tokens`
    - `account_returns_email_for_authed_user`
    - `account_normalizes_email_to_lowercase`
    - `account_requires_authentication`
- [x] `npm run lint` — no new warnings (one pre-existing `AuthContext.tsx` warning I confirmed exists on master).
- [x] `npm run format:check` — clean.
- [x] `npm test` — 74 pass (added `ProfilePage.test.tsx`, `AccountSettings.test.tsx`).
- [x] `npm run build` — clean.
- [x] Playwright MCP against a fresh backend + frontend:
    - Logged in as a user with 2 saved warriors, visited `/profile` — warriors list, stats, Quick Actions with Start Battle → `/lobby`, and full Account Settings panel all render.
    - Visited `/users/<self>` — same warriors list + stats, **no** Account Settings, **no** Quick Actions.
    - Visited `/users/<other>` — the other user's warrior + stats only.
    - Submitted change-password with wrong current password → "Current password is incorrect" surfaced.
    - Submitted change-password with correct current + new password → "Password updated. Other sessions have been signed out." success message. Verified via API that the new password logs in and the old password does not.

## Files touched

Backend:
- `backend/src/account/{mod,handlers}.rs` — new module; `GET /api/account` returns `{ email }`.
- `backend/src/auth/handlers.rs` — new `change_password` handler with argon2 verify, `validate_password` reuse, refresh-token wipeout in a transaction, and fresh cookie issuance.
- `backend/src/auth/rate_limit.rs` — `change_password_limiter` (5/15min).
- `backend/src/main.rs`, `backend/src/lib.rs` — route wiring.
- `backend/tests/{account_integration,auth_integration}.rs` — coverage per above.

Frontend:
- `frontend/src/api/account.ts` — new API client.
- `frontend/src/pages/profile/ProfileContent.tsx` — shared render.
- `frontend/src/pages/profile/AccountSettings.tsx` — own-view panel.
- `frontend/src/pages/profile/passwordRules.ts`, `profileStyles.ts` — non-component exports isolated so react-refresh stays green.
- `frontend/src/pages/profile/ProfilePage.tsx` — refactored to route through `ProfileContent` for both entry paths.
- `frontend/src/pages/profile/{ProfilePage,AccountSettings}.test.tsx` — new coverage.