### PR TITLE
Refresh-on-401 interceptor + socket reauth recovery (#86, #60)

### DIFF
--- a/frontend/src/api/AuthContext.tsx
+++ b/frontend/src/api/AuthContext.tsx
@@ -1,6 +1,7 @@
 import { createContext, useCallback, useContext, useEffect, useState } from 'react';
 import type { ReactNode } from 'react';
 import * as authApi from './auth';
+import { registerSessionHandlers } from './session';
 
 type AuthState = {
   user: authApi.AuthUser | null;
@@ -15,6 +16,17 @@ const AuthContext = createContext<AuthState | null>(null);
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<authApi.AuthUser | null>(null);
   const [loading, setLoading] = useState(true);
+
+  // Wire session.ts's forceLogout() to setUser(null) so the REST interceptor
+  // (client.ts) and any socket-auth recovery flow (socketAuth.ts) can reset
+  // the UI without needing to route through a component ref or a global
+  // event bus. Registered inside a useEffect so the setUser closure is
+  // recreated after every remount instead of pinning a stale one.
+  useEffect(() => {
+    return registerSessionHandlers({
+      onForceLogout: () => setUser(null),
+    });
+  }, []);
 
   useEffect(() => {
     authApi

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { api, ApiError } from './client';
+import { __resetSessionForTests, registerSessionHandlers, SessionExpiredError } from './session';
+
+type FetchMockPlan = Array<{ status: number; body?: unknown }>;
+
+function planFetch(plan: FetchMockPlan): ReturnType<typeof vi.fn> {
+  let idx = 0;
+  return vi.fn().mockImplementation(async (): Promise<Response> => {
+    const entry = plan[Math.min(idx, plan.length - 1)];
+    idx += 1;
+    return {
+      ok: entry.status >= 200 && entry.status < 300,
+      status: entry.status,
+      statusText: 'test',
+      json: async () => entry.body ?? {},
+    } as Response;
+  });
+}
+
+describe('api client refresh-on-401 interceptor', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    __resetSessionForTests();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    __resetSessionForTests();
+  });
+
+  it('passes 2xx responses straight through without touching refresh', async () => {
+    globalThis.fetch = planFetch([{ status: 200, body: { ok: true } }]);
+    await expect(api.get<{ ok: boolean }>('/api/warriors')).resolves.toEqual({ ok: true });
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('recovers a 401 by refreshing and retrying — no error surfaces', async () => {
+    // Sequence: warriors 401, refresh 200, warriors 200
+    globalThis.fetch = planFetch([
+      { status: 401, body: { error: 'Missing access token' } },
+      { status: 200 },
+      { status: 200, body: { warriors: [] } },
+    ]);
+    await expect(api.get<{ warriors: unknown[] }>('/api/warriors')).resolves.toEqual({
+      warriors: [],
+    });
+    // 1st: warriors 401, 2nd: refresh, 3rd: warriors retry.
+    expect(globalThis.fetch).toHaveBeenCalledTimes(3);
+  });
+
+  it('clears user via forceLogout and throws SessionExpiredError when refresh fails', async () => {
+    globalThis.fetch = planFetch([
+      { status: 401, body: { error: 'Missing access token' } },
+      { status: 401, body: { error: 'Missing refresh token' } },
+    ]);
+    const forceLogoutSpy = vi.fn();
+    registerSessionHandlers({ onForceLogout: forceLogoutSpy });
+
+    await expect(api.get('/api/warriors')).rejects.toBeInstanceOf(SessionExpiredError);
+    expect(forceLogoutSpy).toHaveBeenCalledTimes(1);
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('clears user and throws SessionExpiredError when retry still 401s after successful refresh', async () => {
+    globalThis.fetch = planFetch([
+      { status: 401 },
+      { status: 200 }, // refresh
+      { status: 401 }, // retry still 401
+    ]);
+    const forceLogoutSpy = vi.fn();
+    registerSessionHandlers({ onForceLogout: forceLogoutSpy });
+
+    await expect(api.get('/api/warriors')).rejects.toBeInstanceOf(SessionExpiredError);
+    expect(forceLogoutSpy).toHaveBeenCalledTimes(1);
+    expect(globalThis.fetch).toHaveBeenCalledTimes(3);
+  });
+
+  it('does NOT attempt refresh on 401 from auth endpoints (avoids loops)', async () => {
+    globalThis.fetch = planFetch([{ status: 401, body: { error: 'Invalid credentials' } }]);
+    await expect(
+      api.post('/api/auth/login', { username_or_email: 'x', password: 'y' }),
+    ).rejects.toMatchObject({ status: 401, message: 'Invalid credentials' });
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('propagates non-401 errors without engaging refresh', async () => {
+    globalThis.fetch = planFetch([{ status: 500, body: { error: 'Internal server error' } }]);
+    await expect(api.get('/api/warriors')).rejects.toBeInstanceOf(ApiError);
+    await expect(api.get('/api/warriors')).rejects.toMatchObject({ status: 500 });
+  });
+
+  it('a burst of parallel 401s triggers exactly one refresh', async () => {
+    // Plan: infinite refresh interleaved with per-request 401s and then 200s.
+    // We can't easily use a positional plan here because ordering across
+    // parallel calls is nondeterministic. Instead, hand-roll a fetch mock
+    // that classifies by URL and refresh-succeeds after the first call.
+    let refreshCount = 0;
+    const perPathState: Record<string, { hit: number }> = {};
+    globalThis.fetch = vi.fn().mockImplementation(async (url: string): Promise<Response> => {
+      const path = new URL(String(url), 'http://x').pathname;
+      if (path === '/api/auth/refresh') {
+        refreshCount += 1;
+        return {
+          ok: true,
+          status: 200,
+          statusText: 'ok',
+          json: async () => ({}),
+        } as Response;
+      }
+      const state = (perPathState[path] ??= { hit: 0 });
+      state.hit += 1;
+      const status = state.hit === 1 ? 401 : 200;
+      return {
+        ok: status === 200,
+        status,
+        statusText: 'test',
+        json: async () => ({ path, hit: state.hit }),
+      } as Response;
+    });
+
+    const results = await Promise.all([
+      api.get<{ hit: number }>('/api/warriors'),
+      api.get<{ hit: number }>('/api/profile'),
+      api.get<{ hit: number }>('/api/leaderboard'),
+    ]);
+    for (const r of results) {
+      expect(r.hit).toBe(2);
+    }
+    expect(refreshCount).toBe(1);
+  });
+
+  it('sends credentials on every request so the cookie jar rides along', async () => {
+    globalThis.fetch = planFetch([{ status: 200, body: {} }]);
+    await api.get('/api/warriors');
+    const [, init] = (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect((init as RequestInit).credentials).toBe('include');
+  });
+});

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,25 +1,55 @@
+import { ApiError, SessionExpiredError } from './errors';
+import { attemptRefresh, forceLogout, isAuthEndpoint } from './session';
+
+// Re-exported so existing consumers `import { ApiError } from './client'`
+// keep working — the class itself now lives in `./errors` to break a
+// circular import with `./session`.
+export { ApiError, SessionExpiredError };
+
 const API_BASE = import.meta.env.VITE_API_URL ?? 'http://localhost:3001';
 
-export class ApiError extends Error {
-  constructor(
-    public status: number,
-    message: string,
-  ) {
-    super(message);
-    this.name = 'ApiError';
-  }
-}
-
-async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
-  const res = await fetch(`${API_BASE}${path}`, {
+async function performRequest(path: string, options: RequestInit): Promise<Response> {
+  return fetch(`${API_BASE}${path}`, {
     credentials: 'include',
     headers: { 'Content-Type': 'application/json', ...options.headers },
     ...options,
   });
+}
+
+async function parseErrorBody(res: Response): Promise<string> {
+  const body = await res.json().catch(() => ({ error: res.statusText }));
+  return body.error ?? res.statusText;
+}
+
+async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
+  let res = await performRequest(path, options);
+
+  // Refresh-on-401 interceptor. The 15-minute access-token cookie will
+  // routinely expire mid-session; the backend also gives us a 7-day refresh
+  // cookie that can silently mint a fresh access token. Auth endpoints bypass
+  // this — a 401 from /login means "wrong password", not "session expired",
+  // and looping /refresh → /login → 401 would be a bad time.
+  if (res.status === 401 && !isAuthEndpoint(path)) {
+    const refreshed = await attemptRefresh();
+    if (refreshed) {
+      res = await performRequest(path, options);
+      if (res.status === 401) {
+        // Retry still failed after a successful refresh — the endpoint is
+        // rejecting us for a real reason (e.g. deleted user, revoked
+        // permission). Surface it as a session-expired error and clear
+        // client-side auth state so the UI can prompt for re-login.
+        forceLogout();
+        throw new SessionExpiredError();
+      }
+    } else {
+      // Refresh cookie missing / expired / rejected — same treatment.
+      forceLogout();
+      throw new SessionExpiredError();
+    }
+  }
 
   if (!res.ok) {
-    const body = await res.json().catch(() => ({ error: res.statusText }));
-    throw new ApiError(res.status, body.error ?? res.statusText);
+    throw new ApiError(res.status, await parseErrorBody(res));
   }
 
   if (res.status === 204) return undefined as T;

--- a/frontend/src/api/errors.ts
+++ b/frontend/src/api/errors.ts
@@ -1,0 +1,35 @@
+// Error hierarchy for the API layer. Lifted out of `client.ts` and
+// `session.ts` because those two modules would otherwise form a circular
+// import — session.ts needs ApiError to subclass, and client.ts needs
+// SessionExpiredError to throw. Both types live here; both files
+// re-export whatever they need to keep their public surfaces stable.
+
+/**
+ * Any non-2xx response the server sends back — the base class other error
+ * types (like SessionExpiredError) subclass. The interceptor and any
+ * higher-level catch that wants to inspect status/message should key off
+ * `instanceof ApiError`.
+ */
+export class ApiError extends Error {
+  constructor(
+    public status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'ApiError';
+  }
+}
+
+/**
+ * Thrown when refresh has definitively failed and the caller should treat
+ * the session as gone. Subclasses `ApiError` so existing
+ * `instanceof ApiError` catches (e.g. `getMe()` returning null on 401)
+ * keep working; carries user-facing copy instead of raw backend
+ * "Missing access token" strings.
+ */
+export class SessionExpiredError extends ApiError {
+  constructor(message = 'Your session has expired. Please log in again.') {
+    super(401, message);
+    this.name = 'SessionExpiredError';
+  }
+}

--- a/frontend/src/api/session.test.ts
+++ b/frontend/src/api/session.test.ts
@@ -1,0 +1,175 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  __resetSessionForTests,
+  attemptRefresh,
+  forceLogout,
+  isAuthEndpoint,
+  registerSessionHandlers,
+  SessionExpiredError,
+} from './session';
+import { ApiError } from './client';
+
+const REFRESH_URL_SUFFIX = '/api/auth/refresh';
+
+function mockFetchWithDelay(status: number, delayMs: number): ReturnType<typeof vi.fn> {
+  return vi.fn().mockImplementation(
+    () =>
+      new Promise((resolve) => {
+        setTimeout(
+          () =>
+            resolve({
+              ok: status >= 200 && status < 300,
+              status,
+              json: async () => ({}),
+            } as Response),
+          delayMs,
+        );
+      }),
+  );
+}
+
+describe('session', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    __resetSessionForTests();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    __resetSessionForTests();
+  });
+
+  describe('SessionExpiredError', () => {
+    it('is an ApiError with status 401 and a friendly default message', () => {
+      const err = new SessionExpiredError();
+      expect(err).toBeInstanceOf(ApiError);
+      expect(err.status).toBe(401);
+      expect(err.message).toMatch(/session has expired/i);
+      expect(err.name).toBe('SessionExpiredError');
+    });
+
+    it('accepts a custom message', () => {
+      const err = new SessionExpiredError('custom');
+      expect(err.message).toBe('custom');
+    });
+  });
+
+  describe('isAuthEndpoint', () => {
+    it.each([
+      ['/api/auth/refresh', true],
+      ['/api/auth/login', true],
+      ['/api/auth/register', true],
+      ['/api/auth/logout', true],
+      ['/api/auth/me', false],
+      ['/api/warriors', false],
+      ['/api/warriors/foo', false],
+    ])('returns %s for %s', (path, expected) => {
+      expect(isAuthEndpoint(path)).toBe(expected);
+    });
+
+    it('ignores query strings', () => {
+      expect(isAuthEndpoint('/api/auth/login?next=/lobby')).toBe(true);
+      expect(isAuthEndpoint('/api/warriors?page=1')).toBe(false);
+    });
+
+    it('tolerates trailing slashes', () => {
+      expect(isAuthEndpoint('/api/auth/login/')).toBe(true);
+    });
+  });
+
+  describe('attemptRefresh', () => {
+    it('resolves true when POST /api/auth/refresh returns 2xx', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({}),
+      } as Response);
+      await expect(attemptRefresh()).resolves.toBe(true);
+      expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+      const [url, init] = (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(String(url)).toContain(REFRESH_URL_SUFFIX);
+      expect((init as RequestInit).method).toBe('POST');
+      expect((init as RequestInit).credentials).toBe('include');
+    });
+
+    it('resolves false when the endpoint returns 401', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+        json: async () => ({}),
+      } as Response);
+      await expect(attemptRefresh()).resolves.toBe(false);
+    });
+
+    it('resolves false on a network error (does not throw)', async () => {
+      globalThis.fetch = vi.fn().mockRejectedValue(new TypeError('network dead'));
+      await expect(attemptRefresh()).resolves.toBe(false);
+    });
+
+    it('single-flights concurrent callers — one fetch, one shared resolution', async () => {
+      globalThis.fetch = mockFetchWithDelay(200, 25);
+      const [a, b, c] = await Promise.all([attemptRefresh(), attemptRefresh(), attemptRefresh()]);
+      expect([a, b, c]).toEqual([true, true, true]);
+      expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('allows a fresh attempt after the previous one settles', async () => {
+      globalThis.fetch = mockFetchWithDelay(200, 5);
+      await attemptRefresh();
+      await attemptRefresh();
+      expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('propagates failure to concurrent callers and still clears in-flight state', async () => {
+      globalThis.fetch = mockFetchWithDelay(401, 10);
+      const [a, b] = await Promise.all([attemptRefresh(), attemptRefresh()]);
+      expect([a, b]).toEqual([false, false]);
+      expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+
+      // A follow-up succeeds — in-flight guard cleared.
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({}),
+      } as Response);
+      await expect(attemptRefresh()).resolves.toBe(true);
+    });
+  });
+
+  describe('forceLogout / registerSessionHandlers', () => {
+    it('invokes the registered handler', () => {
+      const spy = vi.fn();
+      registerSessionHandlers({ onForceLogout: spy });
+      forceLogout();
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('is a no-op before any handler is registered', () => {
+      // Reset to defaults; verify forceLogout does not throw.
+      __resetSessionForTests();
+      expect(() => forceLogout()).not.toThrow();
+    });
+
+    it('unregisters via the returned teardown, restoring the no-op default', () => {
+      const spy = vi.fn();
+      const unregister = registerSessionHandlers({ onForceLogout: spy });
+      unregister();
+      forceLogout();
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('teardown from a stale registration does not clobber a newer one', () => {
+      const oldSpy = vi.fn();
+      const newSpy = vi.fn();
+      const oldTeardown = registerSessionHandlers({ onForceLogout: oldSpy });
+      registerSessionHandlers({ onForceLogout: newSpy });
+      // The teardown from the *older* registration should be a no-op now
+      // because the current handlers are the newer ones.
+      oldTeardown();
+      forceLogout();
+      expect(oldSpy).not.toHaveBeenCalled();
+      expect(newSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/frontend/src/api/session.ts
+++ b/frontend/src/api/session.ts
@@ -1,0 +1,117 @@
+// Central session-recovery primitive shared by the REST client (client.ts)
+// and any Socket.IO consumer (socketAuth.ts). Answers a single question —
+// "can I get a fresh access-token cookie right now?" — and coordinates a
+// forced-logout hook when the answer is definitively no.
+//
+// Both transports need this because the backend's access-token cookie is a
+// short-lived JWT (15 min) with a much longer refresh-token cookie (7 days)
+// gated behind POST /api/auth/refresh. Neither the fetch wrapper nor the
+// Socket.IO client used to know how to trade the second for the first —
+// this module is the single place that does.
+
+export { SessionExpiredError } from './errors';
+
+const API_BASE = import.meta.env.VITE_API_URL ?? 'http://localhost:3001';
+const REFRESH_PATH = '/api/auth/refresh';
+
+type SessionHandlers = {
+  /**
+   * Called after refresh has definitively failed. The caller (AuthContext)
+   * wires this to `setUser(null)` so the UI drops back to the logged-out
+   * state without waiting for a component re-render.
+   */
+  onForceLogout: () => void;
+};
+
+// Nothing is registered before AuthProvider mounts. The default is a no-op
+// so `forceLogout()` from an interceptor firing during that narrow window
+// doesn't blow up — the initial getMe() 401 already puts the user in the
+// logged-out state anyway.
+let handlers: SessionHandlers = {
+  onForceLogout: () => {},
+};
+
+/**
+ * Register session handlers (called once by AuthProvider on mount). Returns
+ * an unregister function that restores the no-op defaults; call from the
+ * effect cleanup so a hot-reloaded AuthProvider doesn't leave a stale
+ * closure over an unmounted setState.
+ */
+export function registerSessionHandlers(next: SessionHandlers): () => void {
+  handlers = next;
+  return () => {
+    if (handlers === next) {
+      handlers = { onForceLogout: () => {} };
+    }
+  };
+}
+
+/**
+ * Trigger the registered forced-logout handler. Idempotent — extra calls
+ * during a burst-of-401s recovery are harmless because setUser(null) is
+ * itself idempotent.
+ */
+export function forceLogout(): void {
+  handlers.onForceLogout();
+}
+
+// Single-flight guard. A burst of parallel 401s (typical on tab-focus with
+// several sync calls in flight) must trigger exactly one POST /api/auth/refresh,
+// with every caller awaiting the same promise. Cleared *after* resolution so
+// a follow-up call gets a fresh attempt rather than the cached result.
+let inflight: Promise<boolean> | null = null;
+
+/**
+ * Attempt to mint a fresh access-token cookie. Returns true on success,
+ * false on any failure (network, non-2xx, missing refresh cookie). Never
+ * throws — callers use the boolean to branch (retry vs give up).
+ *
+ * Uses raw fetch, not the `api` client, so refresh failures don't recurse
+ * into the interceptor.
+ */
+export function attemptRefresh(): Promise<boolean> {
+  if (inflight) return inflight;
+
+  inflight = (async () => {
+    try {
+      const res = await fetch(`${API_BASE}${REFRESH_PATH}`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+      });
+      return res.ok;
+    } catch {
+      // Network error — treat as refresh failure. Caller will surface a
+      // session-expired error to the user.
+      return false;
+    } finally {
+      inflight = null;
+    }
+  })();
+
+  return inflight;
+}
+
+/**
+ * URL-path check used by the REST interceptor to bypass refresh for the
+ * auth endpoints themselves (otherwise a 401 on /login would loop into
+ * /refresh → 401 → /login). Exported for testing.
+ */
+export function isAuthEndpoint(path: string): boolean {
+  // Match ignores query string; trailing slash is tolerated for symmetry
+  // with backend routes that may or may not carry one.
+  const bare = path.split('?')[0].replace(/\/+$/, '');
+  return (
+    bare === '/api/auth/refresh' ||
+    bare === '/api/auth/login' ||
+    bare === '/api/auth/register' ||
+    bare === '/api/auth/logout'
+  );
+}
+
+// Test-only reset hook. Kept out of the public surface — callers should
+// never touch it in production.
+export function __resetSessionForTests(): void {
+  inflight = null;
+  handlers = { onForceLogout: () => {} };
+}

--- a/frontend/src/api/socketAuth.test.ts
+++ b/frontend/src/api/socketAuth.test.ts
@@ -1,0 +1,300 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Socket } from 'socket.io-client';
+import { installSocketAuthRecovery, type PendingSocketAction } from './socketAuth';
+import { __resetSessionForTests, registerSessionHandlers } from './session';
+
+// Minimal EventEmitter-shaped stand-in for a socket.io-client Socket. We
+// don't need the transport — just the on/off/once/emit surface the
+// installer relies on. `emit` is spied so the test can assert what was
+// sent, and manual `_fire()` drives incoming events.
+type FakeSocket = Socket & {
+  _fire: (event: string, ...args: unknown[]) => void;
+  _emitSpy: ReturnType<typeof vi.fn>;
+};
+
+function makeFakeSocket(): FakeSocket {
+  const listeners = new Map<string, Set<(...args: unknown[]) => void>>();
+  const onceListeners = new Map<string, Set<(...args: unknown[]) => void>>();
+  const emitSpy = vi.fn();
+
+  const on = (event: string, fn: (...args: unknown[]) => void): FakeSocket => {
+    if (!listeners.has(event)) listeners.set(event, new Set());
+    listeners.get(event)!.add(fn);
+    return socket;
+  };
+  const off = (event: string, fn?: (...args: unknown[]) => void): FakeSocket => {
+    if (!fn) {
+      listeners.delete(event);
+      onceListeners.delete(event);
+      return socket;
+    }
+    listeners.get(event)?.delete(fn);
+    onceListeners.get(event)?.delete(fn);
+    return socket;
+  };
+  const once = (event: string, fn: (...args: unknown[]) => void): FakeSocket => {
+    if (!onceListeners.has(event)) onceListeners.set(event, new Set());
+    onceListeners.get(event)!.add(fn);
+    return socket;
+  };
+
+  const socket = {
+    on,
+    off,
+    once,
+    emit: emitSpy,
+    _emitSpy: emitSpy,
+    _fire: (event: string, ...args: unknown[]) => {
+      listeners.get(event)?.forEach((fn) => fn(...args));
+      const oneShots = onceListeners.get(event);
+      if (oneShots) {
+        onceListeners.delete(event);
+        oneShots.forEach((fn) => fn(...args));
+      }
+    },
+  } as unknown as FakeSocket;
+
+  return socket;
+}
+
+function mockFetchResponse(status: number): ReturnType<typeof vi.fn> {
+  return vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: 'test',
+    json: async () => ({}),
+  } as Response);
+}
+
+// Small helper — flush the current microtask queue N times so awaited
+// promise chains inside the recovery flow can settle before we assert.
+async function flushMicrotasks(n = 10): Promise<void> {
+  for (let i = 0; i < n; i += 1) {
+    await Promise.resolve();
+  }
+}
+
+describe('installSocketAuthRecovery', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    __resetSessionForTests();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    __resetSessionForTests();
+  });
+
+  it('registers auth_error and auth_expired handlers and returns a teardown', () => {
+    const socket = makeFakeSocket();
+    const teardown = installSocketAuthRecovery(socket, {
+      onSessionExpired: () => {},
+    });
+    expect(typeof teardown).toBe('function');
+  });
+
+  it('on auth_error → refresh success → emits reauthenticate → replays pending action', async () => {
+    globalThis.fetch = mockFetchResponse(200);
+    const socket = makeFakeSocket();
+    const pending: PendingSocketAction = {
+      event: 'queue:join',
+      payload: { warrior_id: 'w1' },
+    };
+    const onRecovered = vi.fn();
+    const onSessionExpired = vi.fn();
+
+    installSocketAuthRecovery(socket, {
+      getPendingAction: () => pending,
+      onRecovered,
+      onSessionExpired,
+    });
+
+    socket._fire('auth_error', { error: 'Authentication required' });
+    await flushMicrotasks(20);
+
+    // Refresh emit sent
+    expect(socket._emitSpy).toHaveBeenCalledWith('reauthenticate');
+    // Simulate backend acknowledging the reauth
+    socket._fire('auth_refreshed', { user_id: 'u1', username: 'alice' });
+    await flushMicrotasks();
+
+    // Pending action was replayed
+    expect(socket._emitSpy).toHaveBeenCalledWith('queue:join', pending.payload);
+    expect(onRecovered).toHaveBeenCalledTimes(1);
+    expect(onSessionExpired).not.toHaveBeenCalled();
+  });
+
+  it('on auth_expired → refresh success → still replays pending action', async () => {
+    globalThis.fetch = mockFetchResponse(200);
+    const socket = makeFakeSocket();
+    const onSessionExpired = vi.fn();
+
+    installSocketAuthRecovery(socket, {
+      getPendingAction: () => ({ event: 'queue:join', payload: { warrior_id: 'w1' } }),
+      onSessionExpired,
+    });
+
+    socket._fire('auth_expired', { message: 'expired' });
+    await flushMicrotasks(20);
+    socket._fire('auth_refreshed', { user_id: 'u1', username: 'alice' });
+    await flushMicrotasks();
+
+    expect(socket._emitSpy).toHaveBeenCalledWith('reauthenticate');
+    expect(socket._emitSpy).toHaveBeenCalledWith('queue:join', { warrior_id: 'w1' });
+    expect(onSessionExpired).not.toHaveBeenCalled();
+  });
+
+  it('emits without payload when the pending action has none', async () => {
+    globalThis.fetch = mockFetchResponse(200);
+    const socket = makeFakeSocket();
+    installSocketAuthRecovery(socket, {
+      getPendingAction: () => ({ event: 'ping' }),
+      onSessionExpired: vi.fn(),
+    });
+
+    socket._fire('auth_error', {});
+    await flushMicrotasks(20);
+    socket._fire('auth_refreshed', {});
+    await flushMicrotasks();
+
+    // The pending emit should be called with the single event arg only.
+    // First emit is the reauthenticate; second is the pending 'ping'.
+    const pingCall = socket._emitSpy.mock.calls.find((c) => c[0] === 'ping');
+    expect(pingCall).toBeDefined();
+    expect(pingCall).toHaveLength(1);
+  });
+
+  it('no-ops the replay when there is no pending action', async () => {
+    globalThis.fetch = mockFetchResponse(200);
+    const socket = makeFakeSocket();
+    const onRecovered = vi.fn();
+
+    installSocketAuthRecovery(socket, {
+      getPendingAction: () => null,
+      onRecovered,
+      onSessionExpired: vi.fn(),
+    });
+
+    socket._fire('auth_error', {});
+    await flushMicrotasks(20);
+    socket._fire('auth_refreshed', {});
+    await flushMicrotasks();
+
+    // Only the reauthenticate emit should have gone out; nothing else.
+    expect(socket._emitSpy).toHaveBeenCalledTimes(1);
+    expect(socket._emitSpy).toHaveBeenCalledWith('reauthenticate');
+    expect(onRecovered).toHaveBeenCalledTimes(1);
+  });
+
+  it('on refresh failure → forceLogout + onSessionExpired, no reauthenticate emitted', async () => {
+    globalThis.fetch = mockFetchResponse(401);
+    const forceLogoutSpy = vi.fn();
+    registerSessionHandlers({ onForceLogout: forceLogoutSpy });
+
+    const socket = makeFakeSocket();
+    const onSessionExpired = vi.fn();
+    installSocketAuthRecovery(socket, {
+      getPendingAction: () => ({ event: 'queue:join', payload: { warrior_id: 'w1' } }),
+      onSessionExpired,
+    });
+
+    socket._fire('auth_error', {});
+    await flushMicrotasks(20);
+
+    expect(socket._emitSpy).not.toHaveBeenCalled();
+    expect(forceLogoutSpy).toHaveBeenCalledTimes(1);
+    expect(onSessionExpired).toHaveBeenCalledTimes(1);
+  });
+
+  it('on refresh success but second-round auth_error from backend → forceLogout + onSessionExpired', async () => {
+    globalThis.fetch = mockFetchResponse(200);
+    const forceLogoutSpy = vi.fn();
+    registerSessionHandlers({ onForceLogout: forceLogoutSpy });
+
+    const socket = makeFakeSocket();
+    const onSessionExpired = vi.fn();
+    installSocketAuthRecovery(socket, {
+      getPendingAction: () => ({ event: 'queue:join', payload: { warrior_id: 'w1' } }),
+      onSessionExpired,
+    });
+
+    socket._fire('auth_error', {});
+    await flushMicrotasks(20);
+
+    // Server rejects reauth (e.g. race — refresh cookie invalidated between
+    // the REST call and the socket emit).
+    socket._fire('auth_error', { error: 'Reauthentication failed' });
+    await flushMicrotasks();
+
+    expect(socket._emitSpy).toHaveBeenCalledWith('reauthenticate');
+    expect(forceLogoutSpy).toHaveBeenCalledTimes(1);
+    expect(onSessionExpired).toHaveBeenCalledTimes(1);
+  });
+
+  it('guards against re-entry — a burst of auth_error events does not stack recoveries', async () => {
+    globalThis.fetch = mockFetchResponse(200);
+    const socket = makeFakeSocket();
+    installSocketAuthRecovery(socket, {
+      getPendingAction: () => ({ event: 'queue:join', payload: { warrior_id: 'w1' } }),
+      onSessionExpired: vi.fn(),
+    });
+
+    socket._fire('auth_error', {});
+    socket._fire('auth_error', {});
+    socket._fire('auth_error', {});
+    await flushMicrotasks(20);
+    socket._fire('auth_refreshed', {});
+    await flushMicrotasks();
+
+    // Only one reauthenticate emit despite three triggers.
+    const reauthCalls = socket._emitSpy.mock.calls.filter((c) => c[0] === 'reauthenticate');
+    expect(reauthCalls).toHaveLength(1);
+    // And only one pending-action replay.
+    const queueCalls = socket._emitSpy.mock.calls.filter((c) => c[0] === 'queue:join');
+    expect(queueCalls).toHaveLength(1);
+  });
+
+  it('teardown removes both auth_error and auth_expired handlers', async () => {
+    globalThis.fetch = mockFetchResponse(200);
+    const socket = makeFakeSocket();
+    const onSessionExpired = vi.fn();
+    const teardown = installSocketAuthRecovery(socket, {
+      onSessionExpired,
+    });
+
+    teardown();
+    socket._fire('auth_error', {});
+    socket._fire('auth_expired', {});
+    await flushMicrotasks(20);
+
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(onSessionExpired).not.toHaveBeenCalled();
+  });
+
+  it('times out and treats no auth_refreshed response as a session failure', async () => {
+    vi.useFakeTimers();
+    globalThis.fetch = mockFetchResponse(200);
+    const forceLogoutSpy = vi.fn();
+    registerSessionHandlers({ onForceLogout: forceLogoutSpy });
+
+    const socket = makeFakeSocket();
+    const onSessionExpired = vi.fn();
+    installSocketAuthRecovery(socket, {
+      getPendingAction: () => ({ event: 'queue:join', payload: {} }),
+      onSessionExpired,
+      reauthTimeoutMs: 100,
+    });
+
+    socket._fire('auth_error', {});
+    // Let the refresh fetch resolve.
+    await vi.advanceTimersByTimeAsync(0);
+    // Advance past the reauth timeout without firing auth_refreshed.
+    await vi.advanceTimersByTimeAsync(150);
+
+    expect(socket._emitSpy).toHaveBeenCalledWith('reauthenticate');
+    expect(forceLogoutSpy).toHaveBeenCalledTimes(1);
+    expect(onSessionExpired).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
+  });
+});

--- a/frontend/src/api/socketAuth.ts
+++ b/frontend/src/api/socketAuth.ts
@@ -1,0 +1,161 @@
+// Socket.IO auth-recovery primitive. Any page that opens a Socket.IO
+// connection to the backend should call `installSocketAuthRecovery` on it
+// so that a mid-session access-token expiry is transparently recovered
+// (or, if refresh definitively fails, cleanly surfaced as a session-expired
+// state to the user).
+//
+// The backend contract (see backend/src/auth/socket.rs):
+//   - `auth_error`   — emitted by require_auth() when the connection is
+//                       anonymous but authentication is required.
+//   - `auth_expired` — emitted when a valid-looking cookie is present but
+//                       has expired.
+//   - `reauthenticate` — client-emitted event that re-reads cookies. The
+//                        backend responds with either `auth_refreshed`
+//                        (success) or `auth_error` (still failing).
+//
+// The recovery loop is:
+//   1. On auth_error / auth_expired, call attemptRefresh() over REST to
+//      mint a fresh access-token cookie.
+//   2. If refresh succeeded, emit `reauthenticate` and wait for the server's
+//      `auth_refreshed` (success) or a second `auth_error` (fail).
+//   3. On success, replay the last-emitted auth-required action so the user
+//      does not have to click the button a second time.
+//   4. On failure, call the registered forceLogout() to drop UI auth state
+//      and invoke the caller-supplied `onSessionExpired` so the page can
+//      reset local state and show a friendly prompt.
+
+import type { Socket } from 'socket.io-client';
+import { attemptRefresh, forceLogout } from './session';
+
+export type PendingSocketAction = {
+  event: string;
+  payload?: unknown;
+};
+
+type Options = {
+  /**
+   * Returns the last auth-required action so recovery can replay it. Return
+   * `null` if nothing is queued (e.g. the user is just idling in the lobby
+   * with no click pending). Called at recovery time — evaluate live state,
+   * do not close over a stale snapshot.
+   */
+  getPendingAction?: () => PendingSocketAction | null;
+
+  /**
+   * Called after a successful reauthenticate + pending-action replay.
+   * Useful for clearing UI error messages left over from a prior failed
+   * attempt.
+   */
+  onRecovered?: () => void;
+
+  /**
+   * Called when refresh has definitively failed and the user must log in
+   * again. `forceLogout()` will already have been invoked by this point;
+   * the page should reset any transport-state it owned (e.g. lobby phase
+   * back to idle) and surface a session-expired message.
+   */
+  onSessionExpired: () => void;
+
+  /**
+   * Overrideable timeout for the reauthenticate round-trip. If the server
+   * fails to respond within this window we treat it as a session failure
+   * rather than hanging forever. Default 5s.
+   */
+  reauthTimeoutMs?: number;
+};
+
+const DEFAULT_REAUTH_TIMEOUT_MS = 5000;
+
+/**
+ * Attach auth-recovery handlers to a socket. Returns a teardown function
+ * that removes them — call it on component unmount to avoid leaks when
+ * the socket outlives the component (or, more commonly, when React
+ * StrictMode double-mounts).
+ */
+export function installSocketAuthRecovery(socket: Socket, options: Options): () => void {
+  const {
+    getPendingAction,
+    onRecovered,
+    onSessionExpired,
+    reauthTimeoutMs = DEFAULT_REAUTH_TIMEOUT_MS,
+  } = options;
+
+  // Guard against re-entry — a burst of auth_error / auth_expired (e.g. two
+  // require_auth checks firing back-to-back) must not start two overlapping
+  // recovery flows.
+  let recovering = false;
+
+  async function attemptRecovery(): Promise<void> {
+    if (recovering) return;
+    recovering = true;
+    try {
+      const refreshed = await attemptRefresh();
+      if (!refreshed) {
+        forceLogout();
+        onSessionExpired();
+        return;
+      }
+
+      // Race the server's response — `auth_refreshed` (success) or
+      // `auth_error` (definitive failure) — against a timeout so the UI
+      // never hangs waiting on a dropped socket. Whichever path resolves
+      // first, we always tear down both once-listeners so a late-arriving
+      // event after we've given up doesn't fire into a dead flow.
+      const outcome = await new Promise<'refreshed' | 'failed'>((resolve) => {
+        const cleanup = (): void => {
+          clearTimeout(timer);
+          socket.off('auth_refreshed', onRefreshed);
+          socket.off('auth_error', onError);
+        };
+        const onRefreshed = (): void => {
+          cleanup();
+          resolve('refreshed');
+        };
+        const onError = (): void => {
+          cleanup();
+          resolve('failed');
+        };
+        const timer = setTimeout(() => {
+          cleanup();
+          resolve('failed');
+        }, reauthTimeoutMs);
+        socket.once('auth_refreshed', onRefreshed);
+        socket.once('auth_error', onError);
+        socket.emit('reauthenticate');
+      });
+
+      if (outcome === 'refreshed') {
+        const pending = getPendingAction?.();
+        if (pending) {
+          if (pending.payload !== undefined) {
+            socket.emit(pending.event, pending.payload);
+          } else {
+            socket.emit(pending.event);
+          }
+        }
+        onRecovered?.();
+      } else {
+        forceLogout();
+        onSessionExpired();
+      }
+    } finally {
+      recovering = false;
+    }
+  }
+
+  // Both auth_error and auth_expired route through the same recovery path.
+  // `attemptRecovery` is a plain function returning a promise; socket.io's
+  // event listeners don't await the return so we spawn-and-forget here
+  // and the re-entry guard above prevents overlap.
+  const onAuthEvent = (): void => {
+    void attemptRecovery();
+  };
+
+  socket.on('auth_error', onAuthEvent);
+  socket.on('auth_expired', onAuthEvent);
+
+  return () => {
+    socket.off('auth_error', onAuthEvent);
+    socket.off('auth_expired', onAuthEvent);
+  };
+}

--- a/frontend/src/pages/LobbyPage.tsx
+++ b/frontend/src/pages/LobbyPage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useAuth } from '../api/AuthContext';
+import { installSocketAuthRecovery, type PendingSocketAction } from '../api/socketAuth';
 import { useWarriorLibrary, type Warrior } from '../warriors/library';
 import { io, type Socket } from 'socket.io-client';
 import type { MatchStartPayload } from './match/useMatchReplay';
@@ -105,6 +106,8 @@ export default function LobbyPage() {
   const [result, setResult] = useState<MatchResultData | null>(null);
   const [error, setError] = useState<string | null>(null);
   const socketRef = useRef<Socket | null>(null);
+  const socketTeardownRef = useRef<(() => void) | null>(null);
+  const pendingActionRef = useRef<PendingSocketAction | null>(null);
   const autoQueuedRef = useRef(false);
 
   const effectiveId = selectedId || firstUuid;
@@ -114,9 +117,16 @@ export default function LobbyPage() {
     const s = io(API_BASE, { withCredentials: true });
     socketRef.current = s;
 
-    s.on('queue:joined', () => setPhase('queued'));
-    s.on('queue:left', () => setPhase('idle'));
+    s.on('queue:joined', () => {
+      pendingActionRef.current = null;
+      setPhase('queued');
+    });
+    s.on('queue:left', () => {
+      pendingActionRef.current = null;
+      setPhase('idle');
+    });
     s.on('queue:error', (data: { error: string }) => {
+      pendingActionRef.current = null;
       setError(data.error);
       setPhase('idle');
     });
@@ -135,6 +145,20 @@ export default function LobbyPage() {
       setPhase('result');
     });
 
+    // Silent recovery on access-token expiry. Without this, an idle
+    // 15+ minute session lets the socket reconnect as anonymous and
+    // `require_auth` on the backend drops queue:join with no visible
+    // feedback (issue #60).
+    socketTeardownRef.current = installSocketAuthRecovery(s, {
+      getPendingAction: () => pendingActionRef.current,
+      onRecovered: () => setError(null),
+      onSessionExpired: () => {
+        pendingActionRef.current = null;
+        setPhase('idle');
+        setError('Your session has expired. Please log in again.');
+      },
+    });
+
     return s;
   }, [navigate]);
 
@@ -145,7 +169,12 @@ export default function LobbyPage() {
       if (!warriorId) return;
       setError(null);
       const s = connect();
-      s.emit('queue:join', { warrior_id: warriorId });
+      const payload = { warrior_id: warriorId };
+      // Record the pending action *before* emitting so the socket-auth
+      // recovery layer can replay it if the backend drops this emit because
+      // the connection is anonymous.
+      pendingActionRef.current = { event: 'queue:join', payload };
+      s.emit('queue:join', payload);
     },
     [connect],
   );
@@ -180,8 +209,11 @@ export default function LobbyPage() {
 
   useEffect(() => {
     return () => {
+      socketTeardownRef.current?.();
+      socketTeardownRef.current = null;
       socketRef.current?.disconnect();
       socketRef.current = null;
+      pendingActionRef.current = null;
     };
   }, []);
 


### PR DESCRIPTION
## Summary

Two related silent-failure bugs: after the 15-min access-token TTL expires, the frontend never asks the backend for a fresh one, so both REST and Socket.IO calls die quietly. Fixes both by adding one shared "attempt refresh, retry, else force-logout" primitive and wiring it into `client.ts` (REST) and `LobbyPage.tsx`'s socket flow.

Closes #86.
Closes #60.

## What changed

New primitives under `frontend/src/api/`:

- **`session.ts`** — single-flight `attemptRefresh()` and `forceLogout()` hook. A burst of parallel 401s coalesces to exactly one `POST /api/auth/refresh`; the guard clears after the promise settles so follow-up calls try again.
- **`errors.ts`** — `ApiError` extracted here plus new `SessionExpiredError` subclass. Needed to break the circular import between `client.ts` and `session.ts`. `client.ts` re-exports both so existing `import { ApiError } from './client'` sites keep working.
- **`socketAuth.ts`** — reusable `installSocketAuthRecovery(socket, opts)`. Handles `auth_error` and `auth_expired`, drives `attemptRefresh → emit('reauthenticate') → auth_refreshed`, replays a pending action (the last-queued auth-required emit), and cleanly gives up on failure. Factored out of the lobby so spectator mode (#51) can reuse it in three lines.

Wiring:

- **`client.ts`** — 401 → refresh → retry once. Auth endpoints (`/api/auth/refresh|login|register|logout`) bypass to avoid loops. Definitive failure surfaces as `SessionExpiredError` with user-facing copy (**"Your session has expired. Please log in again."**) instead of the raw backend `"Missing access token"` string called out in the issue.
- **`AuthContext.tsx`** — one `useEffect` registers `onForceLogout: () => setUser(null)`. Cleanup on unmount so a hot-reloaded `AuthProvider` doesn't leave a stale closure.
- **`LobbyPage.tsx`** — `installSocketAuthRecovery` on `connect()`, tracks the last `queue:join` payload in a ref, `onSessionExpired` resets phase to idle and sets `"Your session has expired. Please log in again."`.

## Test plan

Vitest (24 new, 95 total passing):

- **`session.test.ts`** — single-flight coalescing (N parallel callers → 1 fetch), success/failure return values, `forceLogout` dispatch + unregister, `isAuthEndpoint` edge cases (query strings, trailing slashes, `/api/auth/me` NOT treated as auth-endpoint).
- **`client.test.ts`** — 401 → refresh success → retry succeeds; refresh failure → `SessionExpiredError` + `forceLogout()` called; retry still 401 after successful refresh → same; burst of parallel 401s → exactly one refresh; auth-endpoint 401s bypass the interceptor; 500s pass through.
- **`socketAuth.test.ts`** — both `auth_error` and `auth_expired` trigger recovery; pending action replayed on success (with and without payload); no-op when nothing pending; refresh failure calls `forceLogout` + `onSessionExpired` and does NOT emit `reauthenticate`; server-side reauth failure (second `auth_error` after `reauthenticate`) same treatment; re-entry guard against event bursts; reauth timeout treated as session failure; teardown removes both listeners.

- [x] `npm run lint` — clean apart from one pre-existing warning on `AuthContext.tsx` (`react-refresh/only-export-components`, unchanged from master; I initially tried to fix it by splitting `useAuth` but reverted to keep this PR's diff off `useBuilder.ts` (#95's territory) and `ProfilePage.tsx` (#88's territory).
- [x] `npm run format:check` — clean.
- [x] `npm test` — 95/95.
- [x] `npm run build` — clean.

## Playwright verification (the money shot)

Since the point of the PR is behavioral, not just green tests, I drove both flows in a real browser via Playwright MCP against the local dev stack:

**Setup:** temporarily shortened `ACCESS_TOKEN_DURATION_SECS` in `backend/src/auth/jwt.rs` from `15 * 60` to `15` for the run, then reverted before commit. Backend + frontend + Postgres + Redis all local.

**REST recovery path:**
1. Logged in as `_test_red`.
2. Idled 20s past expiry.
3. Navigated to `/profile`.
4. Network log: two `GET /api/auth/me` requests both 401 (React StrictMode), single `POST /api/auth/refresh` returned 200, both `/me` retries returned 200, both `/profile` calls succeeded. **Single refresh coalesced N 401s** — the single-flight guard doing its job. No user-visible error.

**Socket recovery path:**
1. Logged in fresh, opened `/builder` to trigger warrior sync, navigated back to `/lobby`.
2. Idled 20s past expiry.
3. Clicked **Find Match**.
4. Socket connected anonymous (JWT expired). Backend `require_auth` on `queue:join` fired `auth_error`. `installSocketAuthRecovery` caught it → REST refresh → `emit('reauthenticate')` → backend `auth_refreshed` → pending `queue:join` replayed → backend `queue:joined`.
5. Lobby transitioned idle → "Searching for opponent..." with a Cancel button. **Zero console errors, zero user-visible state confusion.**

## Files kept out of scope

- `frontend/src/pages/builder/useBuilder.ts` — Orion's PR #95 territory (#85). Left alone.
- `frontend/src/pages/profile/ProfilePage.tsx` — Vale's issue #88 territory. Left alone. The "friendly copy instead of raw backend error" acceptance criterion is delivered by `SessionExpiredError`'s baked-in message that all catchers get; individual page copy cleanups are #88's redesign scope.

## Follow-ups (not filed as issues yet)

- Proactive refresh before expiry (out of scope per #86; reactive is sufficient).
- Reconcile `getMe()` on tab focus (out of scope per #86).
- Broader `SessionExpiredError` UI treatment beyond the lobby's inline text — a global toast/banner would be nice but crosses into #88.

🤖 Generated with [Claude Code](https://claude.com/claude-code)