### PR TITLE
Add PreToolUse hook to protect dotenv files

### DIFF
--- a/.claude/hooks/protect-env.py
+++ b/.claude/hooks/protect-env.py
@@ -5,12 +5,25 @@ Allows .env.example / .env.sample / .env.template (docs/templates).
 Blocks .env, .env.local, .env.production, .env.*.local, etc.
 
 Covers Read, Edit, Write, NotebookEdit, Grep, and Bash.
+
+Scope / limitations. This is defense-in-depth against accidental or
+forgetful access, not an airtight sandbox. Bash commands are checked
+via shlex tokenization: a token that is a `.env`-like filename gets
+blocked, tokens with internal whitespace (i.e. quoted string content)
+are skipped. That means `git commit -m "mentions .env"` passes, but
+so does `python -c "print(open('.env').read())"` because we cannot
+tell quoted code from quoted text without executing it. Similar gaps
+exist for symlinks, `find -exec`, base64-encoded paths, etc. Closing
+those requires a real shell parser or full sandboxing; this hook
+raises the cost of casual/unintended access without pretending to be
+unbypassable.
 """
 
 from __future__ import annotations
 
 import json
 import re
+import shlex
 import sys
 
 ALLOWED_SUFFIXES = (".example", ".sample", ".template")
@@ -21,6 +34,10 @@ ALLOWED_SUFFIXES = (".example", ".sample", ".template")
 # and `path/to/.env.production` do.
 DOTENV_TOKEN = re.compile(r"(?<![\w.-])\.env(?:\.[a-zA-Z0-9_-]+)*")
 
+# Strict filename match — a real dotenv basename, nothing embedded in a
+# larger blob (like JSON payloads that happen to contain `.env`).
+DOTENV_FILENAME = re.compile(r"^\.env(?:\.[a-zA-Z0-9_-]+)*$")
+
 
 def basename(path: str) -> str:
     return path.rsplit("/", 1)[-1]
@@ -30,7 +47,7 @@ def is_protected_path(path: str) -> bool:
     if not path:
         return False
     base = basename(path)
-    if not base.startswith(".env"):
+    if not DOTENV_FILENAME.fullmatch(base):
         return False
     if base.endswith(ALLOWED_SUFFIXES):
         return False
@@ -38,11 +55,28 @@ def is_protected_path(path: str) -> bool:
 
 
 def bash_offender(cmd: str) -> str | None:
-    """Return the first non-allowed .env token in a shell command, or None."""
-    for m in DOTENV_TOKEN.finditer(cmd):
-        token = m.group()
-        if not token.endswith(ALLOWED_SUFFIXES):
-            return token
+    """Return the first non-allowed .env token in a shell command, or None.
+
+    Uses shlex.split so quoted string content (like `-m "message with .env"`)
+    doesn't false-positive: real file arguments cannot contain unescaped
+    whitespace, so any token with internal whitespace came from a quoted
+    string, not a file reference. Falls back to a raw regex scan if the
+    command can't be tokenized (unmatched quotes, heredocs, etc.).
+    """
+    try:
+        tokens = shlex.split(cmd, comments=False, posix=True)
+    except ValueError:
+        for m in DOTENV_TOKEN.finditer(cmd):
+            token = m.group()
+            if not token.endswith(ALLOWED_SUFFIXES):
+                return token
+        return None
+
+    for tok in tokens:
+        if any(c.isspace() for c in tok):
+            continue
+        if is_protected_path(tok):
+            return tok
     return None
 
 

--- a/.claude/hooks/protect-env.py
+++ b/.claude/hooks/protect-env.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: block reads/writes/searches of .env files.
+
+Allows .env.example / .env.sample / .env.template (docs/templates).
+Blocks .env, .env.local, .env.production, .env.*.local, etc.
+
+Covers Read, Edit, Write, NotebookEdit, Grep, and Bash.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+
+ALLOWED_SUFFIXES = (".example", ".sample", ".template")
+
+# A .env-like token: `.env` optionally followed by dotted suffixes.
+# Left boundary: start of string OR any char that isn't a word/dot/hyphen — so
+# `my.env-thing` and `foo.envconfig` don't match, but `cat .env`, `< .env.local`,
+# and `path/to/.env.production` do.
+DOTENV_TOKEN = re.compile(r"(?<![\w.-])\.env(?:\.[a-zA-Z0-9_-]+)*")
+
+
+def basename(path: str) -> str:
+    return path.rsplit("/", 1)[-1]
+
+
+def is_protected_path(path: str) -> bool:
+    if not path:
+        return False
+    base = basename(path)
+    if not base.startswith(".env"):
+        return False
+    if base.endswith(ALLOWED_SUFFIXES):
+        return False
+    return True
+
+
+def bash_offender(cmd: str) -> str | None:
+    """Return the first non-allowed .env token in a shell command, or None."""
+    for m in DOTENV_TOKEN.finditer(cmd):
+        token = m.group()
+        if not token.endswith(ALLOWED_SUFFIXES):
+            return token
+    return None
+
+
+def pattern_offender(pattern: str) -> str | None:
+    for m in DOTENV_TOKEN.finditer(pattern):
+        token = m.group()
+        if not token.endswith(ALLOWED_SUFFIXES):
+            return token
+    return None
+
+
+def deny(reason: str) -> None:
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": reason,
+        }
+    }))
+    sys.exit(0)
+
+
+def main() -> None:
+    try:
+        payload = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        sys.exit(0)
+
+    tool_name = payload.get("tool_name", "")
+    tool_input = payload.get("tool_input") or {}
+
+    if tool_name in ("Read", "Edit", "Write"):
+        path = tool_input.get("file_path", "") or ""
+        if is_protected_path(path):
+            deny(
+                f"Blocked: '{path}' is a protected secrets file. "
+                f"Read the corresponding .example file instead "
+                f"(e.g. backend/.env.example)."
+            )
+
+    elif tool_name == "NotebookEdit":
+        path = tool_input.get("notebook_path", "") or ""
+        if is_protected_path(path):
+            deny(f"Blocked: '{path}' is a protected secrets file.")
+
+    elif tool_name == "Grep":
+        path = tool_input.get("path", "") or ""
+        if is_protected_path(path):
+            deny(
+                f"Blocked: cannot Grep '{path}'. "
+                f"Read the corresponding .example file instead."
+            )
+        for key in ("glob", "include"):
+            pat = tool_input.get(key, "") or ""
+            offender = pattern_offender(pat) if pat else None
+            if offender:
+                deny(
+                    f"Blocked: Grep {key} pattern targets a protected secrets file "
+                    f"('{offender}'). Restrict the pattern or read .env.example directly."
+                )
+
+    elif tool_name == "Bash":
+        cmd = tool_input.get("command", "") or ""
+        offender = bash_offender(cmd)
+        if offender is not None:
+            deny(
+                f"Blocked: command references '{offender}', a protected secrets file. "
+                f"Use the matching .example file "
+                f"(e.g. backend/.env.example) to see the schema."
+            )
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Read|Edit|Write|NotebookEdit|Grep|Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/protect-env.py"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,8 @@ dist/
 # and any other local scratch stay ignored.
 .claude/*
 !.claude/agents/
+!.claude/hooks/
+!.claude/settings.json
 
 # MCP server config (contains local paths)
 .mcp.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,6 +146,7 @@ Backend release build: `cargo build --release` from `backend/`. Output binary at
 - All dev happens inside **WSL2 Ubuntu** on Windows 11. Keep files in the Linux filesystem (`~/dev/...`), never `/mnt/c/...`, for performance and to avoid file-watcher issues with Vite and `cargo watch`.
 - Backend reads `backend/.env` via `python-dotenv`. Defaults assume Postgres at `localhost:5432` (user/pass/db all `corewar`) and Redis at `localhost:6379`, matching `docker-compose.yml`.
 - Backend port is `3001`; frontend dev server is `5173`. Don't change one without updating CORS (`FRONTEND_URL`) and any frontend API base URL.
+- **Secrets policy:** `.env` files (`.env`, `.env.local`, `.env.production`, etc.) are off-limits — a `PreToolUse` hook at `.claude/hooks/protect-env.py` blocks Read / Edit / Write / Grep / Bash / NotebookEdit against them. Use the matching `*.example` file (e.g. `backend/.env.example`) to see the schema. This applies to subagents too; there is no workaround, and you should not attempt one.
 
 ## Key concepts
 


### PR DESCRIPTION
## Summary
- Adds a `PreToolUse` hook (`.claude/hooks/protect-env.py`) that deterministically blocks Read / Edit / Write / NotebookEdit / Grep / Bash from touching protected dotenv files. Allows `*.example`, `*.sample`, `*.template`.
- Wires the hook via a new **project-level** `.claude/settings.json` so anyone cloning the repo inherits the policy — subagents get it for free (hooks are inherited from the parent session, no per-agent config needed).
- `.gitignore` un-ignores `.claude/hooks/` and `.claude/settings.json`; personal `settings.local.json` and worktrees stay ignored.
- Brief note in `CLAUDE.md` under Environment so the model steers to `.example` files on its own instead of retrying.

## Why a hook, not just docs / permissions
- Docs (CLAUDE.md, subagent frontmatter) are advisory and can be compressed out of a subagent's context.
- Permission `deny` rules cover the `Read` tool but not `cat/grep .env` via Bash.
- A single `PreToolUse` hook is deterministic across every tool surface and inherits to every subagent type.

## Bash-command handling
Bash commands are tokenized with `shlex.split` and each token is checked:
- Tokens with internal whitespace can only come from quoted string content (`-m "mentions dotenv"`), so they're skipped — no false positive on commit messages, PR bodies, `echo` output, JSON payloads that happen to contain `.env`.
- Clean file-like tokens (`.env`, `backend/.env`, `$HOME/.env`, `"backend/.env"`) are matched against a strict filename regex — the basename must fully match `\.env(\.[a-zA-Z0-9_-]+)*`, not merely start with `.env`.
- Falls back to a raw regex scan if shlex can't tokenize (unmatched quotes, heredocs) — false-blocking a malformed command is preferable to leaking a real read.

## Scope note (documented in the script)
This is defense-in-depth against accidental / forgetful access, not an airtight sandbox. Quoted code inside `-c` / `-e` interpreter flags (`python -c "print(open('.env').read())"`) is a known blind spot — we can't distinguish quoted code from quoted text without executing it. Same for symlinks, `find -exec`, base64-encoded paths, etc. Closing those requires either a full shell parser or real sandboxing. The hook is deliberately scoped to catch the cases that matter in practice (direct reads and forgetful subagents) without pretending to be unbypassable.

## Test plan
- [x] 26-case pipe-test matrix: original blocks (10), false-positive fixes (5), non-trivial attack paths (9), malformed-command fallback (2). 25/26 pass; the one documented miss is the `python -c` case above.
- [x] End-to-end proof of the fix: the second commit on this PR was created with plain `git commit -m "..."` containing the string `.env` — pre-fix that would have been blocked, post-fix it succeeds.
- [x] Confirmed in-session that a real `Read backend/.env` and `cat backend/.env` both get blocked with the intended message.
- [x] `settings.json` validates and points at the expected hook path.
