### PR TITLE
Scrub personal domain and email from docs; harden .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,37 @@ dist/
 
 # MCP server config (contains local paths)
 .mcp.json
+
+# --- General hygiene: fail-closed against common accidental commits. ---
+# OS-generated metadata (Finder / Explorer thumbnails)
+.DS_Store
+Thumbs.db
+desktop.ini
+
+# Editor swap / autosave / temp
+*.swp
+*.swo
+*~
+\#*\#
+.\#*
+
+# JetBrains + VS Code personal workspace files (shared configs would need to
+# be opt-in via `!.vscode/settings.json` etc. — none tracked today)
+.idea/
+.vscode/
+
+# Log files (Node package managers + generic)
+*.log
+npm-debug.log*
+yarn-error.log
+yarn-debug.log*
+pnpm-debug.log*
+
+# TypeScript incremental build metadata
+*.tsbuildinfo
+
+# Patch / backup / rejected-hunk droppings
+*.bak
+*.orig
+*.rej
+*.old

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,7 +1,7 @@
 # VPS bootstrap & manual deploy runbook
 
 This runbook stands the backend stack up on a fresh DigitalOcean droplet,
-hardens it, configures DNS for `api.corewar.coltcampbell.dev`, and walks
+hardens it, configures DNS for `api.corewar.example.com`, and walks
 through the first deploy and the steady-state redeploy.
 
 The deploy is fully manual at this stage. `deploy/deploy.sh` rsyncs the
@@ -14,22 +14,22 @@ deploys are independent — Pages can ship before this VPS exists; the app
 will just see a non-resolving API host until the droplet is up.
 
 > All `<placeholder>` values are things you fill in. Wherever the runbook
-> references `coltcampbell.dev`, replace with your domain if you forked.
+> references `example.com`, replace with your domain if you forked.
 
 ## Prerequisites
 
 Before starting:
 
 - DigitalOcean account with a payment method on file.
-- Domain `coltcampbell.dev` registered (Porkbun) with DNS management access.
+- Domain `example.com` registered (Porkbun) with DNS management access.
 - A dedicated SSH key pair for the droplet — **separate from any key you already use** (e.g. your GitHub key at `~/.ssh/id_ed25519`). Generate one with an explicit filename so the default location isn't clobbered:
   ```bash
-  ssh-keygen -t ed25519 -f ~/.ssh/droplet -C "colt@coltcampbell.dev"
+  ssh-keygen -t ed25519 -f ~/.ssh/droplet -C "you@example.com"
   ```
   Subsequent commands assume this key. To skip typing `-i ~/.ssh/droplet` every time, add a `~/.ssh/config` alias once the droplet's hostname resolves:
   ```
-  Host droplet api.corewar.coltcampbell.dev
-      HostName api.corewar.coltcampbell.dev
+  Host droplet api.corewar.example.com
+      HostName api.corewar.example.com
       User colt
       IdentityFile ~/.ssh/droplet
       IdentitiesOnly yes
@@ -215,7 +215,7 @@ docker pull ghcr.io/coltosaur/core-war-backend:latest
 
 ## 6. DNS records at Porkbun
 
-In the Porkbun control panel for `coltcampbell.dev` → **DNS**:
+In the Porkbun control panel for `example.com` → **DNS**:
 
 | Type | Host | Answer | TTL |
 |---|---|---|---|
@@ -225,8 +225,8 @@ In the Porkbun control panel for `coltcampbell.dev` → **DNS**:
 Verify propagation from your laptop (give it 1–5 minutes):
 
 ```bash
-dig +short api.corewar.coltcampbell.dev
-dig +short AAAA api.corewar.coltcampbell.dev
+dig +short api.corewar.example.com
+dig +short AAAA api.corewar.example.com
 ```
 
 Both should return the droplet's addresses before you proceed — Caddy can't
@@ -236,27 +236,27 @@ issue a Let's Encrypt cert until the hostname resolves to this box.
 
 CAA pins which CAs are allowed to issue certs for the apex and any
 subdomain. Without it, any compromised CA in the global trust store can
-mint a cert for `coltcampbell.dev` — CAA is a cheap belt-and-braces.
+mint a cert for `example.com` — CAA is a cheap belt-and-braces.
 
 Two CAs are in play here:
 
-- **Let's Encrypt** — issues for `api.corewar.coltcampbell.dev` via Caddy.
+- **Let's Encrypt** — issues for `api.corewar.example.com` via Caddy.
 - **Google Trust Services** (`pki.goog`) — issues for
-  `corewar.coltcampbell.dev` because Cloudflare Pages uses GTS.
+  `corewar.example.com` because Cloudflare Pages uses GTS.
 
-At the Porkbun apex (`coltcampbell.dev`):
+At the Porkbun apex (`example.com`):
 
 | Type | Host | Answer | TTL |
 |---|---|---|---|
 | `CAA` | (apex) | `0 issue "letsencrypt.org"` | 3600 |
 | `CAA` | (apex) | `0 issue "pki.goog"` | 3600 |
-| `CAA` | (apex) | `0 iodef "mailto:campbellcolt297@gmail.com"` | 3600 |
+| `CAA` | (apex) | `0 iodef "mailto:you@example.com"` | 3600 |
 
 The `iodef` record is optional — it tells a CA where to mail
 misissuance reports. Verify with:
 
 ```bash
-dig CAA coltcampbell.dev +short
+dig CAA example.com +short
 ```
 
 You should see all three records back. CAA is checked **at cert issuance
@@ -288,9 +288,9 @@ all of which break URL parsing (sqlx will reject the URL with
 `Configuration(InvalidPort)`).
 
 ```ini
-BACKEND_DOMAIN=api.corewar.coltcampbell.dev
-ACME_EMAIL=colt@coltcampbell.dev
-FRONTEND_URL=https://corewar.coltcampbell.dev
+BACKEND_DOMAIN=api.corewar.example.com
+ACME_EMAIL=you@example.com
+FRONTEND_URL=https://corewar.example.com
 JWT_SECRET=<openssl rand -hex 48>
 POSTGRES_USER=corewar
 POSTGRES_PASSWORD=<openssl rand -hex 24>
@@ -318,10 +318,10 @@ droplet — the build is CPU-bound on cargo) and bring the stack up.
 
 ```bash
 # Cheap liveness probe — public, no DB work.
-curl -i https://api.corewar.coltcampbell.dev/health
+curl -i https://api.corewar.example.com/health
 
 # Deep readiness probe — DB-probing, used by the container HEALTHCHECK.
-curl -i https://api.corewar.coltcampbell.dev/health/deep
+curl -i https://api.corewar.example.com/health/deep
 ```
 
 The first request can take **30+ seconds** while Caddy negotiates the
@@ -347,7 +347,7 @@ the container unhealthy.
 
 If the cert handshake fails:
 
-- `dig +short api.corewar.coltcampbell.dev` must return the droplet IP.
+- `dig +short api.corewar.example.com` must return the droplet IP.
 - Port 80 must be reachable from the public internet (Let's Encrypt's
   HTTP-01 challenge uses it). `sudo ufw status` should show 80/tcp ALLOW.
 - Inspect Caddy's logs: `docker compose -f docker-compose.prod.yml logs caddy`.
@@ -470,7 +470,7 @@ repository secret**:
 
 | Secret | Value |
 |---|---|
-| `DROPLET_HOST` | Droplet IPv4 (or `api.corewar.coltcampbell.dev` once DNS is in) |
+| `DROPLET_HOST` | Droplet IPv4 (or `api.corewar.example.com` once DNS is in) |
 | `DROPLET_USER` | The non-root user from section 2 (e.g. `colt`) |
 | `DROPLET_SSH_KEY` | **Private** half of an SSH key whose public half is in the droplet's `~/.ssh/authorized_keys`. Generate a fresh one for CI — don't reuse your personal key: `ssh-keygen -t ed25519 -f ~/.ssh/corewar_deploy -C corewar-deploy`. Copy `~/.ssh/corewar_deploy.pub` to the droplet's `~/.ssh/authorized_keys`, paste the contents of `~/.ssh/corewar_deploy` (the private file) here. |
 
@@ -516,7 +516,7 @@ liveness:
 2. **+ New Monitor**:
    - Type: HTTPS
    - Friendly name: `Core War backend`
-   - URL: `https://api.corewar.coltcampbell.dev/health/deep`
+   - URL: `https://api.corewar.example.com/health/deep`
    - Monitoring interval: 5 minutes (free-tier minimum)
 3. **Alert contacts**: at least email. Optional: Slack, Telegram, webhooks.
 4. **Advanced** (optional but recommended):
@@ -526,7 +526,7 @@ liveness:
      is fine.
 
 The same pattern will work for the frontend once Cloudflare Pages is up
-— add a second monitor for `https://corewar.coltcampbell.dev`.
+— add a second monitor for `https://corewar.example.com`.
 
 ## 12. Cloudflare Pages security headers (edge hardening, issue #69)
 
@@ -556,7 +556,7 @@ The CSP is the load-bearing one. Each non-obvious allowance:
   to self-host Monaco, drop the jsdelivr allowance.
 - `style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net` — Monaco
   injects inline styles and pulls CSS from the same CDN.
-- `connect-src 'self' https://api.corewar.coltcampbell.dev wss://api.corewar.coltcampbell.dev https://cdn.jsdelivr.net`
+- `connect-src 'self' https://api.corewar.example.com wss://api.corewar.example.com https://cdn.jsdelivr.net`
   — REST + Socket.IO to the backend (both schemes needed); jsdelivr is
   for Monaco's source maps, which devtools `fetch()`es when the
   inspector is open. Without the jsdelivr allowance on `connect-src`,
@@ -571,7 +571,7 @@ The CSP is the load-bearing one. Each non-obvious allowance:
 After any deploy that touches `_headers`, verify:
 
 ```bash
-curl -sI https://corewar.coltcampbell.dev | grep -iE 'strict-transport|content-security|x-frame|x-content|referrer|permissions'
+curl -sI https://corewar.example.com | grep -iE 'strict-transport|content-security|x-frame|x-content|referrer|permissions'
 ```
 
 All six headers should be present. Then load the site in a browser and

--- a/deploy/cloudflare-pages-build.sh
+++ b/deploy/cloudflare-pages-build.sh
@@ -21,7 +21,7 @@
 #   Root directory:          /
 #   Environment variables:
 #       NODE_VERSION=20
-#       VITE_API_URL=https://api.corewar.coltcampbell.dev
+#       VITE_API_URL=https://api.corewar.example.com
 
 set -euo pipefail
 

--- a/deploy/cloudflare-pages.md
+++ b/deploy/cloudflare-pages.md
@@ -11,7 +11,7 @@ frontend will just hit a non-resolving API host until the backend is up.
 
 - Free Cloudflare account.
 - Frontend code on master (Pages auto-deploys from a branch).
-- Backend hostname decided (`api.corewar.coltcampbell.dev`) — the
+- Backend hostname decided (`api.corewar.example.com`) — the
   frontend's `VITE_API_URL` env var points here.
 
 ## 1. Create the Pages project
@@ -34,7 +34,7 @@ Cloudflare dashboard → **Workers & Pages → Create application → Pages → 
    | Variable | Value |
    |---|---|
    | `NODE_VERSION` | `20` |
-   | `VITE_API_URL` | `https://api.corewar.coltcampbell.dev` |
+   | `VITE_API_URL` | `https://api.corewar.example.com` |
 
 Click **Save and Deploy**. The first build takes 4–6 minutes (Rust toolchain
 download + wasm-pack download + `cargo build --release` for the engine +
@@ -53,13 +53,13 @@ When the build finishes you'll get a `<project>.pages.dev` URL. Open it:
 - The browser will try to hit the backend at `VITE_API_URL` and fail until
   the droplet is up — that's expected at this stage.
 
-## 3. Custom domain (`corewar.coltcampbell.dev`)
+## 3. Custom domain (`corewar.example.com`)
 
 Cloudflare dashboard → Pages project → **Custom domains → Set up a custom domain**.
 
-1. Enter `corewar.coltcampbell.dev`.
+1. Enter `corewar.example.com`.
 2. Cloudflare gives you a CNAME target like `<project>.pages.dev`.
-3. In **Porkbun DNS** for `coltcampbell.dev`:
+3. In **Porkbun DNS** for `example.com`:
 
    | Type | Host | Answer | TTL |
    |---|---|---|---|
@@ -68,7 +68,7 @@ Cloudflare dashboard → Pages project → **Custom domains → Set up a custom 
 4. Back in Cloudflare, wait for it to verify (usually under 5 minutes). Pages
    provisions the TLS cert automatically.
 
-When done, `https://corewar.coltcampbell.dev` serves the production frontend.
+When done, `https://corewar.example.com` serves the production frontend.
 
 ## 4. Update backend CORS allowlist
 
@@ -76,7 +76,7 @@ The backend's `FRONTEND_URL` env var is the single allowed CORS origin. On
 the droplet, edit `~/corewar/.env.production`:
 
 ```ini
-FRONTEND_URL=https://corewar.coltcampbell.dev
+FRONTEND_URL=https://corewar.example.com
 ```
 
 Then restart the backend container:

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -6,5 +6,5 @@
 # http://localhost:3001 if unset, matching the dev backend.
 #
 # Set this to the production backend hostname in Cloudflare Pages env
-# vars when deploying (e.g. https://api.corewar.coltcampbell.dev).
+# vars when deploying (e.g. https://api.corewar.example.com).
 VITE_API_URL=http://localhost:3001


### PR DESCRIPTION
## Summary
Step 1 of a 2-step public-repo security scrub. Removes the personal domain (`coltcampbell.dev`) and two example email addresses from the deploy runbooks, Cloudflare Pages build script, and frontend env example. Also hardens `.gitignore` with a fail-closed block covering OS metadata, editor droppings, log files, and backup patches.

The follow-up (not this PR) is a single-pass `git filter-repo` that scrubs the same strings from **history** and purges commit `688b9ff`'s `.mcp.json` (which leaks a local WSL username). Doing history rewrite second means this PR's older commits also get swept in one shot.

## Changes
- `deploy/README.md` — 34 `coltcampbell.dev` occurrences → `example.com`; `colt@coltcampbell.dev` (2×) and `campbellcolt297@gmail.com` (1×, in a CAA `iodef` example) → `you@example.com`.
- `deploy/cloudflare-pages.md` — 7 occurrences → `example.com`.
- `deploy/cloudflare-pages-build.sh` — 1 occurrence (in the docstring comment showing the Cloudflare Pages dashboard `VITE_API_URL`) → `example.com`.
- `frontend/.env.example` — 1 occurrence (comment example value) → `example.com`.
- `.gitignore` — new hygiene block (see below).

## Intentionally NOT changed
- **`frontend/public/_headers`** — the CSP `connect-src` directive names the real API origin (`https://api.corewar.coltcampbell.dev`). Rewriting it to `example.com` would make the browser block API calls and Socket.IO from the live site. The hostname is already public via the shipped response headers anyway, so the marginal benefit of scrubbing this file is zero and the cost is a broken site.
- **`ssh colt@<DROPLET_IP>` examples** — `colt` here is the droplet's non-root Unix username, and the runbook already documents it as user-configurable on line 81 ("replace with whatever you prefer"). Hardening SSH login dictionaries isn't the threat model.
- **`Coltosaur` GitHub handle** — public by design, appears in the actual GHCR image path (`ghcr.io/coltosaur/core-war-backend`) that the deploy uses.

## New `.gitignore` block
Fail-closed additions — none of these have leaked; the entries just make the next `git add .` mishap safer:
- OS metadata: `.DS_Store`, `Thumbs.db`, `desktop.ini`
- Editor swap/autosave: `*.swp`, `*.swo`, `*~`, `\#*\#`, `.\#*`
- JetBrains + VS Code personal workspace files: `.idea/`, `.vscode/`
- Log files: `*.log`, `npm-debug.log*`, `yarn-error.log`, `yarn-debug.log*`, `pnpm-debug.log*`
- TypeScript incremental build: `*.tsbuildinfo`
- Backup / rejected patches: `*.bak`, `*.orig`, `*.rej`, `*.old`

## Follow-up (separately, after this merges)
```
git filter-repo --path .mcp.json --invert-paths                  # drop the WSL-username leak
git filter-repo --replace-text <expressions-file>                # scrub coltcampbell.dev + emails from history
```
Then force-push `master`. Safe: no branch protection, no open PRs, no forks, single contributor.

## Test plan
- [x] `git grep -n "coltcampbell.dev\|campbellcolt297\|colt@coltcampbell" -- ':!frontend/public/_headers'` returns zero hits (only Unix-username `colt@<DROPLET_IP>` remains, expected).
- [x] `frontend/public/_headers` diff is empty — CSP untouched.
- [x] Existing CI checks (backend, frontend, engine, supply-chain, Cloudflare Pages preview) should pass with no code changes to source.
