### PR TITLE
Make email optional end-to-end

### DIFF
--- a/backend/migrations/20260718000001_make_email_optional.sql
+++ b/backend/migrations/20260718000001_make_email_optional.sql
@@ -1,0 +1,5 @@
+-- Email is optional until #83 (email verification) lands, so a user can
+-- register without one. The UNIQUE constraint is kept: Postgres treats
+-- NULLs as distinct under UNIQUE, so multiple emailless rows coexist and
+-- collisions between real addresses are still caught.
+ALTER TABLE users ALTER COLUMN email DROP NOT NULL;

--- a/backend/src/account/handlers.rs
+++ b/backend/src/account/handlers.rs
@@ -7,24 +7,28 @@ use serde::Serialize;
 
 /// Response body for `GET /api/account`.
 ///
-/// Deliberately minimal today (email only). Add fields here — verified status,
-/// last-password-change, connected identities — as the account-settings surface
-/// grows, rather than expanding the `/api/profile` contract, which is meant to
-/// remain the public/anonymous-facing view.
+/// `email` is nullable because registration doesn't require one until #83
+/// (verification flow) lands. Add fields here — verified status,
+/// last-password-change, connected identities — as the account-settings
+/// surface grows, rather than expanding the `/api/profile` contract, which
+/// remains the public/anonymous-facing view.
 #[derive(Serialize)]
 pub struct AccountResponse {
-    pub email: String,
+    pub email: Option<String>,
 }
 
 pub async fn me(
     State(state): State<AppState>,
     user: AuthUser,
 ) -> Result<Json<AccountResponse>, AppError> {
-    let email: String = sqlx::query_scalar("SELECT email FROM users WHERE id = $1")
-        .bind(user.user_id)
-        .fetch_optional(&state.db)
-        .await?
-        .ok_or_else(|| AppError::Unauthorized("User not found".into()))?;
+    // Outer Option = row-exists?; inner Option = column-nullable. Users that
+    // registered without an email round-trip as `null` in the JSON body.
+    let email: Option<String> =
+        sqlx::query_scalar::<_, Option<String>>("SELECT email FROM users WHERE id = $1")
+            .bind(user.user_id)
+            .fetch_optional(&state.db)
+            .await?
+            .ok_or_else(|| AppError::Unauthorized("User not found".into()))?;
 
     Ok(Json(AccountResponse { email }))
 }

--- a/backend/src/auth/handlers.rs
+++ b/backend/src/auth/handlers.rs
@@ -14,7 +14,11 @@ use serde::{Deserialize, Serialize};
 #[derive(Deserialize)]
 pub struct RegisterRequest {
     pub username: String,
-    pub email: String,
+    // Optional until #83 (verification) ships. Empty strings from the UI are
+    // normalized to `None` in the handler so we never store `""` alongside
+    // real addresses.
+    #[serde(default)]
+    pub email: Option<String>,
     pub password: String,
 }
 
@@ -134,10 +138,19 @@ pub async fn register(
     Json(body): Json<RegisterRequest>,
 ) -> Result<impl IntoResponse, AppError> {
     let username = body.username.trim();
-    let email = body.email.trim().to_lowercase();
+    // Treat an omitted key and an empty string identically — the UI sends
+    // `""` when the user leaves the field blank, and we don't want that
+    // sneaking into the DB as a distinct "empty" email.
+    let email = body
+        .email
+        .as_deref()
+        .map(|s| s.trim().to_lowercase())
+        .filter(|s| !s.is_empty());
 
     validate_username(username)?;
-    validate_email(&email)?;
+    if let Some(ref e) = email {
+        validate_email(e)?;
+    }
     validate_password(&body.password)?;
 
     let password_hash = hash_password(&body.password)?;
@@ -146,7 +159,7 @@ pub async fn register(
         "INSERT INTO users (username, email, password_hash) VALUES ($1, $2, $3) RETURNING id, username",
     )
     .bind(username)
-    .bind(&email)
+    .bind(email.as_deref())
     .bind(&password_hash)
     .fetch_one(&state.db)
     .await

--- a/backend/src/models/user.rs
+++ b/backend/src/models/user.rs
@@ -6,7 +6,7 @@ use uuid::Uuid;
 pub struct User {
     pub id: Uuid,
     pub username: String,
-    pub email: String,
+    pub email: Option<String>,
     pub password_hash: String,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,

--- a/backend/tests/account_integration.rs
+++ b/backend/tests/account_integration.rs
@@ -121,6 +121,47 @@ async fn account_returns_email_for_authed_user(pool: PgPool) {
 }
 
 #[sqlx::test]
+async fn account_returns_null_email_when_none_registered(pool: PgPool) {
+    // Users can register without an email (see auth_integration:
+    // register_without_email_succeeds). /api/account must round-trip that
+    // as JSON null, not as "" or a missing key — the frontend uses
+    // `email === null` as the "not set" signal.
+    let router = app(pool);
+    let resp = send(
+        router.clone(),
+        post_json(
+            "/api/auth/register",
+            &json!({
+                "username": "acctnoemail",
+                "password": "password1234",
+            }),
+        ),
+    )
+    .await;
+    assert_eq!(resp.status, StatusCode::CREATED);
+    let access = resp.cookies["access_token"].clone();
+
+    let resp = send(
+        router,
+        get_with_cookies("/api/account", &format!("access_token={access}")),
+    )
+    .await;
+    assert_eq!(resp.status, StatusCode::OK);
+    assert!(
+        resp.json["email"].is_null(),
+        "expected null, got {:?}",
+        resp.json["email"]
+    );
+}
+
+#[sqlx::test]
+async fn account_requires_authentication(pool: PgPool) {
+    let router = app(pool);
+    let resp = send(router, get_no_auth("/api/account")).await;
+    assert_eq!(resp.status, StatusCode::UNAUTHORIZED);
+}
+
+#[sqlx::test]
 async fn account_normalizes_email_to_lowercase(pool: PgPool) {
     // Registration lowercases the email — /api/account should reflect that
     // stored form so the settings page can display it verbatim.
@@ -135,11 +176,4 @@ async fn account_normalizes_email_to_lowercase(pool: PgPool) {
     .await;
     assert_eq!(resp.status, StatusCode::OK);
     assert_eq!(resp.json["email"], "acct+mixed@example.com");
-}
-
-#[sqlx::test]
-async fn account_requires_authentication(pool: PgPool) {
-    let router = app(pool);
-    let resp = send(router, get_no_auth("/api/account")).await;
-    assert_eq!(resp.status, StatusCode::UNAUTHORIZED);
 }

--- a/backend/tests/auth_integration.rs
+++ b/backend/tests/auth_integration.rs
@@ -321,12 +321,74 @@ async fn register_validation_errors(pool: PgPool) {
 
 #[sqlx::test]
 async fn register_missing_fields(pool: PgPool) {
+    // username without password → 422 (missing required field). Email is
+    // optional as of the make-email-optional change, so leaving it off
+    // must NOT flip this to 422; the missing-password is the actual reason.
     let resp = send(
         app(pool),
         post_json("/api/auth/register", &json!({"username": "test"})),
     )
     .await;
     assert_eq!(resp.status, StatusCode::UNPROCESSABLE_ENTITY);
+}
+
+#[sqlx::test]
+async fn register_without_email_succeeds(pool: PgPool) {
+    // Email is optional. Two flavors: omit the key entirely, and pass an
+    // empty string (which the handler normalizes to None so it can't be
+    // stored as a distinct "empty" address).
+    let router = app(pool);
+
+    let resp = send(
+        router.clone(),
+        post_json(
+            "/api/auth/register",
+            &json!({"username": "noemail1", "password": "password1234"}),
+        ),
+    )
+    .await;
+    assert_eq!(resp.status, StatusCode::CREATED);
+    assert_eq!(resp.json["username"], "noemail1");
+
+    let resp = send(
+        router,
+        post_json(
+            "/api/auth/register",
+            &json!({"username": "noemail2", "email": "", "password": "password1234"}),
+        ),
+    )
+    .await;
+    assert_eq!(resp.status, StatusCode::CREATED);
+    assert_eq!(resp.json["username"], "noemail2");
+}
+
+#[sqlx::test]
+async fn register_multiple_without_email_no_conflict(pool: PgPool) {
+    // Postgres UNIQUE treats NULLs as distinct — so two emailless users
+    // must not trip the email uniqueness constraint. Regression guard: if
+    // someone "fixes" the schema by adding a partial-unique-on-NULL or by
+    // storing "" instead of NULL, this test flips to 409.
+    let router = app(pool);
+
+    let resp = send(
+        router.clone(),
+        post_json(
+            "/api/auth/register",
+            &json!({"username": "nullone", "password": "password1234"}),
+        ),
+    )
+    .await;
+    assert_eq!(resp.status, StatusCode::CREATED);
+
+    let resp = send(
+        router,
+        post_json(
+            "/api/auth/register",
+            &json!({"username": "nulltwo", "password": "password1234"}),
+        ),
+    )
+    .await;
+    assert_eq!(resp.status, StatusCode::CREATED);
 }
 
 #[sqlx::test]

--- a/frontend/src/api/AuthModal.tsx
+++ b/frontend/src/api/AuthModal.tsx
@@ -21,7 +21,12 @@ export default function AuthModal({ onClose }: Props) {
       if (mode === 'login') {
         await login({ username_or_email: username, password });
       } else {
-        await register({ username, email, password });
+        const trimmedEmail = email.trim();
+        await register({
+          username,
+          password,
+          ...(trimmedEmail ? { email: trimmedEmail } : {}),
+        });
       }
       onClose();
     } catch (err) {
@@ -57,14 +62,16 @@ export default function AuthModal({ onClose }: Props) {
 
           {mode === 'register' && (
             <label style={LABEL}>
-              Email
+              Email <span style={OPTIONAL_HINT}>(optional)</span>
               <input
                 style={INPUT}
                 type="email"
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
-                required
               />
+              <span style={HELPER_TEXT}>
+                Not used yet — password recovery and verification arrive later.
+              </span>
             </label>
           )}
 
@@ -204,6 +211,18 @@ const TOGGLE: React.CSSProperties = {
   textAlign: 'center',
   fontSize: '0.75rem',
   color: '#888',
+};
+
+const OPTIONAL_HINT: React.CSSProperties = {
+  color: '#666',
+  textTransform: 'none',
+  fontSize: '0.7rem',
+};
+
+const HELPER_TEXT: React.CSSProperties = {
+  color: '#666',
+  fontSize: '0.65rem',
+  marginTop: '0.15rem',
 };
 
 const LINK_BTN: React.CSSProperties = {

--- a/frontend/src/api/account.ts
+++ b/frontend/src/api/account.ts
@@ -1,7 +1,9 @@
 import { api } from './client';
 
 export type Account = {
-  email: string;
+  // `null` when the user registered without an email (email is optional
+  // until #83 ships).
+  email: string | null;
 };
 
 export type ChangePasswordInput = {

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -7,7 +7,9 @@ export type AuthUser = {
 
 export type RegisterInput = {
   username: string;
-  email: string;
+  // Optional until #83 (email verification) ships. Omit the key or send an
+  // empty string; the backend normalizes both to a stored NULL.
+  email?: string;
   password: string;
 };
 

--- a/frontend/src/pages/profile/AccountSettings.test.tsx
+++ b/frontend/src/pages/profile/AccountSettings.test.tsx
@@ -155,6 +155,14 @@ describe('<AccountSettings /> change-password form', () => {
     expect(screen.getByText(/delete account/i)).toBeInTheDocument();
   });
 
+  it('renders "Not set" when the account has no email on file', async () => {
+    mockGetAccount.mockResolvedValue({ email: null });
+    render(<AccountSettings />);
+    await waitFor(() => {
+      expect(screen.getByTestId('account-email')).toHaveTextContent(/not set/i);
+    });
+  });
+
   it('logout button calls the auth context logout', async () => {
     const user = userEvent.setup();
     render(<AccountSettings />);

--- a/frontend/src/pages/profile/AccountSettings.tsx
+++ b/frontend/src/pages/profile/AccountSettings.tsx
@@ -185,7 +185,10 @@ function RuleItem({ rule }: { rule: PasswordRule }) {
 
 export default function AccountSettings() {
   const { logout } = useAuth();
-  const [email, setEmail] = useState<string | null>(null);
+  // Three states: `undefined` = still loading, `null` = loaded, no email on
+  // file, `string` = loaded, has email. Collapsing loading + not-set to a
+  // single `null` (as before) meant "Not set" flashed during load.
+  const [email, setEmail] = useState<string | null | undefined>(undefined);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [currentPassword, setCurrentPassword] = useState('');
   const [newPassword, setNewPassword] = useState('');
@@ -254,8 +257,10 @@ export default function AccountSettings() {
         <span style={VALUE_STYLE} data-testid="account-email">
           {loadError ? (
             <span style={ERROR_STYLE}>{loadError}</span>
-          ) : email === null ? (
+          ) : email === undefined ? (
             <span style={{ color: '#666' }}>Loading...</span>
+          ) : email === null ? (
+            <span style={{ color: '#666', fontStyle: 'italic' }}>Not set</span>
           ) : (
             email
           )}


### PR DESCRIPTION
## Summary

- Email is now optional for registration — nullable in the DB, `Option<String>` on the wire, `email?: string` in `RegisterInput`, and rendered as `Email (optional)` in the auth modal with a small "not used yet" helper line.
- `/api/account` returns JSON `null` when the user registered without an email; `AccountSettings` renders italic "Not set" (with a new `undefined` loading state so the label doesn't flash).
- Migration `20260718000001_make_email_optional.sql` drops `NOT NULL` only — the UNIQUE constraint stays, and Postgres treats NULLs as distinct, so many emailless users coexist and real-address collisions still 409.

## Why this instead of #82 / #83 / #84 right now

Not ready to stand up transactional email, so the required-email UX was blocking users for no gain. Making it optional preserves any addresses already collected and keeps #83 / #84 as a straightforward add later without a second migration. Both issues have been noted with the new precondition.

## Test plan
- [x] `cargo fmt` + `cargo clippy --all-targets -- -D warnings` (backend)
- [x] `cargo test` (backend) — 33/33 auth pass including `register_without_email_succeeds`, `register_multiple_without_email_no_conflict`; 4/4 account pass including `account_returns_null_email_when_none_registered`
- [x] `npm run lint` + `npm run format:check` + `npm test` (127/127) + `npm run build` (frontend)
- [ ] Manual: register without email, load `/me`, confirm "Not set" renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)